### PR TITLE
feat(profile): add error message display for display name field

### DIFF
--- a/inc/launchpad/Panels/ProfilePanel.php
+++ b/inc/launchpad/Panels/ProfilePanel.php
@@ -348,6 +348,9 @@ class ProfilePanel extends AbstractPanel
                                     </template>
                                 </ul>
                             </div>
+                            <label class="exclamation-circle__error" hidden
+                                data-wp-bind--hidden="!<?= $this->statePath('fieldErrors') ?>.displayName"
+                                data-wp-text="<?= $this->statePath('fieldErrors') ?>.displayName"></label>
                         </div>
 
                         <div class="form-field">


### PR DESCRIPTION
Integrate an error label into the ProfilePanel template to provide visual feedback when validation fails for the display name field. The label uses reactive data binding to toggle visibility based on the presence of field errors.