### PR TITLE
refactor(shared): decode html entities in service responses

### DIFF
--- a/inc/launchpad/Services/OpportunitiesService.php
+++ b/inc/launchpad/Services/OpportunitiesService.php
@@ -229,13 +229,13 @@ class OpportunitiesService
             if (!is_wp_error($children)) {
                 $childData = array_map(fn($c) => [
                     'id'   => $c->term_id,
-                    'name' => $c->name
+                    'name' => html_entity_decode($c->name)
                 ], $children);
             }
 
             $result[] = [
                 'id'       => $parent->term_id,
-                'name'     => $parent->name,
+                'name'     => html_entity_decode($parent->name),
                 'children' => $childData,
             ];
         }

--- a/inc/listing/Services/ListingService.php
+++ b/inc/listing/Services/ListingService.php
@@ -346,7 +346,7 @@ class ListingService
 
         return [
             'id'            => $postId,
-            'title'         => get_the_title($post),
+            'title'         => html_entity_decode(get_the_title($post)),
             'excerpt'       => wp_trim_words($post->post_content, 38, ' …'),
             'thumbnail'     => get_the_post_thumbnail_url($post, 'medium') ?: null,
             'company'       => get_post_meta($postId, 'opportunity_company', true),

--- a/inc/projects/Services/ProjectsService.php
+++ b/inc/projects/Services/ProjectsService.php
@@ -129,7 +129,7 @@ class ProjectsService
 
             $cards[] = [
                 'id'         => $post->ID,
-                'title'      => get_the_title($post->ID),
+                'title'      => html_entity_decode(get_the_title($post->ID)),
                 'url'        => get_permalink($post->ID),
                 'excerpt'    => get_the_excerpt($post->ID),
                 'thumbnail'  => $thumbnail ?: '',


### PR DESCRIPTION
Decode entity‐generated names and titles in the launchpad, listing and project services to return plain text values for API consumers. This improves data consistency without modifying public contract.