### PR TITLE
feat(api): implement rate limiting and argument validation for chat activity

### DIFF
--- a/inc/chat/Api/ActivityController.php
+++ b/inc/chat/Api/ActivityController.php
@@ -6,11 +6,33 @@ declare(strict_types=1);
 namespace Chat\Api;
 
 use Shared\Core\AbstractApiController;
+use Shared\Policy\RateLimitPolicy;
+use Shared\Validation\RestArg;
 use Chat\Services\ActivityService;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
 
 class ActivityController extends AbstractApiController
 {
     protected $namespace = 'chat/v1';
+
+    private const PER_PAGE_MAX     = 50;
+    private const PER_PAGE_DEFAULT = 15;
+
+    // Mark-read and mark-all-read share one bucket — rotating endpoints
+    // shouldn't multiply the budget. 200/hr covers a heavy manual session
+    // (click-through of the feed) with headroom.
+    private const MARK_RATE_LIMIT_MAX    = 200;
+    private const MARK_RATE_LIMIT_WINDOW = HOUR_IN_SECONDS;
+
+    // GET /activity has its own bucket so pagination / manual refresh
+    // doesn't eat the mark budget. Each fetch runs two queries (list +
+    // unread count), which is why this ceiling is deliberately below the
+    // mark budget.
+    private const FETCH_RATE_LIMIT_MAX    = 120;
+    private const FETCH_RATE_LIMIT_WINDOW = HOUR_IN_SECONDS;
+
     private ActivityService $service;
 
     public function __construct(ActivityService $service)
@@ -23,31 +45,62 @@ class ActivityController extends AbstractApiController
         register_rest_route($this->namespace, '/activity', [
             'methods'             => 'GET',
             'callback'            => [$this, 'getActivity'],
-            'permission_callback' => [$this, 'checkLoggedIn'],
+            'permission_callback' => [$this, 'checkLoggedInWithNonce'],
             'args'                => [
-                'page'     => ['default' => 1, 'sanitize_callback' => 'absint'],
-                'per_page' => ['default' => 15, 'sanitize_callback' => 'absint'],
+                'page'     => [
+                    'type'              => 'integer',
+                    'default'           => 1,
+                    'validate_callback' => RestArg::intRange(
+                        1,
+                        PHP_INT_MAX,
+                        __('Page', 'starwishx')
+                    ),
+                ],
+                'per_page' => [
+                    'type'              => 'integer',
+                    'default'           => self::PER_PAGE_DEFAULT,
+                    'validate_callback' => RestArg::intRange(
+                        1,
+                        self::PER_PAGE_MAX,
+                        __('Per page', 'starwishx')
+                    ),
+                ],
             ],
         ]);
 
         register_rest_route($this->namespace, '/activity/(?P<id>\d+)/read', [
             'methods'             => 'POST',
             'callback'            => [$this, 'markRead'],
-            'permission_callback' => [$this, 'checkLoggedIn'],
+            'permission_callback' => [$this, 'checkLoggedInWithNonce'],
+            'args'                => [
+                'id' => [
+                    'validate_callback' => RestArg::intRange(
+                        1,
+                        PHP_INT_MAX,
+                        __('Notification ID', 'starwishx')
+                    ),
+                ],
+            ],
         ]);
 
         register_rest_route($this->namespace, '/activity/read-all', [
             'methods'             => 'POST',
             'callback'            => [$this, 'markAllRead'],
-            'permission_callback' => [$this, 'checkLoggedIn'],
+            'permission_callback' => [$this, 'checkLoggedInWithNonce'],
         ]);
     }
 
-    public function getActivity(\WP_REST_Request $request): \WP_REST_Response|\WP_Error
+    public function getActivity(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
-        $userId  = get_current_user_id();
+        $userId = get_current_user_id();
+
+        $rateLimited = $this->applyFetchRateLimit($userId);
+        if ($rateLimited !== null) {
+            return $rateLimited;
+        }
+
         $page    = (int) $request->get_param('page');
-        $perPage = min((int) $request->get_param('per_page'), 50);
+        $perPage = (int) $request->get_param('per_page');
 
         $data = $this->service->getActivity($userId, $page, $perPage);
         $data['unreadCount'] = $this->service->getUnreadCount($userId);
@@ -55,14 +108,23 @@ class ActivityController extends AbstractApiController
         return $this->success($data);
     }
 
-    public function markRead(\WP_REST_Request $request): \WP_REST_Response|\WP_Error
+    public function markRead(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
-        $id     = (int) $request->get_param('id');
         $userId = get_current_user_id();
 
+        $rateLimited = $this->applyMarkRateLimit($userId);
+        if ($rateLimited !== null) {
+            return $rateLimited;
+        }
+
+        $id     = (int) $request->get_param('id');
         $result = $this->service->markRead($id, $userId);
 
-        if (! $result) {
+        if (!$result) {
+            // 404 intentionally conflates "not found", "not yours", and
+            // the already-read no-op UPDATE. The repository enforces
+            // recipient scoping in the WHERE clause, so distinguishing
+            // these cases would only leak existence.
             return $this->error(__('Notification not found.', 'starwishx'), 404, 'not_found');
         }
 
@@ -71,14 +133,84 @@ class ActivityController extends AbstractApiController
         ]);
     }
 
