### PR TITLE
refactor(api): harden listing endpoints against DoS and invalid input

### DIFF
--- a/inc/listing/Api/AbstractListingController.php
+++ b/inc/listing/Api/AbstractListingController.php
@@ -19,6 +19,17 @@ abstract class AbstractListingController extends AbstractApiController
     protected $namespace = 'listing/v1';
 
     /**
+     * Defensive cap on repeated-key array params after normalization in
+     * getFilterParams(). Intentionally set high enough that no realistic UI
+     * selection is truncated (facet trees may legitimately push into the
+     * low hundreds when users expand multiple categories), while still
+     * blocking pathological payloads like ?category=1&category=2&…×10k.
+     *
+     * This is a DoS cap, not a UX constraint.
+     */
+    protected const ARRAY_PARAM_MAX = 100;
+
+    /**
      * Declare which query params should always resolve as arrays,
      * regardless of how many times they appear in the query string.
      *
@@ -55,6 +66,9 @@ abstract class AbstractListingController extends AbstractApiController
      *
      * Params declared in arrayParamKeys() are always cast to arrays, even when
      * only a single value is present, giving the service layer a consistent type.
+     * Each declared array is also truncated to ARRAY_PARAM_MAX items as a DoS
+     * defense — WP's args schema cannot validate repeated-key params, so the
+     * cap has to live here.
      */
     protected function getFilterParams(WP_REST_Request $request): array
     {
@@ -63,10 +77,12 @@ abstract class AbstractListingController extends AbstractApiController
         // Strip framework internals that are not filter keys
         unset($params['_locale'], $params['_wpnonce']);
 
-        // Normalize declared array params: scalar → single-element array
+        // Normalize declared array params: scalar → single-element array,
+        // then cap length. The cap sits here because these keys bypass WP's
+        // schema layer (see class docblock on arrayParamKeys).
         foreach ($this->arrayParamKeys() as $key) {
             if (array_key_exists($key, $params)) {
-                $params[$key] = (array) $params[$key];
+                $params[$key] = array_slice((array) $params[$key], 0, static::ARRAY_PARAM_MAX);
             }
         }
 

--- a/inc/listing/Api/MainController.php
+++ b/inc/listing/Api/MainController.php
@@ -5,12 +5,31 @@ declare(strict_types=1);
 namespace Listing\Api;
 
 use Listing\Services\ListingService;
+use Shared\Http\ClientIp;
+use Shared\Policy\RateLimitPolicy;
+use Shared\Validation\RestArg;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_Error;
 
 class MainController extends AbstractListingController
 {
+    private const Q_MIN_LENGTH = 2;
+    private const Q_MAX_LENGTH = 100;
+    private const LOCATION_MAX_LENGTH = 100;
+    private const S_MAX_LENGTH = 200;
+    private const PAGE_MAX = 1000;
+
+    // Per-IP rate limits — anonymous endpoints must bucket by IP, not user.
+    // Both /search and /sub-filter share the same ceiling; /search is more
+    // expensive (≈15 queries/call via getFacets), but /sub-filter is faster
+    // to spam, so the effective floor matches.
+    private const SEARCH_RATE_LIMIT_MAX    = 60;
+    private const SEARCH_RATE_LIMIT_WINDOW = MINUTE_IN_SECONDS;
+
+    private const SUB_FILTER_RATE_LIMIT_MAX    = 60;
+    private const SUB_FILTER_RATE_LIMIT_WINDOW = MINUTE_IN_SECONDS;
+
     private ListingService $service;
 
     public function __construct(ListingService $service)
@@ -37,12 +56,42 @@ class MainController extends AbstractListingController
             'callback'            => [$this, 'search'],
             'permission_callback' => [$this, 'publicAccess'],
             'args'                => [
-                // Scalar params are sanitized at the WP layer.
+                // Scalar params validated at the WP layer.
                 // Array params (category, country, seekers) are handled by
                 // QueryStringParser — they bypass WP's schema because WP
-                // cannot represent repeated keys without [] notation.
-                'page'     => ['default' => 1,  'sanitize_callback' => 'absint'],
-                'location' => ['default' => '', 'sanitize_callback' => 'sanitize_text_field'],
+                // cannot represent repeated keys without [] notation. Their
+                // length cap lives in AbstractListingController::getFilterParams.
+                'page'     => [
+                    'type'              => 'integer',
+                    'default'           => 1,
+                    'validate_callback' => RestArg::intRange(
+                        1,
+                        self::PAGE_MAX,
+                        __('Page', 'starwishx')
+                    ),
+                ],
+                'location' => [
+                    'default'           => '',
+                    'sanitize_callback' => 'sanitize_text_field',
+                    'validate_callback' => RestArg::stringLength(
+                        0,
+                        self::LOCATION_MAX_LENGTH,
+                        __('Location', 'starwishx')
+                    ),
+                ],
+                // The `s` param is consumed by QueryBuilder via getFilterParams();
+                // declaring it here also runs sanitize+validate at the WP layer
+                // before it reaches the service. Without this entry the param
+                // would still be accepted (via raw QUERY_STRING) but unbounded.
+                's' => [
+                    'default'           => '',
+                    'sanitize_callback' => 'sanitize_text_field',
+                    'validate_callback' => RestArg::stringLength(
+                        0,
+                        self::S_MAX_LENGTH,
+                        __('Search', 'starwishx')
+                    ),
+                ],
             ],
         ]);
 
