### PR TITLE
feat(gateway): implement inline field validation and error handling

### DIFF
--- a/inc/gateway/Assets/auth/actions.js
+++ b/inc/gateway/Assets/auth/actions.js
@@ -42,7 +42,7 @@ export const loginActions = {
         !state.forms.login.isPasswordVisible;
     }
   },
-  
+
   async submit(event) {
     event.preventDefault();
 
@@ -105,7 +105,14 @@ export const loginActions = {
       }
       // ──────────────────────────────────────────────────────────────────
 
-      form.error = error.message;
+      // Route backend field_errors to inline slots (shared contract).
+      const fieldErrors =
+        (error instanceof RestApiError && error.fieldErrors) || null;
+      if (fieldErrors && Object.keys(fieldErrors).length) {
+        form.fieldErrors = { ...form.fieldErrors, ...fieldErrors };
+      } else {
+        form.error = error.message;
+      }
     } finally {
       form.isSubmitting = false;
     }

--- a/inc/gateway/Assets/recovery/actions.js
+++ b/inc/gateway/Assets/recovery/actions.js
@@ -56,7 +56,14 @@ export const lostPasswordActions = {
       // prevents user enumeration via timing or response differences.
       form.success = true;
     } catch (error) {
-      form.error = error.message;
+      // Route backend field_errors to inline slots (shared contract).
+      const fieldErrors =
+        (error instanceof RestApiError && error.fieldErrors) || null;
+      if (fieldErrors && Object.keys(fieldErrors).length) {
+        form.fieldErrors = { ...form.fieldErrors, ...fieldErrors };
+      } else {
+        form.error = error.message;
+      }
     } finally {
       form.isSubmitting = false;
     }
@@ -134,7 +141,11 @@ export const resetPasswordActions = {
       form.error = messages.tooShort ?? "";
       return;
     }
-    if (!/[A-Z]/.test(password) || !/[0-9]/.test(password) || !/[^A-Za-z0-9]/.test(password)) {
+    if (
+      !/[A-Z]/.test(password) ||
+      !/[0-9]/.test(password) ||
+      !/[^A-Za-z0-9]/.test(password)
+    ) {
       form.error = messages.tooWeak ?? "";
       return;
     }

--- a/inc/gateway/Assets/register/actions.js
+++ b/inc/gateway/Assets/register/actions.js
@@ -89,7 +89,16 @@ export const registerActions = {
         return;
       }
 
-      form.error = error.message;
+      // Route backend field_errors to inline slots (contract in
+      // AbstractApiController). Suppress the banner when inline errors
+      // are present so we don't duplicate the "Please correct…" fallback.
+      const fieldErrors =
+        (error instanceof RestApiError && error.fieldErrors) || null;
+      if (fieldErrors && Object.keys(fieldErrors).length) {
+        form.fieldErrors = { ...form.fieldErrors, ...fieldErrors };
+      } else {
+        form.error = error.message;
+      }
     } finally {
       form.isSubmitting = false;
     }