-    public function markAllRead(\WP_REST_Request $request): \WP_REST_Response|\WP_Error
+    public function markAllRead(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
         $userId = get_current_user_id();
-        $count  = $this->service->markAllRead($userId);
+
+        $rateLimited = $this->applyMarkRateLimit($userId);
+        if ($rateLimited !== null) {
+            return $rateLimited;
+        }
+
+        $count = $this->service->markAllRead($userId);
 
         return $this->success([
             'marked'      => $count,
             'unreadCount' => 0,
         ]);
+    }
+
+    /**
+     * Per-user rate limit — mark-read + mark-all-read share one bucket.
+     */
+    private function applyMarkRateLimit(int $userId): ?WP_Error
+    {
+        return $this->applyRateLimit(
+            'chat_mark',
+            $userId,
+            self::MARK_RATE_LIMIT_MAX,
+            self::MARK_RATE_LIMIT_WINDOW,
+            __('Notification changes', 'starwishx')
+        );
+    }
+
+    /**
+     * Per-user rate limit — GET /activity fetches. Separate from the mark
+     * bucket so pagination / manual refresh doesn't consume action budget.
+     */
+    private function applyFetchRateLimit(int $userId): ?WP_Error
+    {
+        return $this->applyRateLimit(
+            'chat_fetch',
+            $userId,
+            self::FETCH_RATE_LIMIT_MAX,
+            self::FETCH_RATE_LIMIT_WINDOW,
+            __('Activity feed', 'starwishx')
+        );
+    }
+
+    /**
+     * Generic per-user rate-limit guard with an action-named, friendly message.
+     *
+     * Mirrors ProfileController::applyRateLimit — the wait duration is
+     * derived from the window via human_time_diff() so the wording tracks
+     * any future window change.
+     *
+     * `mapServiceError()` translates the policy's `rate_limited` code into 429.
+     */
+    private function applyRateLimit(
+        string $action,
+        int $userId,
+        int $max,
+        int $window,
+        string $actionLabel
+    ): ?WP_Error {
+        $key = RateLimitPolicy::key($action, (string) $userId);
+
+        $message = sprintf(
+            /* translators: 1: action name (e.g., "Notification changes"), 2: human-readable wait duration */
+            __('%1$s limit reached. Please wait %2$s before trying again.', 'starwishx'),
+            $actionLabel,
+            human_time_diff(time(), time() + $window)
+        );
+
+        $check = RateLimitPolicy::check($key, $max, $window, $message);
+        if (is_wp_error($check)) {
+            return $this->mapServiceError($check);
+        }
+
+        RateLimitPolicy::hit($key, $window);
+
+        return null;
     }
 }

--- a/inc/favorites/Core/FavoritesCore.php
+++ b/inc/favorites/Core/FavoritesCore.php
@@ -119,7 +119,7 @@ final class FavoritesCore
             $this->cachedIds = $ids;
 
             wp_interactivity_state('favorites', [
-                '       ' => $ids,
+                'myFavoriteIds' => $ids,
                 'config'        => [
                     'nonce'   => wp_create_nonce('wp_rest'),
                     'restUrl' => rest_url('favorites/v1/'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.2.1",
       "license": "ISC",
       "dependencies": {
-        "@wordpress/i18n": "^6.16.0"
+        "@wordpress/i18n": "^6.17.0"
       },
       "devDependencies": {
         "@babel/core": "^7.29.0",
         "@babel/preset-env": "^7.29.2",
-        "autoprefixer": "^10.4.27",
+        "autoprefixer": "^10.5.0",
         "babel-loader": "^10.1.1",
         "browser-sync": "^3.0.4",
         "del": "^8.0.1",
@@ -2789,9 +2789,9 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "4.43.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.43.0.tgz",
-      "integrity": "sha512-BY7GPjEwhOlgkavVak40E3RtA8Z9ehydqTZckRoesMRjXYfxKSzr1C1FT4wAPS5uXM1pNlWivfofMaJjVNQu5w==",
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.44.0.tgz",
+      "integrity": "sha512-6p2vFvoFaovqnKFnIoy6Kib2XJhTwaJ1VhMXp4tM2PhSLnFMXVm1TpcHeX/kH7E6sWKJACBrDR6FH2nGYMk5dA==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -2799,13 +2799,13 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.16.0.tgz",
-      "integrity": "sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.17.0.tgz",
+      "integrity": "sha512-v1SLBweg7CRzQ+5+WSC1U93i8h9d3AoB0YBvMsd6gWI5vO8Zh4YKlEMexvrHQC++WN83egwqux84fWEdeU0MUA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.43.0",
+        "@wordpress/hooks": "^4.44.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "tannin": "^1.2.0"
@@ -3200,9 +3200,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.27",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
-      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
       "dev": true,
       "funding": [
         {
@@ -3220,8 +3220,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.1",
-        "caniuse-lite": "^1.0.30001774",
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -3405,13 +3405,16 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.11",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
-      "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
+      "version": "2.10.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/batch": {
@@ -4056,9 +4059,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -4076,11 +4079,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4425,9 +4428,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001774",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
-      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "dev": true,
       "funding": [
         {
@@ -5708,9 +5711,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.267",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
-      "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
+      "version": "1.5.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+      "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "dev": true,
       "license": "ISC"
     },
@@ -10391,9 +10394,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@babel/core": "^7.29.0",
     "@babel/preset-env": "^7.29.2",
-    "autoprefixer": "^10.4.27",
+    "autoprefixer": "^10.5.0",
     "babel-loader": "^10.1.1",
     "browser-sync": "^3.0.4",
     "del": "^8.0.1",
@@ -52,6 +52,6 @@
     "yargs": "^18.0.0"
   },
   "dependencies": {
-    "@wordpress/i18n": "^6.16.0"
+    "@wordpress/i18n": "^6.17.0"
   }
 }


### PR DESCRIPTION
Introduces rate limiting policies for chat (app internal/mail messages) activity endpoints to prevent abuse and implements stricter argument validation using RestArg for pagination and notification IDs.

- Add rate limiting for GET /activity and POST /activity/read endpoints
- Implement integer range validation for pagination parameters
- Update favorites interactivity state key for better clarity
- Update package.json dependencies (autoprefixer, @wordpress/i18n)