@@ -53,11 +102,34 @@ class MainController extends AbstractListingController
             'callback'            => [$this, 'searchSubFilter'],
             'permission_callback' => [$this, 'publicAccess'],
             'args'                => [
-                'q'         => ['required' => true, 'sanitize_callback' => 'sanitize_text_field'],
-                // Reject unsupported filter IDs before they reach the service layer
+                'q' => [
+                    'required'          => true,
+                    'sanitize_callback' => 'sanitize_text_field',
+                    'validate_callback' => RestArg::stringLength(
+                        self::Q_MIN_LENGTH,
+                        self::Q_MAX_LENGTH,
+                        __('Search query', 'starwishx')
+                    ),
+                ],
+                // Reject unsupported filter IDs before they reach the service.
+                // The whitelist is owned by ListingService::SUPPORTED_SUB_FILTERS
+                // so adding a new sub-filter is a one-line change.
                 'filter_id' => [
                     'required'          => true,
-                    'validate_callback' => fn($v) => in_array($v, ['location'], true),
+                    'validate_callback' => function ($value) {
+                        if (in_array($value, ListingService::SUPPORTED_SUB_FILTERS, true)) {
+                            return true;
+                        }
+                        return new WP_Error(
+                            'unsupported_filter',
+                            sprintf(
+                                /* translators: %s: filter identifier supplied by client */
+                                __('Filter "%s" is not supported.', 'starwishx'),
+                                (string) $value
+                            ),
+                            ['status' => 400]
+                        );
+                    },
                 ],
             ],
         ]);
@@ -67,8 +139,13 @@ class MainController extends AbstractListingController
      * The primary search endpoint.
      * Returns: { items: [], facets: {}, total: 0, total_pages: 0, page: 1 }
      */
