### PR TITLE
fix(ui): scroll to first error and toggle country selection

### DIFF
--- a/inc/launchpad/Assets/opportunities/actions.js
+++ b/inc/launchpad/Assets/opportunities/actions.js
@@ -255,6 +255,9 @@ export const opportunitiesActions = {
     } catch (error) {
       p.error = error.message;
       p.fieldErrors = error.fieldErrors || {};
+      if (Object.keys(p.fieldErrors).length) {
+        scrollToFirstError(p.fieldErrors);
+      }
     } finally {
       p.isSaving = false;
       p.isUploading = false;
@@ -509,7 +512,8 @@ export const opportunitiesActions = {
     const { state } = store("launchpad");
     const { item } = getContext();
     const p = state.panels.opportunities;
-    p.formData.country = item.id;
+    // Toggle: clicking the already-selected country clears the selection
+    p.formData.country = parseInt(p.formData.country) === item.id ? "" : item.id;
     p.isCountryDropdownOpen = false;
     if (p.fieldErrors?.country) p.fieldErrors.country = null;
   },

--- a/inc/launchpad/Panels/OpportunitiesPanel.php
+++ b/inc/launchpad/Panels/OpportunitiesPanel.php
@@ -593,6 +593,9 @@ class OpportunitiesPanel extends AbstractPanel
                                             <?php echo $required['opportunity_application_form'] ? 'required' : ''; ?>
                                             placeholder="<?php echo esc_attr($placeholders['opportunity_application_form'] ?? ''); ?>"
                                             data-wp-bind--value="<?= $formPath ?>.application_form" data-wp-on--input="actions.opportunities.updateForm" data-wp-on--blur="actions.opportunities.normalizeUrlField" data-field="application_form">
+                                        <label class="exclamation-circle__error" hidden
+                                            data-wp-bind--hidden="!<?= $errPath ?>.application_form"
+                                            data-wp-text="<?= $errPath ?>.application_form"></label>
                                     </div>
                                     <!-- Country Dropdown -->
                                     <div class="form-field">

--- a/src/scss/components/_launchpad.scss
+++ b/src/scss/components/_launchpad.scss
@@ -895,8 +895,8 @@
 
 .blurred {
     filter: blur(5px);
-    cursor: pointer;
     transition: filter 0.3s ease;
+    cursor: pointer;
     user-select: none;
 }
 
@@ -1056,8 +1056,8 @@
         &--delete {
             padding-top: 0;
             .btn-profile-delete {
-                margin-left: auto;
                 gap: 4px;
+                margin-left: auto;
                 svg {
                     color: $icon-color-error;
                 }
@@ -1067,20 +1067,20 @@
 }
 .profile-form {
     .show-more {
-        position: relative;
         display: flex;
-        align-items: center;
+        position: relative;
         justify-content: center;
+        align-items: center;
         margin-top: 10px;
 
         &:before,
         &:after {
-            content: "";
             position: absolute;
-            width: calc((100% - 180px) / 2);
             flex: 1;
-            border-bottom: 1px dashed $input-color-border-hover; /* Line color and thickness */
             margin: 0 15px;
+            border-bottom: 1px dashed $input-color-border-hover; /* Line color and thickness */
+            width: calc((100% - 180px) / 2);
+            content: "";
         }
         &:before {
             left: 0;
@@ -1093,8 +1093,8 @@
         margin-top: 0;
     }
     .field-notifications {
-        margin-bottom: 0;
         margin-top: 1.2rem;
+        margin-bottom: 0;
     }
 }
 .launchpad-form {
@@ -1784,8 +1784,8 @@
             padding: 4px 10px;
             &:hover,
             &:focus-visible {
-                background: $dropdown-surface-color-selected;
                 outline: none;
+                background: $dropdown-surface-color-selected;
             }
             &:active,
             &:active:hover {
@@ -1805,8 +1805,8 @@
 
     &__trigger {
         display: flex;
-        align-items: center;
         justify-content: space-between;
+        align-items: center;
         transition: border-color $animations;
         cursor: pointer;
         border: 1px solid $input-color-border-filled;
@@ -1830,11 +1830,11 @@
     &__chevron {
         flex-shrink: 0;
         transition: transform 0.2s ease;
+        fill: none;
+        stroke: #666;
         margin-left: 8px;
         width: 11px;
         height: 7px;
-        fill: none;
-        stroke: #666;
 
         .lp-dropdown--open & {
             transform: rotate(180deg);
@@ -1887,15 +1887,32 @@
             background: $dropdown-surface-color-hover;
         }
         &:focus-visible {
-            background: $dropdown-surface-color-selected;
             outline: 1px solid $input-color-border-active;
             outline-offset: 1px;
+            background: $dropdown-surface-color-selected;
         }
         &:active {
             background-color: $dropdown-surface-color-pressed;
         }
         &--selected {
+            display: flex;
+            align-items: center;
+            color: $icon-color-accent;
             font-weight: 600;
+            &::after {
+                transform-origin: 50% 60%;
+                transition: all $animations;
+                cursor: pointer;
+                margin-right: 4px;
+                margin-left: auto;
+                content: "🗙";
+                color: $icon-color-accent;
+                font-weight: 400;
+                line-height: 1;
+            }
+            &:hover::after {
+                transform: rotate(180deg);
+            }
         }
     }
 }


### PR DESCRIPTION
Adds scrollToFirstError to opportunity actions so the page jumps to the first displayed field error. Replaces country‑dropdown selection logic with a toggle that clears the field when the same country is clicked. Introduces hidden error labels in the opportunities panel template and updates SCSS for cursor, alignment and spacing tweaks, improving the user experience around the opportunities form.