### PR TITLE
feat(api): add nonce guard to post owner and permission callbacks 

### DIFF
--- a/acf-json/group_69373c79e9c9a.json
+++ b/acf-json/group_69373c79e9c9a.json
@@ -131,7 +131,7 @@
             },
             "default_value": "",
             "allow_in_bindings": 0,
-            "placeholder": "посилання на першоджерело"
+            "placeholder": "Посилання на першоджерело"
         },
         {
             "key": "field_6999cd702bcfd",
@@ -322,5 +322,5 @@
     "description": "",
     "show_in_rest": 0,
     "display_title": "",
-    "modified": 1775370300
+    "modified": 1776340625
 }

--- a/inc/launchpad/Api/AbstractLaunchpadController.php
+++ b/inc/launchpad/Api/AbstractLaunchpadController.php
@@ -7,6 +7,7 @@ namespace Launchpad\Api;
 
 use Shared\Core\AbstractApiController as BaseController;
 use WP_REST_Request;
+use WP_Error;
 
 /**
  * The specific base for all Launchpad module endpoints.
@@ -37,7 +38,7 @@ abstract class AbstractLaunchpadController extends BaseController
 
     /**
      * Core logic: Check if a user owns a specific post ID.
-     * 
+     *
      * This must be public to be accessible as a valid callback.
      */
     public function checkOwner(?int $postId): bool
@@ -50,5 +51,22 @@ abstract class AbstractLaunchpadController extends BaseController
 
         // Ensure post exists and author matches current user
         return $post && (int) $post->post_author === get_current_user_id();
+    }
+
+    /**
+     * Composite: ownership check + wp_rest nonce.
+     *
+     * Same rationale as AbstractApiController::checkLoggedInWithNonce —
+     * binds the request to a page-load origin so non-cookie auth paths
+     * (Application Passwords, JWT) can't be used to read another user's
+     * content with a leaked token and no browser session.
+     */
+    public function checkPostOwnerWithNonce(WP_REST_Request $request): bool|WP_Error
+    {
+        if (!$this->checkPostOwner($request)) {
+            return false;
+        }
+
+        return $this->checkRestNonce($request);
     }
 }

--- a/inc/launchpad/Api/OpportunitiesController.php
+++ b/inc/launchpad/Api/OpportunitiesController.php
@@ -143,8 +143,7 @@ class OpportunitiesController extends AbstractLaunchpadController
         register_rest_route($this->namespace, '/opportunities', [
             'methods'             => 'POST',
             'callback'            => [$this, 'saveOpportunity'],
-            // 'permission_callback' => [$this, 'checkLoggedIn'],
-            'permission_callback' => [$this, 'checkCanPost'],
+            'permission_callback' => [$this, 'checkCanPostWithNonce'],
             'args'                => $saveArgs,
         ]);
 
@@ -158,8 +157,7 @@ class OpportunitiesController extends AbstractLaunchpadController
             [
                 'methods'             => 'PUT',
                 'callback'            => [$this, 'saveOpportunity'],
-                // Inherited from Abstract
-                'permission_callback' => [$this, 'checkCanPost'],
+                'permission_callback' => [$this, 'checkCanPostWithNonce'],
                 'args'                => $saveArgs,
             ],
         ]);