--- a/inc/gateway/Assets/utils.js
+++ b/inc/gateway/Assets/utils.js
@@ -11,12 +11,14 @@ export class RestApiError extends Error {
    * @param {string} message - Human-readable message (from WP error or HTTP status)
    * @param {string} code    - WordPress error code e.g. 'rest_cookie_invalid_nonce'
    * @param {number} status  - HTTP status code
+   * @param {Object|null} fieldErrors - `{field => message}` map from `data.field_errors`
    */
-  constructor(message, code = "", status = 0) {
+  constructor(message, code = "", status = 0, fieldErrors = null) {
     super(message);
     this.name = "RestApiError";
     this.code = code;
     this.status = status;
+    this.fieldErrors = fieldErrors;
   }
 }
 
@@ -107,10 +109,15 @@ export async function fetchJson(
   if (!response.ok) {
     let errorData = {};
     let message = `${response.status} ${response.statusText}`;
+    let fieldErrors = null;
 
     try {
       errorData = await response.json();
       if (errorData?.message) message = errorData.message;
+      // Honors the shared error-shape contract (AbstractApiController):
+      // `data.field_errors` routes to inline slots, top-level `message` to banner.
+      if (errorData?.data?.field_errors)
+        fieldErrors = errorData.data.field_errors;
     } catch (_) {
       // Non-JSON body — keep the HTTP status message
     }
@@ -130,7 +137,12 @@ export async function fetchJson(
     }
     // ──────────────────────────────────────────────────────────────────────
 
-    throw new RestApiError(message, errorData?.code ?? "", response.status);
+    throw new RestApiError(
+      message,
+      errorData?.code ?? "",
+      response.status,
+      fieldErrors,
+    );
   }
 
   if (response.status === 204) return {};

--- a/inc/gateway/Forms/LoginForm.php
+++ b/inc/gateway/Forms/LoginForm.php
@@ -67,7 +67,7 @@ class LoginForm extends AbstractForm
                     data-wp-on--input="actions.<?php echo esc_attr($this->getJsId()); ?>.updateField"
                     data-field="username">
                 <span
-                    class="field-error"
+                    class="exclamation-circle__error"
                     data-wp-bind--hidden="!state.forms.<?php echo esc_attr($this->getJsId()); ?>.fieldErrors.username"
                     data-wp-text="state.forms.<?php echo esc_attr($this->getJsId()); ?>.fieldErrors.username">
                 </span>
@@ -92,13 +92,13 @@ class LoginForm extends AbstractForm
 
                     <button type="button" class="btn-hide-pw"
                         data-wp-on--click="actions.<?php echo esc_attr($this->getJsId()); ?>.toggleVisibility">
-                        <span data-wp-bind--hidden="state.forms.<?php echo esc_attr($this->getJsId()); ?>.isPasswordVisible">
+                        <span data-wp-bind--hidden="state.forms.<?php echo esc_attr($this->getJsId()); ?>.isPasswordVisible" aria-label="<?= esc_attr__('Show password', 'starwishx'); ?>">
                             <!-- < ?php esc_html_e('Show', 'starwishx'); ?> -->
                             <svg width="23" height="23" class="btn-hide-pw__icon">
                                 <use href="/wp-content/themes/starwishx/assets/img/sprites.svg#icon-eye-opened"></use>
                             </svg>
                         </span>
-                        <span data-wp-bind--hidden="!state.forms.<?php echo esc_attr($this->getJsId()); ?>.isPasswordVisible">
+                        <span data-wp-bind--hidden="!state.forms.<?php echo esc_attr($this->getJsId()); ?>.isPasswordVisible" aria-label="<?= esc_attr__('Hide password', 'starwishx'); ?>">
                             <!-- < ?php esc_html_e('Hide', 'starwishx'); ?> -->
                             <svg width="23" height="23" class="btn-hide-pw__icon">
                                 <use href="/wp-content/themes/starwishx/assets/img/sprites.svg#icon-eye-closed"></use>
@@ -107,7 +107,7 @@ class LoginForm extends AbstractForm
                     </button>
                 </div>
                 <span
-                    class="field-error"
+                    class="exclamation-circle__error"
                     data-wp-bind--hidden="!state.forms.<?php echo esc_attr($this->getJsId()); ?>.fieldErrors.password"
                     data-wp-text="state.forms.<?php echo esc_attr($this->getJsId()); ?>.fieldErrors.password">
                 </span>
@@ -124,7 +124,7 @@ class LoginForm extends AbstractForm
             <div class="buttons-group">
                 <button
                     type="submit"
-                    class="btn btn-primary btn-block"
+                    class="btn btn-submit"
                     data-wp-bind--disabled="state.forms.<?php echo esc_attr($this->getJsId()); ?>.isSubmitting">
                     <span data-wp-bind--hidden="state.forms.<?php echo esc_attr($this->getJsId()); ?>.isSubmitting">
                         <?php esc_html_e('Log In', 'starwishx'); ?>
@@ -135,7 +135,7 @@ class LoginForm extends AbstractForm
                 </button>
 
                 <a
-                    class="btn btn-secondary btn-block"
+                    class="btn btn-secondary"
                     href="?view=register"
                     data-wp-on--click="actions.switchView">
                     <?php esc_html_e('Create account', 'starwishx'); ?>

--- a/inc/gateway/Forms/LostPasswordForm.php
+++ b/inc/gateway/Forms/LostPasswordForm.php
@@ -49,7 +49,7 @@ class LostPasswordForm extends AbstractForm
                         data-wp-on--input="actions.<?php echo esc_attr($this->getJsId()); ?>.updateField" data-field="userLogin">
                 </div>
 
-                <button type="submit" class="btn btn-primary btn-block"
+                <button type="submit" class="btn btn-submit"
                     data-wp-bind--disabled="state.forms.<?php echo esc_attr($this->getJsId()); ?>.isSubmitting">
                     <span data-wp-bind--hidden="state.forms.<?php echo esc_attr($this->getJsId()); ?>.isSubmitting">
                         <?php _ex('Get New Password', 'gateway', 'starwishx'); ?>

--- a/inc/gateway/Forms/RegisterForm.php
+++ b/inc/gateway/Forms/RegisterForm.php
@@ -44,24 +44,41 @@ class RegisterForm extends AbstractForm
             <div class="gateway-fields__container" data-wp-bind--hidden="state.forms.<?php echo $jsId; ?>.success">
                 <p class="gateway-form__intro"><?php esc_html_e('Enter your details to receive an activation link.', 'starwishx'); ?></p>
 
-                <div class="form-field">
+                <div class="form-field" data-wp-class--has-error="state.forms.<?php echo $jsId; ?>.fieldErrors.username">
                     <label><?php _ex('Login (latin letters unique username for login)', 'gateway', 'starwishx'); ?></label>
                     <input type="text" required data-field="username"
-                    placeholder="<?php _ex('Latin letters, digits, . - _', 'gateway', 'starwishx'); ?>"
-                    data-wp-bind--value="state.forms.<?php echo $jsId; ?>.username"
-                    data-wp-on--input="actions.<?php echo $jsId; ?>.updateField">
+                        placeholder="<?php _ex('Latin letters, digits, . - _', 'gateway', 'starwishx'); ?>"
+                        data-wp-bind--value="state.forms.<?php echo $jsId; ?>.username"
+                        data-wp-bind--disabled="state.forms.<?php echo $jsId; ?>.isSubmitting"
+                        data-wp-on--input="actions.<?php echo $jsId; ?>.updateField">
                     <span class="label-info exclamation-circle"><?php _ex('f.ex.: Oleg12, kat33, grew.panda', 'gateway', 'starwishx'); ?></span>
+                    <span
+                        class="exclamation-circle__error"
+                        data-wp-bind--hidden="!state.forms.<?php echo esc_attr($this->getJsId()); ?>.fieldErrors.username"
+                        data-wp-text="state.forms.<?php echo esc_attr($this->getJsId()); ?>.fieldErrors.username">
+                    </span>
                 </div>
 
-                <div class="form-field">
+                <div class="form-field" data-wp-class--has-error="state.forms.<?php echo $jsId; ?>.fieldErrors.email">
                     <label><?php _ex('Email', 'gateway', 'starwishx'); ?></label>
                     <input type="email" required data-field="email"
                         data-wp-bind--value="state.forms.<?php echo $jsId; ?>.email"
+                        data-wp-bind--disabled="state.forms.<?php echo $jsId; ?>.isSubmitting"
                         data-wp-on--input="actions.<?php echo $jsId; ?>.updateField">
+                    <span
+                        class="exclamation-circle__error"
+                        data-wp-bind--hidden="!state.forms.<?php echo esc_attr($this->getJsId()); ?>.fieldErrors.email"
+                        data-wp-text="state.forms.<?php echo esc_attr($this->getJsId()); ?>.fieldErrors.email">
+                    </span>
                 </div>
 
-                <button type="submit" class="btn btn-primary btn-block" data-wp-bind--disabled="state.forms.<?php echo $jsId; ?>.isSubmitting">
-                    <?php esc_html_e('Register', 'starwishx'); ?>
+                <button type="submit" class="btn btn-submit" data-wp-bind--disabled="state.forms.<?php echo $jsId; ?>.isSubmitting">
+                    <span data-wp-bind--hidden="state.forms.<?php echo $jsId; ?>.isSubmitting">
+                        <?php esc_html_e('Register', 'starwishx'); ?>
+                    </span>
+                    <span data-wp-bind--hidden="!state.forms.<?php echo $jsId; ?>.isSubmitting">
+                        <?php esc_html_e('Registering...', 'starwishx'); ?>
+                    </span>
                 </button>
             </div>
 

--- a/inc/gateway/Forms/ResetPasswordForm.php
+++ b/inc/gateway/Forms/ResetPasswordForm.php
@@ -85,7 +85,7 @@ class ResetPasswordForm extends AbstractForm
 
                 <div class="buttons-group">
 
-                    <button type="button" class="btn btn-secondary btn-block"
+                    <button type="button" class="btn btn-secondary"
                         data-wp-on--click="actions.<?php echo esc_attr($this->getJsId()); ?>.generate"
                         data-wp-bind--disabled="state.forms.<?php echo esc_attr($this->getJsId()); ?>.isGenerating">
                         <span data-wp-bind--hidden="state.forms.<?php echo esc_attr($this->getJsId()); ?>.isGenerating">
@@ -97,7 +97,7 @@ class ResetPasswordForm extends AbstractForm
                     </button>
 
                     <!-- Submit Button with Loading State -->
-                    <button type="submit" class="btn btn-primary btn-block"
+                    <button type="submit" class="btn btn-submit"
                         data-wp-bind--disabled="state.forms.<?php echo esc_attr($this->getJsId()); ?>.isSubmitting">
                         <span data-wp-bind--hidden="state.forms.<?php echo esc_attr($this->getJsId()); ?>.isSubmitting">
                             <?php esc_html_e('Save Password', 'starwishx'); ?>

--- a/src/scss/components/_gateway.scss
+++ b/src/scss/components/_gateway.scss
@@ -125,6 +125,23 @@
             flex-flow: row nowrap;
             align-items: center;
         }
+        // Applied via data-wp-class--has-error when server (or client) sets
+        // a fieldErrors entry. Mimics a focused state so the affected input
+        // stands out alongside the inline message in .exclamation-circle__error.
+        &.has-error {
+            input[type="text"],
+            input[type="email"],
+            input[type="password"],
+            input[type="url"],
+            input[type="date"] {
+                border-color: $icon-color-error;
+                background-color: $input-color-surface-error;
+                &:focus {
+                    box-shadow: 0 0 0 1px $icon-color-error;
+                    border-color: $icon-color-error;
+                }
+            }
+        }
     }
     .buttons-group {
         display: flex;


### PR DESCRIPTION
Introduce a shared error contract to support field-specific validation messages across authentication and recovery forms.

- Update `RestApiError` and `fetchJson` to capture and propagate `field_errors` from API responses.
- Refactor JS actions in `auth`, `recovery`, and `register` to route backend field errors to a new `fieldErrors` state property.
- Update PHP form templates to display inline error messages using the `exclamation-circle__error` class.
- Add SCSS styles for `.has-error` state to visually highlight invalid input fields.
- Improve accessibility by adding `aria-label` to password visibility toggles.