-    public function search(WP_REST_Request $request): WP_REST_Response
+    public function search(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
+        $rateLimited = $this->applySearchRateLimit();
+        if ($rateLimited !== null) {
+            return $rateLimited;
+        }
+
         $filters = $this->getFilterParams($request);
 
         $results = $this->service->search($filters);
@@ -90,6 +167,11 @@ class MainController extends AbstractListingController
      */
     public function searchSubFilter(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
+        $rateLimited = $this->applySubFilterRateLimit();
+        if ($rateLimited !== null) {
+            return $rateLimited;
+        }
+
         $filterId   = $request->get_param('filter_id');
         $searchTerm = $request->get_param('q');
 
@@ -100,5 +182,72 @@ class MainController extends AbstractListingController
         }
 
         return $this->success($options);
+    }
+
+    /**
+     * Per-IP rate limit — /search bucket.
+     * Each /search call runs ~15 DB queries (main WP_Query + getFacets
+     * re-runs the user's filter context once per taxonomy), so the ceiling
+     * is tuned to 1 req/s sustained.
+     */
+    private function applySearchRateLimit(): ?WP_Error
+    {
+        return $this->applyIpRateLimit(
+            'listing_search',
+            self::SEARCH_RATE_LIMIT_MAX,
+            self::SEARCH_RATE_LIMIT_WINDOW,
+            __('Search', 'starwishx')
+        );
+    }
+
+    /**
+     * Per-IP rate limit — /sub-filter bucket.
+     * Typeahead is burstier than /search but each call is a single LIKE
+     * query, so the ceiling matches. Separate bucket from /search so users
+     * browsing the catalog don't exhaust their autocomplete budget.
+     */
+    private function applySubFilterRateLimit(): ?WP_Error
+    {
+        return $this->applyIpRateLimit(
+            'listing_sub_filter',
+            self::SUB_FILTER_RATE_LIMIT_MAX,
+            self::SUB_FILTER_RATE_LIMIT_WINDOW,
+            __('Location search', 'starwishx')
+        );
+    }
+
+    /**
+     * Generic per-IP rate-limit guard.
+     *
+     * Uses ClientIp::resolve() so the operator can opt in to trusted-proxy
+     * headers (Cloudflare, ALB, etc.) — on direct-origin deployments it
+     * falls back to REMOTE_ADDR. Wait duration is derived from the window
+     * via human_time_diff() so wording tracks future tuning.
+     *
+     * `mapServiceError()` translates the policy's `rate_limited` code into 429.
+     */
+    private function applyIpRateLimit(
+        string $action,
+        int $max,
+        int $window,
+        string $actionLabel
+    ): ?WP_Error {
+        $key = RateLimitPolicy::key($action, ClientIp::resolve());
+
+        $message = sprintf(
+            /* translators: 1: action name, 2: human-readable wait duration */
+            __('%1$s limit reached. Please wait %2$s before trying again.', 'starwishx'),
+            $actionLabel,
+            human_time_diff(time(), time() + $window)
+        );
+
+        $check = RateLimitPolicy::check($key, $max, $window, $message);
+        if (is_wp_error($check)) {
+            return $this->mapServiceError($check);
+        }
+
+        RateLimitPolicy::hit($key, $window);
+
+        return null;
     }
 }

--- a/inc/listing/Services/ListingService.php
+++ b/inc/listing/Services/ListingService.php
@@ -11,6 +11,17 @@ use WP_Query;
 
 class ListingService
 {
+    /**
+     * Single source of truth for which filter IDs the /sub-filter route
+     * supports. Consumed by:
+     *   - MainController route validate_callback (rejects unknown IDs early)
+     *   - searchFilterOptions() service-layer safety net
+     * Adding a new filter is a one-line change here.
+     *
+     * @var string[]
+     */
+    public const SUPPORTED_SUB_FILTERS = ['location'];
+
     private QueryBuilder $queryBuilder;
     private TermCountingService $termCounter;
     private FavoritesService $favoritesService;
@@ -266,9 +277,10 @@ class ListingService
     {
         global $wpdb;
 
-        // Guard is kept as a safety net; the route's validate_callback should
-        // already have rejected unsupported filter IDs before reaching here.
-        if ($filterId !== 'location') {
+        // Safety net — the route's validate_callback should already have
+        // rejected unsupported filter IDs. Reads from the shared const so
+        // adding a filter is a one-line change in one place.
+        if (!in_array($filterId, self::SUPPORTED_SUB_FILTERS, true)) {
             return new \WP_Error(
                 'unsupported_filter',
                 sprintf(__('Filter "%s" is not supported.', 'starwishx'), $filterId),


### PR DESCRIPTION
Implements defensive programming patterns across the listing API to prevent resource exhaustion and ensure strict parameter validation.

- Add `ARRAY_PARAM_MAX` cap in `AbstractListingController` to prevent pathological repeated-key array payloads.
- Implement rate limiting for `/search` and `/sub-filter` endpoints using IP-based bucketing.
- Replace loose parameter handling with strict `RestArg` validation for `page`, `location`, and `s` parameters.
- Centralize supported sub-filters in `ListingService` to ensure consistency between controller validation and service logic.