@@ -168,7 +166,7 @@ class OpportunitiesController extends AbstractLaunchpadController
         register_rest_route($this->namespace, '/opportunities/(?P<id>\d+)/status', [
             'methods'             => 'POST',
             'callback'            => [$this, 'handleStatusChange'],
-            'permission_callback' => [$this, 'checkCanPost'],
+            'permission_callback' => [$this, 'checkCanPostWithNonce'],
             'args'                => [
                 'status' => [
                     'required'          => true,
@@ -365,5 +363,23 @@ class OpportunitiesController extends AbstractLaunchpadController
         }
 
         return true;
+    }
+
+    /**
+     * Composite: checkCanPost + wp_rest nonce.
+     *
+     * Applied to write endpoints (create / update / status-change). See
+     * AbstractApiController::checkLoggedInWithNonce — the nonce closes the
+     * non-cookie auth bypass that would otherwise let a leaked Application
+     * Password flood this controller from a headless script.
+     */
+    public function checkCanPostWithNonce(WP_REST_Request $request): bool|WP_Error
+    {
+        $result = $this->checkCanPost();
+        if ($result !== true) {
+            return $result;
+        }
+
+        return $this->checkRestNonce($request);
     }
 }

--- a/inc/launchpad/Panels/OpportunitiesPanel.php
+++ b/inc/launchpad/Panels/OpportunitiesPanel.php
@@ -578,10 +578,10 @@ class OpportunitiesPanel extends AbstractPanel
 
                                 <div class="launchpad-grid-auto">
                                     <div class="form-field">
-                                        <label for="opportunity-sourcelink" class="<?php echo $required['opportunity_sourcelink'] ? 'label-required' : ''; ?>"><?php echo esc_html($labels['opportunity_sourcelink'] ?? __('Link', 'starwishx')); ?></label>
+                                        <label for="opportunity-sourcelink" class="<?php echo $required['opportunity_sourcelink'] ? 'label-required' : ''; ?>"><?= esc_html($labels['opportunity_sourcelink'] ?? __('Link', 'starwishx')); ?></label>
                                         <input id="opportunity-sourcelink" type="url"
-                                            <?php echo $required['opportunity_sourcelink'] ? 'required' : ''; ?>
-                                            placeholder="<?php echo esc_attr($placeholders['opportunity_sourcelink'] ?? ''); ?>"
+                                            <?= $required['opportunity_sourcelink'] ? 'required' : ''; ?>
+                                            placeholder="<?= esc_attr($placeholders['opportunity_sourcelink'] ?? ''); ?>"
                                             data-wp-bind--value="<?= $formPath ?>.sourcelink" data-wp-on--input="actions.opportunities.updateForm" data-wp-on--blur="actions.opportunities.normalizeUrlField" data-field="sourcelink">
                                         <label class="exclamation-circle__error" hidden
                                             data-wp-bind--hidden="!<?= $errPath ?>.sourcelink"

--- a/inc/launchpad/Panels/ProfilePanel.php
+++ b/inc/launchpad/Panels/ProfilePanel.php
@@ -219,7 +219,7 @@ class ProfilePanel extends AbstractPanel
                 data-wp-bind--hidden="!<?= $this->statePath('isEditing') ?>"
                 data-wp-on--submit="actions.profile.save"
                 data-wp-init="actions.profile.initPhoneWidget">
-                <div class="form-group-card1 launchpad-grid-auto">
+                <div class="launchpad-grid-auto">
 
                     <div class="form-field">
                         <label class="label-required" for="lp-first-name"><?= esc_html__('First Name', 'starwishx'); ?></label>

--- a/inc/shared/Core/AbstractApiController.php
+++ b/inc/shared/Core/AbstractApiController.php
@@ -119,6 +119,28 @@ abstract class AbstractApiController extends WP_REST_Controller
     }
 
     /**
+     * Shared Guard: Logged-in user + valid wp_rest nonce
+     *
+     * Binds authenticated requests to a page-load origin. WP core already
+     * enforces the nonce for cookie auth (via rest_cookie_check_errors), so
+     * this guard is a no-op for the browser path. Its value is closing the
+     * non-cookie auth bypass: Application Passwords / JWT / OAuth accept
+     * credentials without a nonce, which would let a script with a leaked
+     * token reach write endpoints from Postman. Requiring the nonce on top
+     * means the attacker must also compromise an interactive browser
+     * session — a meaningfully higher bar.
+     */
+    public function checkLoggedInWithNonce(WP_REST_Request $request): bool|WP_Error
+    {
+        $loggedIn = $this->checkLoggedIn($request);
+        if (is_wp_error($loggedIn)) {
+            return $loggedIn;
+        }
+
+        return $this->checkRestNonce($request);
+    }
+
+    /**
      * Unified success response
      *
      * @param array $data Response data

--- a/src/scss/components/_launchpad.scss
+++ b/src/scss/components/_launchpad.scss
@@ -1143,9 +1143,24 @@
         }
     }
 }
-// .profile-form,
+
 .password-form {
     max-width: 520px;
+}
+.profile-form {
+    .launchpad-grid-auto {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 10px;
+        @include max-laptop {
+            & > *:last-child {
+                grid-column: 1 / -1;
+            }
+        }
+        @include min-tablet {
+            grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+        }
+    }
 }
 
 .launchpad-grid-3-col {


### PR DESCRIPTION
Add nonce checks to protect write endpoints from non-cookie auth bypasses,
ensuring only requests with a valid nonce can modify resources.

style(launchpad): minor grid style fixes following report on card _2. Recommendations/comments on improving the opportunity provision form, user profile_