### PR TITLE
feat(shared) security hardening via add enforce nonce guard for public auth endpoints

### DIFF
--- a/inc/contact/Api/ContactController.php
+++ b/inc/contact/Api/ContactController.php
@@ -33,7 +33,7 @@ class ContactController extends AbstractApiController
         register_rest_route($this->namespace, '/send', [
             'methods'             => 'POST',
             'callback'            => [$this, 'send'],
-            'permission_callback' => '__return_true',
+            'permission_callback' => [$this, 'checkRestNonce'],
         ]);
     }
 
@@ -42,7 +42,7 @@ class ContactController extends AbstractApiController
      */
     public function send(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
-        /* ---- Rate limit: IP-based, every submission counts ---- */
+        /* ---- Rate limit: IP-based, every attempt counts ---- */
         $rl_key = RateLimitPolicy::key('contact', ClientIp::resolve());
 
         $rl_check = RateLimitPolicy::check(
@@ -54,20 +54,20 @@ class ContactController extends AbstractApiController
         if (is_wp_error($rl_check)) {
             return $this->mapServiceError($rl_check);
         }
+        RateLimitPolicy::hit($rl_key, self::RATE_LIMIT_WINDOW);
 
         /* ---- Honeypot: silent success to avoid tipping off bots ---- */
         if (! empty($request->get_param('honeypot'))) {
-            RateLimitPolicy::hit($rl_key, self::RATE_LIMIT_WINDOW);
             return $this->success([
                 'message' => __('Message sent successfully!', 'starwishx'),
             ]);
         }
 
-        /* ---- Raw input ---- */
-        $raw_name    = (string) ($request->get_param('name')    ?? '');
-        $raw_email   = (string) ($request->get_param('email')   ?? '');
-        $raw_phone   = (string) ($request->get_param('phone')   ?? '');
-        $raw_message = (string) ($request->get_param('message') ?? '');
+        /* ---- Raw input, capped at field limits (log/memory hardening) ---- */
+        $raw_name    = mb_substr((string) ($request->get_param('name')    ?? ''), 0, ContactCore::NAME_MAX_LENGTH,    'UTF-8');
+        $raw_email   = mb_substr((string) ($request->get_param('email')   ?? ''), 0, ContactCore::EMAIL_MAX_LENGTH,   'UTF-8');
+        $raw_phone   = mb_substr((string) ($request->get_param('phone')   ?? ''), 0, ContactCore::PHONE_MAX_LENGTH,   'UTF-8');
+        $raw_message = mb_substr((string) ($request->get_param('message') ?? ''), 0, ContactCore::MESSAGE_MAX_LENGTH, 'UTF-8');
 
         /* ---- Email: RFC 5321/5322 validation ---- */
         if (empty($raw_email)) {
@@ -93,14 +93,20 @@ class ContactController extends AbstractApiController
         }
 
         /* ---- Sanitize ---- */
-        $name  = InputSanitizer::sanitizeText($raw_name);
-        $email = sanitize_email($raw_email);
-
-        $char_limit = ContactCore::MESSAGE_MAX_LENGTH;
-        if (mb_strlen($raw_message, 'UTF-8') > $char_limit) {
-            $raw_message = mb_substr($raw_message, 0, $char_limit, 'UTF-8');
-        }
+        $name    = InputSanitizer::sanitizeText($raw_name);
+        $email   = sanitize_email($raw_email);
         $message = InputSanitizer::sanitizeTextarea($raw_message);
+
+        // sanitize_email can strip a value that passed EmailPolicy to empty
+        // (quirky but policy-valid locals). Re-check before we compose a mail
+        // header with it.
+        if (empty($email)) {
+            return $this->error(
+                __('Please enter a valid email address', 'starwishx'),
+                422,
+                'invalid_email'
+            );
+        }
 
         /* ---- Phone: sanitize then validate via PhonePolicy ---- */
         $phone = InputSanitizer::sanitizeText($raw_phone);
@@ -141,13 +147,9 @@ class ContactController extends AbstractApiController
             $message
         );
 
-        $headers = [];
-        if (! empty($email)) {
-            $headers[] = sprintf('Reply-To: %s', $email);
-        }
+        $headers = [sprintf('Reply-To: %s', $email)];
 
         if (wp_mail($email_to, $subject, $body, $headers)) {
-            RateLimitPolicy::hit($rl_key, self::RATE_LIMIT_WINDOW);
             return $this->success([
                 'message' => __('Message sent successfully!', 'starwishx'),
             ]);

--- a/inc/contact/Api/ContactController.php
+++ b/inc/contact/Api/ContactController.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Contact\Api;
 
 use Shared\Core\AbstractApiController;
+use Shared\Http\ClientIp;
 use Shared\Policy\EmailPolicy;
 use Shared\Sanitize\InputSanitizer;
 use Shared\Policy\RateLimitPolicy;
@@ -42,10 +43,7 @@ class ContactController extends AbstractApiController
     public function send(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
         /* ---- Rate limit: IP-based, every submission counts ---- */
-        $ip = $request->get_header('X-Forwarded-For')
-            ? explode(',', $request->get_header('X-Forwarded-For'))[0]
-            : ($_SERVER['REMOTE_ADDR'] ?? '0.0.0.0');
-        $rl_key = RateLimitPolicy::key('contact', trim($ip));
+        $rl_key = RateLimitPolicy::key('contact', ClientIp::resolve());
 
         $rl_check = RateLimitPolicy::check(
             $rl_key,

--- a/inc/contact/Core/ContactCore.php
+++ b/inc/contact/Core/ContactCore.php
@@ -18,6 +18,9 @@ namespace Contact\Core;
 
 final class ContactCore
 {
+    public const NAME_MAX_LENGTH    = 100;
+    public const EMAIL_MAX_LENGTH   = 254; // RFC 5321 total-length cap
+    public const PHONE_MAX_LENGTH   = 30;  // E.164 + separators/formatting slack
     public const MESSAGE_MAX_LENGTH = 500;
 
     private static ?self $instance = null;

--- a/inc/gateway/Api/AuthController.php
+++ b/inc/gateway/Api/AuthController.php
@@ -29,7 +29,7 @@ class AuthController extends AbstractApiController
         register_rest_route($this->namespace, '/login', [
             'methods'             => 'POST',
             'callback'            => [$this, 'login'],
-            'permission_callback' => [$this, 'checkLoggedOut'],
+            'permission_callback' => [$this, 'checkGuestWithNonce'],
             'args'                => [
                 'username' => [
                     'required'          => true,

--- a/inc/gateway/Api/PasswordController.php
+++ b/inc/gateway/Api/PasswordController.php
@@ -30,7 +30,7 @@ class PasswordController extends AbstractApiController
         register_rest_route($this->namespace, '/password/lost', [
             'methods'             => 'POST',
             'callback'            => [$this, 'lostPassword'],
-            'permission_callback' => [$this, 'checkLoggedOut'],
+            'permission_callback' => [$this, 'checkGuestWithNonce'],
             'args'                => [
                 'user_login' => ['required' => true, 'sanitize_callback' => 'sanitize_text_field'],
             ],
@@ -39,7 +39,7 @@ class PasswordController extends AbstractApiController
         register_rest_route($this->namespace, '/password/reset', [
             'methods'             => 'POST',
             'callback'            => [$this, 'resetPassword'],
-            'permission_callback' => [$this, 'checkLoggedOut'],
+            'permission_callback' => [$this, 'checkGuestWithNonce'],
             'args'                => [
                 'login'    => ['required' => true, 'sanitize_callback' => 'sanitize_user'],
                 'key'      => ['required' => true, 'sanitize_callback' => 'sanitize_text_field'],
@@ -47,10 +47,12 @@ class PasswordController extends AbstractApiController
             ],
         ]);
         // GET /gateway/v1/password/generate
+        // Bound to a page-load nonce so this can't be used as a public
+        // random-string service from outside the gateway UI.
         register_rest_route($this->namespace, '/password/generate', [
             'methods'             => 'GET',
             'callback'            => [$this, 'generatePassword'],
-            'permission_callback' => '__return_true', // Public endpoint (just returns random string)
+            'permission_callback' => [$this, 'checkRestNonce'],
         ]);
     }
     public function lostPassword(WP_REST_Request $request): WP_REST_Response|WP_Error

--- a/inc/gateway/Api/PasswordController.php
+++ b/inc/gateway/Api/PasswordController.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 namespace Gateway\Api;
 
 use Shared\Core\AbstractApiController;
+use Shared\Http\ClientIp;
+use Shared\Policy\RateLimitPolicy;
 use Gateway\Services\PasswordResetService;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -19,6 +21,16 @@ use WP_Error;
 class PasswordController extends AbstractApiController
 {
     protected $namespace = 'gateway/v1';
+
+    // Per-IP budget — caps SMTP-flooding / cross-user email bombing.
+    private const LOST_IP_MAX    = 5;
+    private const LOST_IP_WINDOW = HOUR_IN_SECONDS;
+
+    // Per (IP, user_login) — protects an individual user's inbox from a
+    // targeted flood while keeping the per-IP cap as an overall ceiling.
+    private const LOST_TARGET_MAX    = 3;
+    private const LOST_TARGET_WINDOW = 15 * MINUTE_IN_SECONDS;
+
     private PasswordResetService $service;
     public function __construct(?PasswordResetService $service = null)
     {
@@ -57,14 +69,43 @@ class PasswordController extends AbstractApiController
     }
     public function lostPassword(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
-        $result = $this->service->handleLostPassword($request->get_param('user_login'));
+        $user_login = (string) $request->get_param('user_login');
+        $ip = ClientIp::resolve();
+
+        // Dual rate limit — evaluated BEFORE user lookup so timing cannot
+        // reveal whether an account exists (the service applies the same
+        // pre-lookup discipline for enumeration resistance).
+        $ipKey = RateLimitPolicy::key('gateway.password_lost', $ip);
+        $ipCheck = RateLimitPolicy::check(
+            $ipKey,
+            self::LOST_IP_MAX,
+            self::LOST_IP_WINDOW,
+            __('Too many password reset attempts. Please try again later.', 'starwishx')
+        );
+        if (is_wp_error($ipCheck)) {
+            return $this->mapServiceError($ipCheck);
+        }
+
+        $targetKey = RateLimitPolicy::key('gateway.password_lost_target', $ip, $user_login);
+        $targetCheck = RateLimitPolicy::check(
+            $targetKey,
+            self::LOST_TARGET_MAX,
+            self::LOST_TARGET_WINDOW,
+            __('Too many password reset attempts. Please try again later.', 'starwishx')
+        );
+        if (is_wp_error($targetCheck)) {
+            return $this->mapServiceError($targetCheck);
+        }
+
+        RateLimitPolicy::hit($ipKey, self::LOST_IP_WINDOW);
+        RateLimitPolicy::hit($targetKey, self::LOST_TARGET_WINDOW);
+
+        $result = $this->service->handleLostPassword($user_login);
         if (is_wp_error($result)) {
-            // Only codes that handleLostPassword can actually return:
-            // - empty_username (PasswordResetService.php:33)
-            // - too_many_attempts (via checkRateLimit, PasswordResetService.php:39-40)
+            // Only code handleLostPassword can actually return now that
+            // rate limiting lives at the controller edge: empty_username.
             return $this->mapServiceError($result, [
-                'empty_username'    => 400,
-                'too_many_attempts' => 429,
+                'empty_username' => 400,
             ]);
         }
         return $this->success([
@@ -80,10 +121,6 @@ class PasswordController extends AbstractApiController
             $request->get_param('password')
         );
         if (is_wp_error($result)) {
-            // Only codes that resetPassword can actually return:
-            // - invalid_key (via validateKey, PasswordResetService.php:119-121)
-            // - password_too_short, password_too_weak, password_contains_userdata (via validatePasswordStrength, PasswordResetService.php:125-128)
-            // NOTE: resetPassword does NOT call checkRateLimit, so too_many_attempts is NOT returned here
             return $this->mapServiceError($result, [
                 'password_too_short'         => 400,
                 'password_too_weak'          => 400,

--- a/inc/gateway/Api/RegisterController.php
+++ b/inc/gateway/Api/RegisterController.php
@@ -29,7 +29,13 @@ class RegisterController extends AbstractApiController
         register_rest_route($this->namespace, '/register', [
             'methods'             => 'POST',
             'callback'            => [$this, 'register'],
-            'permission_callback' => [$this, 'checkLoggedOut'],
+            'permission_callback' => function (WP_REST_Request $request) {
+                $loggedOut = $this->checkLoggedOut($request);
+                if (is_wp_error($loggedOut)) {
+                    return $loggedOut;
+                }
+                return $this->checkRestNonce($request);
+            },
             'args'                => [
                 'username' => ['required' => true, 'sanitize_callback' => 'sanitize_user'],
                 'email'    => [

--- a/inc/gateway/Api/RegisterController.php
+++ b/inc/gateway/Api/RegisterController.php
@@ -29,13 +29,7 @@ class RegisterController extends AbstractApiController
         register_rest_route($this->namespace, '/register', [
             'methods'             => 'POST',
             'callback'            => [$this, 'register'],
-            'permission_callback' => function (WP_REST_Request $request) {
-                $loggedOut = $this->checkLoggedOut($request);
-                if (is_wp_error($loggedOut)) {
-                    return $loggedOut;
-                }
-                return $this->checkRestNonce($request);
-            },
+            'permission_callback' => [$this, 'checkGuestWithNonce'],
             'args'                => [
                 'username' => ['required' => true, 'sanitize_callback' => 'sanitize_user'],
                 'email'    => [

--- a/inc/gateway/Api/RegisterController.php
+++ b/inc/gateway/Api/RegisterController.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Gateway\Api;
 
 use Shared\Core\AbstractApiController;
+use Shared\Http\ClientIp;
 use Shared\Policy\EmailPolicy;
+use Shared\Policy\RateLimitPolicy;
 use Gateway\Services\RegisterService;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -17,6 +19,10 @@ use WP_Error;
 class RegisterController extends AbstractApiController
 {
     protected $namespace = 'gateway/v1';
+
+    private const RATE_LIMIT_MAX    = 5;
+    private const RATE_LIMIT_WINDOW = HOUR_IN_SECONDS;
+
     private RegisterService $service;
 
     public function __construct(?RegisterService $service = null)
@@ -48,6 +54,21 @@ class RegisterController extends AbstractApiController
 
     public function register(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
+        // Rate limit: every attempt past this point counts against the IP's
+        // quota, including ones that fail validation downstream. Abuse
+        // prevention beats typo leniency for registration.
+        $rlKey = RateLimitPolicy::key('gateway.register', ClientIp::resolve());
+        $rlCheck = RateLimitPolicy::check(
+            $rlKey,
+            self::RATE_LIMIT_MAX,
+            self::RATE_LIMIT_WINDOW,
+            __('Too many registration attempts. Please try again later.', 'starwishx')
+        );
+        if (is_wp_error($rlCheck)) {
+            return $this->mapServiceError($rlCheck);
+        }
+        RateLimitPolicy::hit($rlKey, self::RATE_LIMIT_WINDOW);
+
         $result = $this->service->handleRegistration(
             (string) $request->get_param('username'),
             (string) $request->get_param('email')

--- a/inc/gateway/Services/PasswordResetService.php
+++ b/inc/gateway/Services/PasswordResetService.php
@@ -17,12 +17,13 @@ use WP_User;
 
 class PasswordResetService
 {
-    private const RATE_LIMIT_MAX_ATTEMPTS = 5;
-    private const RATE_LIMIT_TIMEOUT_MINUTES = 15;
-
     /**
      * Phase 1: Handle the "Lost Password" request.
      * Generates a key and sends the email link.
+     *
+     * Rate limiting lives at the controller edge (PasswordController) and
+     * runs before this method, so enumeration timing attacks see identical
+     * latency regardless of whether the account exists.
      *
      * @param string $user_login Username or Email.
      * @return true|WP_Error
@@ -31,13 +32,6 @@ class PasswordResetService
     {
         if (empty($user_login)) {
             return new WP_Error('empty_username', __('Please enter a username or email.', 'starwishx'));
-        }
-
-        // CRITICAL: Check rate limit BEFORE any user lookup
-        // This prevents enumeration via timing attacks
-        $rate_check = $this->checkRateLimit($user_login);
-        if (is_wp_error($rate_check)) {
-            return $rate_check;
         }
 
         // Identify user by login or email
@@ -129,51 +123,6 @@ class PasswordResetService
 
         // Uses the function from your provided user.php (Line 2118)
         reset_password($user, $new_password);
-
-        return true;
-    }
-
-    /**
-     * Check rate limiting for password reset requests.
-     * Uses combination of user_login + IP to prevent global user lockout.
-     *
-     * @param string $userLogin Username or email attempting reset
-     * @return true|WP_Error
-     */
-    private function checkRateLimit(string $userLogin): bool|WP_Error
-    {
-        $ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
-
-        // Combine user login and IP for the transient key
-        // This prevents attackers from locking out a user globally
-        $identifier = sanitize_key($userLogin . '_' . $ip);
-        $transient_key = "pwd_reset_attempts_{$identifier}";
-
-        $attempts = (int) get_transient($transient_key);
-
-        if ($attempts >= self::RATE_LIMIT_MAX_ATTEMPTS) {
-            // Log the blocked attempt
-            error_log(sprintf(
-                '[Gateway Security] Password reset rate limit exceeded for user: %s from IP: %s',
-                $userLogin,
-                $ip
-            ));
-
-            return new WP_Error(
-                'too_many_attempts',
-                sprintf(
-                    __('Too many password reset attempts. Please try again in %d minutes.', 'starwishx'),
-                    self::RATE_LIMIT_TIMEOUT_MINUTES
-                )
-            );
-        }
-
-        // Increment attempt counter
-        set_transient(
-            $transient_key,
-            $attempts + 1,
-            self::RATE_LIMIT_TIMEOUT_MINUTES * MINUTE_IN_SECONDS
-        );
 
         return true;
     }

--- a/inc/shared/Core/AbstractApiController.php
+++ b/inc/shared/Core/AbstractApiController.php
@@ -101,6 +101,24 @@ abstract class AbstractApiController extends WP_REST_Controller
     }
 
     /**
+     * Shared Guard: Guest + valid wp_rest nonce
+     *
+     * Convenience composite for public endpoints that must only accept
+     * anonymous requests originating from a page that was issued a nonce
+     * (login, register, password recovery). Short-circuits on the first
+     * failing guard so the caller gets a precise error code.
+     */
+    public function checkGuestWithNonce(WP_REST_Request $request): bool|WP_Error
+    {
+        $loggedOut = $this->checkLoggedOut($request);
+        if (is_wp_error($loggedOut)) {
+            return $loggedOut;
+        }
+
+        return $this->checkRestNonce($request);
+    }
+
+    /**
      * Unified success response
      *
      * @param array $data Response data

--- a/inc/shared/Core/AbstractApiController.php
+++ b/inc/shared/Core/AbstractApiController.php
@@ -49,12 +49,11 @@ abstract class AbstractApiController extends WP_REST_Controller
      *
      * Returns WP_Error (not bare false) for unambiguous HTTP response.
      *
-     * NOTE: This fixes the case where browser requests via Interactivity API
-     * (with X-WP-Nonce) correctly identify authenticated users. For requests
-     * with cookies but no nonce (e.g., Postman), is_user_logged_in() returns
-     * false in REST context - this is a WordPress constraint, not fixed here.
-     * The WP_Error return ensures unambiguous handling when authentication
-     * state IS correctly detected.
+     * NOTE: WordPress requires BOTH auth cookie AND valid nonce to report a
+     * user as logged-in in REST context. A request with cookies but no nonce
+     * (e.g., Postman) is seen as logged-out here — this is a WordPress
+     * constraint, not fixed in this guard. The correct fix for that gap is
+     * to compose this guard with checkRestNonce() in the permission callback.
      */
     public function checkLoggedOut(WP_REST_Request $request): bool|WP_Error
     {
@@ -62,6 +61,38 @@ abstract class AbstractApiController extends WP_REST_Controller
             return new WP_Error(
                 'already_authenticated',
                 __('You are already logged in.', 'starwishx'),
+                ['status' => 403]
+            );
+        }
+
+        return true;
+    }
+
+    /**
+     * Shared Guard: Require a valid wp_rest nonce
+     *
+     * WordPress core only verifies the nonce for requests that already carry
+     * auth cookies (see rest_cookie_check_errors). Anonymous requests bypass
+     * nonce validation entirely, which is why Postman can hit a public
+     * endpoint without any token. This guard closes that gap by verifying
+     * the wp_rest nonce regardless of auth state, binding the request to a
+     * prior page load where the nonce was hydrated into the client.
+     *
+     * Uses the same error code as WP core (rest_cookie_invalid_nonce) so the
+     * client retry flow in gateway utils.js recovers automatically when a
+     * legitimate user's nonce has rolled over.
+     */
+    public function checkRestNonce(WP_REST_Request $request): bool|WP_Error
+    {
+        $nonce = $request->get_header('X-WP-Nonce');
+        if (!$nonce) {
+            $nonce = (string) $request->get_param('_wpnonce');
+        }
+
+        if (!$nonce || !wp_verify_nonce($nonce, 'wp_rest')) {
+            return new WP_Error(
+                'rest_cookie_invalid_nonce',
+                __('Cookie check failed.', 'starwishx'),
                 ['status' => 403]
             );
         }

--- a/inc/shared/Http/ClientIp.php
+++ b/inc/shared/Http/ClientIp.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shared\Http;
+
+/**
+ * Client IP resolution with opt-in proxy awareness.
+ *
+ * Defaults to $_SERVER['REMOTE_ADDR'] — the only always-accurate source for
+ * direct connections. Forwarded-for headers (X-Forwarded-For, CF-Connecting-IP,
+ * etc.) are trivially spoofable on direct connections, so this helper does NOT
+ * honor them by default.
+ *
+ * Sites behind a trusted proxy (Cloudflare, nginx upstream, LB) can override
+ * via the `starwishx/client_ip` filter:
+ *
+ *     add_filter('starwishx/client_ip', function ($default) {
+ *         return $_SERVER['HTTP_CF_CONNECTING_IP'] ?? $default;
+ *     });
+ */
+final class ClientIp
+{
+    public static function resolve(): string
+    {
+        $ip = (string) ($_SERVER['REMOTE_ADDR'] ?? '0.0.0.0');
+
+        return (string) apply_filters('starwishx/client_ip', $ip);
+    }
+}

--- a/inc/shared/Http/ClientIp.php
+++ b/inc/shared/Http/ClientIp.php
@@ -5,26 +5,83 @@ declare(strict_types=1);
 namespace Shared\Http;
 
 /**
- * Client IP resolution with opt-in proxy awareness.
+ * Client IP resolution with opt-in trusted-proxy support.
  *
  * Defaults to $_SERVER['REMOTE_ADDR'] — the only always-accurate source for
  * direct connections. Forwarded-for headers (X-Forwarded-For, CF-Connecting-IP,
- * etc.) are trivially spoofable on direct connections, so this helper does NOT
- * honor them by default.
+ * etc.) are trivially spoofable on direct connections and are honored ONLY
+ * when the operator explicitly opts in.
  *
- * Sites behind a trusted proxy (Cloudflare, nginx upstream, LB) can override
- * via the `starwishx/client_ip` filter:
+ * OPERATOR SETUP — pick the preset matching your infra in wp-config.php:
  *
- *     add_filter('starwishx/client_ip', function ($default) {
- *         return $_SERVER['HTTP_CF_CONNECTING_IP'] ?? $default;
- *     });
+ *     Direct origin (default — safe, no config needed):
+ *     nothing to do
+ *
+ *     Behind Cloudflare:
+ *     define('STARWISHX_TRUSTED_PROXY', 'cloudflare');
+ *
+ *     Behind nginx / ALB / standard reverse proxy:
+ *     define('STARWISHX_TRUSTED_PROXY', 'standard');
+ *
+ *     Custom header (Akamai True-Client-IP, Fastly, etc.) — pass the raw
+ *     $_SERVER key:
+ *     define('STARWISHX_TRUSTED_PROXY', 'HTTP_TRUE_CLIENT_IP');
+ *
+ * SECURITY MODEL — defining the constant is an operator attestation that the
+ * site ONLY accepts traffic through the named proxy. If the origin is reachable
+ * directly (bypassing the proxy), an attacker can forge the forwarded header
+ * and evade rate limiting. Firewall the origin to the proxy's published IP
+ * ranges to close that gap; this class does not verify proxy origin itself.
+ *
+ * The `starwishx/client_ip` filter runs after the preset and can override for
+ * advanced cases (CIDR-verified Cloudflare, custom proxy chains, etc.).
  */
 final class ClientIp
 {
+    /** Read REMOTE_ADDR directly. Default when the constant is unset. */
+    public const PROXY_NONE = 'none';
+
+    /** Trust CF-Connecting-IP. Use behind Cloudflare. */
+    public const PROXY_CLOUDFLARE = 'cloudflare';
+
+    /** Trust first entry in X-Forwarded-For. Use behind nginx / ALB / standard LB. */
+    public const PROXY_STANDARD = 'standard';
+
     public static function resolve(): string
     {
-        $ip = (string) ($_SERVER['REMOTE_ADDR'] ?? '0.0.0.0');
+        $default = (string) ($_SERVER['REMOTE_ADDR'] ?? '0.0.0.0');
+        $ip = self::resolveByMode($default);
 
         return (string) apply_filters('starwishx/client_ip', $ip);
+    }
+
+    private static function resolveByMode(string $default): string
+    {
+        if (!defined('STARWISHX_TRUSTED_PROXY')) {
+            return $default;
+        }
+
+        $mode = (string) constant('STARWISHX_TRUSTED_PROXY');
+
+        return match ($mode) {
+            self::PROXY_NONE       => $default,
+            self::PROXY_CLOUDFLARE => (string) ($_SERVER['HTTP_CF_CONNECTING_IP'] ?? $default),
+            self::PROXY_STANDARD   => self::firstForwardedFor($default),
+            // Any other value is treated as a raw $_SERVER key so vendors
+            // beyond the built-in presets (Akamai, Fastly, custom LBs) work
+            // without a code change here.
+            default => (string) ($_SERVER[$mode] ?? $default),
+        };
+    }
+
+    private static function firstForwardedFor(string $default): string
+    {
+        $xff = (string) ($_SERVER['HTTP_X_FORWARDED_FOR'] ?? '');
+        if ($xff === '') {
+            return $default;
+        }
+
+        $first = trim(explode(',', $xff)[0] ?? '');
+        return $first !== '' ? $first : $default;
     }
 }


### PR DESCRIPTION
Shared & Gateway
- add guest with nonce guard for public auth endpoints
- add IP‑based rate limiting

Contact
- refactor(contact): replace custom IP extraction with ClientIp helper for rate limiting, 
- feat(contact): add input caps, nonce guard, and improved rate limiting

const feature flag for possible publishing via Cloudflare
- feat(shared): add trusted‑proxy support to ClientIp