### PR TITLE
refactor(comments): add content validation and rate limiting

### DIFF
--- a/inc/comments/Api/CommentsController.php
+++ b/inc/comments/Api/CommentsController.php
@@ -6,6 +6,7 @@ namespace Comments\Api;
 
 use Comments\Services\CommentsService;
 use Shared\Core\AbstractApiController;
+use Shared\Policy\RateLimitPolicy;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_Error;
@@ -13,6 +14,10 @@ use WP_Error;
 class CommentsController extends AbstractApiController
 {
     protected $namespace = 'comments/v1';
+
+    private const RATE_LIMIT_MAX    = 10;
+    private const RATE_LIMIT_WINDOW = HOUR_IN_SECONDS;
+    private const PER_PAGE_MAX      = 50;
 
     private CommentsService $service;
 
@@ -23,6 +28,17 @@ class CommentsController extends AbstractApiController
 
     public function registerRoutes(): void
     {
+        // Shared validator: required, non-empty, capped length.
+        $contentArg = [
+            'required'          => true,
+            'sanitize_callback' => 'sanitize_textarea_field',
+            'validate_callback' => function ($param) {
+                return is_string($param)
+                    && trim($param) !== ''
+                    && mb_strlen($param) <= CommentsService::CONTENT_MAX_LENGTH;
+            },
+        ];
+
         // 1. Get List with Pagination
         // GET /comments/v1/comments
         register_rest_route($this->namespace, '/comments', [
@@ -31,17 +47,22 @@ class CommentsController extends AbstractApiController
             'permission_callback' => '__return_true', // Publicly readable
             'args'                => [
                 'post_id' => [
-                    'required' => true,
-                    'sanitize_callback' => 'absint'
+                    'required'          => true,
+                    'sanitize_callback' => 'absint',
                 ],
                 'page' => [
-                    'default' => 1,
-                    'sanitize_callback' => 'absint'
+                    'default'           => 1,
+                    'sanitize_callback' => 'absint',
                 ],
                 'per_page' => [
-                    'default' => CommentsService::ITEMS_PER_PAGE,
-                    'sanitize_callback' => 'absint'
-                ]
+                    'default'           => CommentsService::ITEMS_PER_PAGE,
+                    'sanitize_callback' => 'absint',
+                    'validate_callback' => function ($param) {
+                        return is_numeric($param)
+                            && (int) $param >= 1
+                            && (int) $param <= self::PER_PAGE_MAX;
+                    },
+                ],
             ],
         ]);
 
@@ -49,10 +70,10 @@ class CommentsController extends AbstractApiController
         register_rest_route($this->namespace, '/comments', [
             'methods'             => 'POST',
             'callback'            => [$this, 'createComment'],
-            'permission_callback' => [$this, 'checkLoggedIn'],
+            'permission_callback' => [$this, 'checkLoggedInWithNonce'],
             'args'                => [
                 'post_id'   => ['required' => true, 'sanitize_callback' => 'absint'],
-                'content'   => ['required' => true, 'sanitize_callback' => 'sanitize_textarea_field'],
+                'content'   => $contentArg,
                 'rating'    => ['type' => 'integer', 'minimum' => 0, 'maximum' => 5],
                 'parent_id' => ['type' => 'integer', 'default' => 0],
             ],
@@ -62,13 +83,45 @@ class CommentsController extends AbstractApiController
         register_rest_route($this->namespace, '/comments/(?P<id>\d+)', [
             'methods'             => 'PUT',
             'callback'            => [$this, 'updateComment'],
-            'permission_callback' => [$this, 'checkLoggedIn'],
+            'permission_callback' => [$this, 'checkCommentOwnerWithNonce'],
             'args'                => [
                 'id'      => ['required' => true, 'sanitize_callback' => 'absint'],
-                'content' => ['required' => true, 'sanitize_callback' => 'sanitize_textarea_field'],
+                'content' => $contentArg,
                 'rating'  => ['type' => 'integer', 'minimum' => 0, 'maximum' => 5],
             ],
         ]);
+    }
+
+    /**
+     * Permission helper: current user owns the targeted comment.
+     */
+    public function checkCommentOwner(WP_REST_Request $request): bool
+    {
+        $id = (int) $request->get_param('id');
+
+        if (!$id || !is_user_logged_in()) {
+            return false;
+        }
+
+        $comment = get_comment($id);
+
+        return $comment && (int) $comment->user_id === get_current_user_id();
+    }
+
+    /**
+     * Composite: comment ownership + wp_rest nonce.
+     *
+     * Mirrors AbstractLaunchpadController::checkPostOwnerWithNonce — binds the
+     * write to a page-load origin so non-cookie auth paths (Application
+     * Passwords, JWT) can't update another user's comment with a leaked token.
+     */
+    public function checkCommentOwnerWithNonce(WP_REST_Request $request): bool|WP_Error
+    {
+        if (!$this->checkCommentOwner($request)) {
+            return false;
+        }
+
+        return $this->checkRestNonce($request);
     }
 
     public function getComments(WP_REST_Request $request): WP_REST_Response
@@ -92,11 +145,17 @@ class CommentsController extends AbstractApiController
 
     public function createComment(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
+        $userId = get_current_user_id();
+
+        $rateLimited = $this->applyWriteRateLimit($userId);
+        if ($rateLimited !== null) {
+            return $rateLimited;
+        }
+
         $postId   = (int) $request->get_param('post_id');
         $content  = $request->get_param('content');
         $rating   = (int) $request->get_param('rating');
         $parentId = (int) $request->get_param('parent_id');
-        $userId   = get_current_user_id();
 
         $result = $this->service->addComment($userId, $postId, $content, $rating, $parentId);
 
@@ -109,10 +168,16 @@ class CommentsController extends AbstractApiController
 
     public function updateComment(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
+        $userId = get_current_user_id();
+
+        $rateLimited = $this->applyWriteRateLimit($userId);
+        if ($rateLimited !== null) {
+            return $rateLimited;
+        }
+
         $commentId = (int) $request->get_param('id');
         $content   = $request->get_param('content');
         $rating    = (int) $request->get_param('rating');
-        $userId    = get_current_user_id();
 
         $result = $this->service->updateComment($userId, $commentId, $content, $rating);
 
@@ -121,5 +186,29 @@ class CommentsController extends AbstractApiController
         }
 
         return $this->success($result);
+    }
+
+    /**
+     * Per-user write rate limit (shared bucket between create and update).
+     *
+     * Returns a mapped WP_Error (HTTP 429) when the limit is exceeded; null
+     * otherwise. Every attempt counts — same pattern as ContactController.
+     */
+    private function applyWriteRateLimit(int $userId): ?WP_Error
+    {
+        $key = RateLimitPolicy::key('comment_write', (string) $userId);
+
+        $check = RateLimitPolicy::check(
+            $key,
+            self::RATE_LIMIT_MAX,
+            self::RATE_LIMIT_WINDOW
+        );
+        if (is_wp_error($check)) {
+            return $this->mapServiceError($check);
+        }
+
+        RateLimitPolicy::hit($key, self::RATE_LIMIT_WINDOW);
+
+        return null;
     }
 }

--- a/inc/comments/Core/CommentsCore.php
+++ b/inc/comments/Core/CommentsCore.php
@@ -72,11 +72,7 @@ final class CommentsCore
      */
     public function enqueueAssets(): void
     {
-        $needsComments = is_singular('opportunity')
-            || is_singular('project')
-            || is_singular('news');
-
-        if (!$needsComments) {
+        if (!is_singular(CommentsService::ALLOWED_POST_TYPES)) {
             return;
         }
 

--- a/inc/comments/Services/CommentsService.php
+++ b/inc/comments/Services/CommentsService.php
@@ -11,6 +11,7 @@ class CommentsService
 {
     public const ITEMS_PER_PAGE = 2;
     public const EDIT_TIMEOUT_SECONDS = 15 * 60;
+    public const CONTENT_MAX_LENGTH = 2000;
 
     /**
      * Get comments with rating data (Optimized to avoid N+1 queries)

--- a/inc/comments/Services/CommentsService.php
+++ b/inc/comments/Services/CommentsService.php
@@ -12,6 +12,7 @@ class CommentsService
     public const ITEMS_PER_PAGE = 2;
     public const EDIT_TIMEOUT_SECONDS = 15 * 60;
     public const CONTENT_MAX_LENGTH = 2000;
+    public const ALLOWED_POST_TYPES = ['opportunity', 'project', 'news'];
 
     /**
      * Get comments with rating data (Optimized to avoid N+1 queries)
@@ -165,6 +166,11 @@ class CommentsService
         if (!$post || $post->post_status !== 'publish') {
             return new WP_Error('not_published', __('Comments are only allowed on published posts.', 'starwishx'), ['status' => 403]);
         }
+
+        if (!in_array($post->post_type, self::ALLOWED_POST_TYPES, true)) {
+            return new WP_Error('not_commentable', __('Comments are not allowed on this content.', 'starwishx'), ['status' => 403]);
+        }
+
         $author_name = $user->display_name ?: $user->user_login;
 
         // Prevent post author from self-reviewing (top-level comments).
@@ -178,9 +184,15 @@ class CommentsService
             $parentComm = get_comment($parentId);
             if (!$parentComm) return new WP_Error('invalid_parent', __('Parent comment not found.', 'starwishx'));
 
+            // Cross-post guard: without this, a client could submit
+            // post_id=A & parent_id=<comment of B> and graft an orphan reply
+            // onto the wrong thread.
+            if ((int) $parentComm->comment_post_ID !== $postId) {
+                return new WP_Error('parent_post_mismatch', __('Invalid parent comment.', 'starwishx'), ['status' => 422]);
+            }
+
             // Server-side canReply validation
-            $post                = get_post($postId);
-            $postAuthorId        = $post ? (int) $post->post_author : 0;
+            $postAuthorId        = (int) $post->post_author;
             $parentCommentUserId = (int) $parentComm->user_id;
 
             $canReply = (


### PR DESCRIPTION
Add constants for rate limiting and per‑page limits, introduce a
validation callback that ensures comment content is a non‑empty string
and does not exceed the maximum length. Update the POST and PUT
permission callbacks to use the nonce guard. These changes improve
API robustness, enforce input constraints, and protect against abuse.