### PR TITLE
feat(users): implement account activation and moderation lifecycle 

### DIFF
--- a/acf-json/group_6942164a75686.json
+++ b/acf-json/group_6942164a75686.json
@@ -3,6 +3,59 @@
     "title": "Users",
     "fields": [
         {
+            "key": "field_69e4ca2342bd0",
+            "label": "Is Activated",
+            "name": "is_activated",
+            "aria-label": "",
+            "type": "true_false",
+            "instructions": "If subscriber's account is not activated via email activation link it will be automatically wiped",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "Subscriber's account is activated via email link",
+            "default_value": 0,
+            "allow_in_bindings": 0,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
+            "key": "field_69e4ccb9f8d5b",
+            "label": "Account Moderation Status",
+            "name": "moderation_status",
+            "aria-label": "",
+            "type": "select",
+            "instructions": "-Subscriber-: `normal` \/ `muted`, `restricted` can't comment, still can add to favorites \/ `suspended` only login \/ `banned` can't login \/\r\n-Contributor-: `normal` \/ `muted` can't comment, still can add to favorites, add opportunities \/  `restricted` can't comment & add opportunities, still can add to favorites \/ `suspended` only login \/ `banned` can't login",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+                "normal": "normal",
+                "muted": "muted",
+                "restricted": "restricted",
+                "suspended": "suspended",
+                "banned": "banned"
+            },
+            "default_value": false,
+            "return_format": "value",
+            "multiple": 0,
+            "allow_null": 1,
+            "allow_in_bindings": 0,
+            "ui": 0,
+            "ajax": 0,
+            "placeholder": "",
+            "create_options": 0,
+            "save_options": 0
+        },
+        {
             "key": "field_6942164aad908",
             "label": "Телефон",
             "name": "phone",
@@ -112,5 +165,5 @@
     "description": "",
     "show_in_rest": 0,
     "display_title": "",
-    "modified": 1774187250
+    "modified": 1776605658
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "require": {
         "league/uri": "^7.8",
-        "egulias/email-validator": "^4.0"
+        "egulias/email-validator": "^4.0",
+        "monolog/monolog": "^3.10"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fbae706b2b23a872314bdc862589614e",
+    "content-hash": "6a7886fb461452f6a995738ba0301b71",
     "packages": [
         {
             "name": "doctrine/lexer",
@@ -333,6 +333,109 @@
             "time": "2026-03-08T20:05:35+00:00"
         },
         {
+            "name": "monolog/monolog",
+            "version": "3.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8 || ^2.0",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "php-console/php-console": "^3.1.8",
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^10.5.17 || ^11.0.7",
+                "predis/predis": "^1.1 || ^2",
+                "rollbar/rollbar": "^4.0",
+                "ruflin/elastica": "^7 || ^8",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-02T08:56:05+00:00"
+        },
+        {
             "name": "psr/http-factory",
             "version": "1.1.0",
             "source": {
@@ -439,6 +542,56 @@
                 "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
             "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",

--- a/functions.php
+++ b/functions.php
@@ -198,6 +198,11 @@ require_once get_template_directory() . '/vendor/autoload.php';
 // init for Shared infrastructure
 require_once get_template_directory() . '/inc/shared/setup.php';
 
+// init for Users - user-lifecycle state (is_activated, moderation_status)
+// Loads before Gateway so user_register / after_password_reset / login hooks
+// are registered before Gateway starts firing them.
+require_once get_template_directory() . '/inc/users/setup.php';
+
 // init for Menu - header navigation module
 require_once get_template_directory() . '/inc/menu/setup.php';
 

--- a/inc/gateway/Services/AuthService.php
+++ b/inc/gateway/Services/AuthService.php
@@ -55,6 +55,16 @@ class AuthService
             );
         }
 
+        // Activation gate — block login for accounts that haven't completed
+        // the activation flow (clicking the emailed link + setting password).
+        // Must fire before wp_set_auth_cookie so inactive bots never get a session.
+        if (function_exists('users') && !\users()->stateService()->isActivated($user->ID)) {
+            return new WP_Error(
+                'account_not_activated',
+                __('Please activate your account via the link sent to your email.', 'starwishx')
+            );
+        }
+
         // Success - clear rate limiting
         $this->clearAttempts($username);
 

--- a/inc/shared/Log/Logger.php
+++ b/inc/shared/Log/Logger.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Shared\Log\Logger — lightweight file-based application logger.
+ *
+ * Writes to wp-content/uploads/sw/app-YYYY-MM-DD.log.
+ * Date-based filenames avoid rename-race hazards that plague size-based
+ * rotation under concurrent PHP processes. A daily prune job (registered
+ * by UsersCore) removes files older than 30 days.
+ *
+ * Method signatures deliberately mirror Psr\Log\LoggerInterface so a future
+ * swap to Monolog requires only adapter glue, not a call-site rewrite.
+ *
+ * File: inc/shared/Log/Logger.php
+ */
+
+declare(strict_types=1);
+
+namespace Shared\Log;
+
+final class Logger
+{
+    private const DIR = 'sw';
+
+    public static function info(string $module, string $message, array $context = []): void
+    {
+        self::write('INFO', $module, $message, $context);
+    }
+
+    public static function warning(string $module, string $message, array $context = []): void
+    {
+        self::write('WARNING', $module, $message, $context);
+    }
+
+    public static function error(string $module, string $message, array $context = []): void
+    {
+        self::write('ERROR', $module, $message, $context);
+    }
+
+    public static function debug(string $module, string $message, array $context = []): void
+    {
+        if (!(defined('WP_DEBUG') && WP_DEBUG)) {
+            return;
+        }
+        self::write('DEBUG', $module, $message, $context);
+    }
+
+    /**
+     * Delete log files older than the given retention window.
+     * Called by the daily sw_log_prune cron.
+     *
+     * @return int Number of files deleted.
+     */
+    public static function pruneOldLogs(int $daysToKeep = 30): int
+    {
+        $dir = self::logDirectory();
+        if ($dir === null || !is_dir($dir)) {
+            return 0;
+        }
+
+        $threshold = time() - ($daysToKeep * DAY_IN_SECONDS);
+        $deleted = 0;
+
+        foreach ((array) glob($dir . '/app-*.log') as $file) {
+            if (is_file($file) && filemtime($file) < $threshold) {
+                if (@unlink($file)) {
+                    $deleted++;
+                }
+            }
+        }
+
+        return $deleted;
+    }
+
+    private static function write(string $level, string $module, string $message, array $context): void
+    {
+        $path = self::ensureTodayPath();
+        if ($path === null) {
+            // Filesystem unavailable — degrade to PHP error log so nothing is lost silently.
+            error_log(sprintf('[%s] [%s] %s', $level, $module, $message));
+            return;
+        }
+
+        $ctx = !empty($context) ? ' ' . wp_json_encode($context) : '';
+        $line = sprintf("[%s] [%s] [%s] %s%s\n", gmdate('c'), $level, $module, $message, $ctx);
+
+        // error_log with type=3 performs an atomic append per call — safe under concurrent writes.
+        @error_log($line, 3, $path);
+    }
+
+    private static function ensureTodayPath(): ?string
+    {
+        $dir = self::logDirectory();
+        if ($dir === null) {
+            return null;
+        }
+
+        if (!is_dir($dir)) {
+            wp_mkdir_p($dir);
+
+            $htaccess = $dir . '/.htaccess';
+            if (!file_exists($htaccess)) {
+                @file_put_contents($htaccess, "Deny from all\n");
+            }
+            $index = $dir . '/index.php';
+            if (!file_exists($index)) {
+                @file_put_contents($index, "<?php\n// Silence is golden.\n");
+            }
+        }
+
+        return $dir . '/app-' . gmdate('Y-m-d') . '.log';
+    }
+
+    private static function logDirectory(): ?string
+    {
+        $upload = wp_upload_dir(null, false);
+        if (!empty($upload['error']) || empty($upload['basedir'])) {
+            return null;
+        }
+        return rtrim((string) $upload['basedir'], '/\\') . DIRECTORY_SEPARATOR . self::DIR;
+    }
+}

--- a/inc/shared/Log/Logger.php
+++ b/inc/shared/Log/Logger.php
@@ -1,15 +1,15 @@
 <?php
 
 /**
- * Shared\Log\Logger — lightweight file-based application logger.
+ * Shared\Log\Logger — static facade over Monolog 3.x.
  *
- * Writes to wp-content/uploads/sw/app-YYYY-MM-DD.log.
- * Date-based filenames avoid rename-race hazards that plague size-based
- * rotation under concurrent PHP processes. A daily prune job (registered
- * by UsersCore) removes files older than 30 days.
+ * Writes to wp-content/uploads/sw/app-YYYY-MM-DD.log via Monolog's
+ * RotatingFileHandler, which auto-prunes files older than RETENTION_DAYS.
  *
- * Method signatures deliberately mirror Psr\Log\LoggerInterface so a future
- * swap to Monolog requires only adapter glue, not a call-site rewrite.
+ * Monolog 3 is PSR-3 compatible; this facade keeps a simpler static call
+ * shape (`Logger::info($module, $message, $context)`) so call sites don't
+ * have to juggle channel construction — $module becomes the Monolog
+ * channel, memoized per name.
  *
  * File: inc/shared/Log/Logger.php
  */
@@ -18,105 +18,109 @@ declare(strict_types=1);
 
 namespace Shared\Log;
 
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\RotatingFileHandler;
+use Monolog\Level;
+use Monolog\Logger as MonologLogger;
+
 final class Logger
 {
-    private const DIR = 'sw';
+    private const DIR            = 'sw';
+    private const FILENAME       = 'app.log';
+    private const RETENTION_DAYS = 30;
+
+    /** @var array<string, MonologLogger> */
+    private static array $channels = [];
 
     public static function info(string $module, string $message, array $context = []): void
     {
-        self::write('INFO', $module, $message, $context);
+        self::channel($module)->info($message, $context);
     }
 
     public static function warning(string $module, string $message, array $context = []): void
     {
-        self::write('WARNING', $module, $message, $context);
+        self::channel($module)->warning($message, $context);
     }
 
     public static function error(string $module, string $message, array $context = []): void
     {
-        self::write('ERROR', $module, $message, $context);
+        self::channel($module)->error($message, $context);
     }
 
     public static function debug(string $module, string $message, array $context = []): void
     {
-        if (!(defined('WP_DEBUG') && WP_DEBUG)) {
-            return;
-        }
-        self::write('DEBUG', $module, $message, $context);
+        self::channel($module)->debug($message, $context);
     }
 
     /**
-     * Delete log files older than the given retention window.
-     * Called by the daily sw_log_prune cron.
-     *
-     * @return int Number of files deleted.
+     * Reset the memoized channel registry — intended for tests.
      */
-    public static function pruneOldLogs(int $daysToKeep = 30): int
+    public static function reset(): void
     {
-        $dir = self::logDirectory();
-        if ($dir === null || !is_dir($dir)) {
-            return 0;
-        }
-
-        $threshold = time() - ($daysToKeep * DAY_IN_SECONDS);
-        $deleted = 0;
-
-        foreach ((array) glob($dir . '/app-*.log') as $file) {
-            if (is_file($file) && filemtime($file) < $threshold) {
-                if (@unlink($file)) {
-                    $deleted++;
-                }
-            }
-        }
-
-        return $deleted;
+        self::$channels = [];
     }
 
-    private static function write(string $level, string $module, string $message, array $context): void
+    private static function channel(string $module): MonologLogger
     {
-        $path = self::ensureTodayPath();
-        if ($path === null) {
-            // Filesystem unavailable — degrade to PHP error log so nothing is lost silently.
-            error_log(sprintf('[%s] [%s] %s', $level, $module, $message));
-            return;
+        $name = $module !== '' ? $module : 'app';
+
+        if (isset(self::$channels[$name])) {
+            return self::$channels[$name];
         }
 
-        $ctx = !empty($context) ? ' ' . wp_json_encode($context) : '';
-        $line = sprintf("[%s] [%s] [%s] %s%s\n", gmdate('c'), $level, $module, $message, $ctx);
+        $logger = new MonologLogger($name);
 
-        // error_log with type=3 performs an atomic append per call — safe under concurrent writes.
-        @error_log($line, 3, $path);
+        $path = self::ensureLogPath();
+        if ($path !== null) {
+            $minLevel = (defined('WP_DEBUG') && WP_DEBUG) ? Level::Debug : Level::Info;
+
+            $handler = new RotatingFileHandler(
+                $path,
+                self::RETENTION_DAYS,
+                $minLevel,
+                true,   // bubble
+                null,   // filePermission — inherit umask
+                true    // useLocking — safer under concurrent PHP-FPM writers on Windows
+            );
+
+            // Default Monolog format: "[%datetime%] %channel%.%level_name%: %message% %context% %extra%\n"
+            // Example: [2026-04-19T14:23:11+00:00] Users.INFO: Wiped inactive account {"userId":42}
+            $handler->setFormatter(new LineFormatter(
+                null,   // use default template
+                'c',    // ISO-8601 datetime
+                true,   // allowInlineLineBreaks — useful for stack traces
+                true    // ignoreEmptyContextAndExtra
+            ));
+
+            $logger->pushHandler($handler);
+        }
+
+        self::$channels[$name] = $logger;
+        return $logger;
     }
 
-    private static function ensureTodayPath(): ?string
-    {
-        $dir = self::logDirectory();
-        if ($dir === null) {
-            return null;
-        }
-
-        if (!is_dir($dir)) {
-            wp_mkdir_p($dir);
-
-            $htaccess = $dir . '/.htaccess';
-            if (!file_exists($htaccess)) {
-                @file_put_contents($htaccess, "Deny from all\n");
-            }
-            $index = $dir . '/index.php';
-            if (!file_exists($index)) {
-                @file_put_contents($index, "<?php\n// Silence is golden.\n");
-            }
-        }
-
-        return $dir . '/app-' . gmdate('Y-m-d') . '.log';
-    }
-
-    private static function logDirectory(): ?string
+    private static function ensureLogPath(): ?string
     {
         $upload = wp_upload_dir(null, false);
         if (!empty($upload['error']) || empty($upload['basedir'])) {
             return null;
         }
-        return rtrim((string) $upload['basedir'], '/\\') . DIRECTORY_SEPARATOR . self::DIR;
+
+        $dir = rtrim((string) $upload['basedir'], '/\\') . DIRECTORY_SEPARATOR . self::DIR;
+
+        if (!is_dir($dir)) {
+            wp_mkdir_p($dir);
+
+            $htaccess = $dir . DIRECTORY_SEPARATOR . '.htaccess';
+            if (!file_exists($htaccess)) {
+                @file_put_contents($htaccess, "Deny from all\n");
+            }
+            $index = $dir . DIRECTORY_SEPARATOR . 'index.php';
+            if (!file_exists($index)) {
+                @file_put_contents($index, "<?php\n// Silence is golden.\n");
+            }
+        }
+
+        return $dir . DIRECTORY_SEPARATOR . self::FILENAME;
     }
 }

--- a/inc/users/Core/UsersCore.php
+++ b/inc/users/Core/UsersCore.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * UsersCore — singleton bootstrap for the Users module.
+ *
+ * Registers:
+ *   - user_register           → flag new users as unactivated, detect admin-created
+ *   - after_password_reset    → flip is_activated=true after reset_password() commits
+ *   - sw_users_daily_cleanup  → cron handler (finds + wipes inactive subscribers)
+ *   - sw_log_prune            → daily log retention (30 days)
+ *
+ * File: inc/users/Core/UsersCore.php
+ */
+
+declare(strict_types=1);
+
+namespace Users\Core;
+
+use Shared\Log\Logger;
+use Users\Services\UserCleanupService;
+use Users\Services\UserStateService;
+use WP_User;
+
+final class UsersCore
+{
+    public const CRON_CLEANUP = 'sw_users_daily_cleanup';
+    public const CRON_PRUNE   = 'sw_log_prune';
+
+    private static ?self $instance = null;
+
+    private UserStateService $stateService;
+    private UserCleanupService $cleanupService;
+
+    public static function instance(
+        ?UserStateService $stateService = null,
+        ?UserCleanupService $cleanupService = null
+    ): self {
+        if (!self::$instance) {
+            $stateService   = $stateService   ?? new UserStateService();
+            $cleanupService = $cleanupService ?? new UserCleanupService($stateService);
+
+            self::$instance = new self($stateService, $cleanupService);
+        }
+
+        return self::$instance;
+    }
+
+    public static function reset(): void
+    {
+        self::$instance = null;
+    }
+
+    private function __construct(
+        UserStateService $stateService,
+        UserCleanupService $cleanupService
+    ) {
+        $this->stateService   = $stateService;
+        $this->cleanupService = $cleanupService;
+
+        $this->bootstrap();
+    }
+
+    private function bootstrap(): void
+    {
+        // Lifecycle hooks
+        add_action('user_register',         [$this, 'onUserRegister'], 10, 1);
+        add_action('after_password_reset',  [$this, 'onPasswordReset'], 10, 2);
+
+        // Cron handlers
+        add_action(self::CRON_CLEANUP, [$this->cleanupService, 'runCleanup']);
+        add_action(self::CRON_PRUNE,   [$this, 'onPruneLogs']);
+
+        // Schedule crons on init (runs after WP-Cron has parsed existing schedules)
+        add_action('init', [$this, 'ensureCronSchedules'], 20);
+    }
+
+    public function ensureCronSchedules(): void
+    {
+        if (!wp_next_scheduled(self::CRON_CLEANUP)) {
+            wp_schedule_event(time() + HOUR_IN_SECONDS, 'daily', self::CRON_CLEANUP);
+        }
+        if (!wp_next_scheduled(self::CRON_PRUNE)) {
+            wp_schedule_event(time() + HOUR_IN_SECONDS, 'daily', self::CRON_PRUNE);
+        }
+    }
+
+    /**
+     * Fires after wp_insert_user() succeeds in any context (Gateway, wp-admin, WP-CLI).
+     * New users start as unactivated. If an administrator triggered the creation
+     * (via wp-admin/user-new.php), mark the account so the cleanup cron skips it.
+     */
+    public function onUserRegister(int $userId): void
+    {
+        $this->stateService->initAsUnactivated($userId);
+
+        if (function_exists('current_user_can') && current_user_can('create_users')) {
+            $this->stateService->markAdminCreated($userId);
+        }
+    }
+
+    /**
+     * Fires after reset_password() commits. Using after_password_reset (not
+     * password_reset) avoids flipping the flag if the password save later errors.
+     * Clicking the emailed link and successfully setting a password proves
+     * email-address ownership — that's the activation signal.
+     */
+    public function onPasswordReset(WP_User $user, string $newPass): void
+    {
+        if (!$this->stateService->isActivated($user->ID)) {
+            $this->stateService->activate($user->ID, ['trigger' => 'password_reset_link']);
+        }
+    }
+
+    public function onPruneLogs(): void
+    {
+        $deleted = Logger::pruneOldLogs();
+        if ($deleted > 0) {
+            Logger::info('Users', 'Pruned old log files', ['deleted' => $deleted]);
+        }
+    }
+
+    // --- Public accessors ---
+
+    public function stateService(): UserStateService
+    {
+        return $this->stateService;
+    }
+
+    public function cleanupService(): UserCleanupService
+    {
+        return $this->cleanupService;
+    }
+}

--- a/inc/users/Core/UsersCore.php
+++ b/inc/users/Core/UsersCore.php
@@ -7,7 +7,8 @@
  *   - user_register           → flag new users as unactivated, detect admin-created
  *   - after_password_reset    → flip is_activated=true after reset_password() commits
  *   - sw_users_daily_cleanup  → cron handler (finds + wipes inactive subscribers)
- *   - sw_log_prune            → daily log retention (30 days)
+ *
+ * Log retention is handled by Monolog's RotatingFileHandler — no custom prune cron.
  *
  * File: inc/users/Core/UsersCore.php
  */
@@ -16,7 +17,6 @@ declare(strict_types=1);
 
 namespace Users\Core;
 
-use Shared\Log\Logger;
 use Users\Services\UserCleanupService;
 use Users\Services\UserStateService;
 use WP_User;
@@ -24,7 +24,6 @@ use WP_User;
 final class UsersCore
 {
     public const CRON_CLEANUP = 'sw_users_daily_cleanup';
-    public const CRON_PRUNE   = 'sw_log_prune';
 
     private static ?self $instance = null;
 
@@ -66,11 +65,10 @@ final class UsersCore
         add_action('user_register',         [$this, 'onUserRegister'], 10, 1);
         add_action('after_password_reset',  [$this, 'onPasswordReset'], 10, 2);
 
-        // Cron handlers
+        // Cron handler
         add_action(self::CRON_CLEANUP, [$this->cleanupService, 'runCleanup']);
-        add_action(self::CRON_PRUNE,   [$this, 'onPruneLogs']);
 
-        // Schedule crons on init (runs after WP-Cron has parsed existing schedules)
+        // Schedule cron on init (runs after WP-Cron has parsed existing schedules)
         add_action('init', [$this, 'ensureCronSchedules'], 20);
     }
 
@@ -78,9 +76,6 @@ final class UsersCore
     {
         if (!wp_next_scheduled(self::CRON_CLEANUP)) {
             wp_schedule_event(time() + HOUR_IN_SECONDS, 'daily', self::CRON_CLEANUP);
-        }
-        if (!wp_next_scheduled(self::CRON_PRUNE)) {
-            wp_schedule_event(time() + HOUR_IN_SECONDS, 'daily', self::CRON_PRUNE);
         }
     }
 
@@ -108,14 +103,6 @@ final class UsersCore
     {
         if (!$this->stateService->isActivated($user->ID)) {
             $this->stateService->activate($user->ID, ['trigger' => 'password_reset_link']);
-        }
-    }
-
-    public function onPruneLogs(): void
-    {
-        $deleted = Logger::pruneOldLogs();
-        if ($deleted > 0) {
-            Logger::info('Users', 'Pruned old log files', ['deleted' => $deleted]);
         }
     }
 

--- a/inc/users/Services/UserCleanupService.php
+++ b/inc/users/Services/UserCleanupService.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * UserCleanupService — finds and wipes inactive (bot-suspected) accounts.
+ *
+ * Safety rules baked into the query:
+ *   - role__in = ['subscriber']                   higher roles never candidates
+ *   - is_activated = '0' (exact match, NOT NOT-EXISTS) only users flagged
+ *                                                   by this module; legacy users safe
+ *   - sw_user_source != 'admin'                   admin-created accounts permanently skipped
+ *   - user_registered < now - $olderThanDays days
+ *   - number = $batchSize                         next cron picks up the rest
+ *
+ * Idempotency: runCleanup() is guarded by a transient lock so overlapping
+ * WP-Cron fires cannot double-wipe.
+ *
+ * File: inc/users/Services/UserCleanupService.php
+ */
+
+declare(strict_types=1);
+
+namespace Users\Services;
+
+use Shared\Log\Logger;
+use WP_User_Query;
+
+final class UserCleanupService
+{
+    public const LOCK_KEY = 'sw_users_cleanup_running';
+    public const LOCK_TTL = 10 * MINUTE_IN_SECONDS;
+
+    public const DEFAULT_THRESHOLD_DAYS = 2;
+    public const DEFAULT_BATCH_SIZE     = 50;
+
+    private UserStateService $stateService;
+
+    public function __construct(UserStateService $stateService)
+    {
+        $this->stateService = $stateService;
+    }
+
+    /**
+     * @return int[] User IDs that match the inactive-account criteria.
+     */
+    public function findInactiveAccounts(
+        int $olderThanDays = self::DEFAULT_THRESHOLD_DAYS,
+        int $batchSize = self::DEFAULT_BATCH_SIZE
+    ): array {
+        $threshold = gmdate('Y-m-d H:i:s', time() - ($olderThanDays * DAY_IN_SECONDS));
+
+        $query = new WP_User_Query([
+            'role__in'    => ['subscriber'],
+            'number'      => $batchSize,
+            'fields'      => 'ID',
+            'date_query'  => [
+                [
+                    'column' => 'user_registered',
+                    'before' => $threshold,
+                    'inclusive' => true,
+                ],
+            ],
+            'meta_query'  => [
+                'relation' => 'AND',
+                [
+                    'key'     => UserStateService::META_ACTIVATED,
+                    'value'   => '0',
+                    'compare' => '=',
+                ],
+                [
+                    'relation' => 'OR',
+                    [
+                        'key'     => UserStateService::META_SOURCE,
+                        'compare' => 'NOT EXISTS',
+                    ],
+                    [
+                        'key'     => UserStateService::META_SOURCE,
+                        'value'   => UserStateService::SOURCE_ADMIN,
+                        'compare' => '!=',
+                    ],
+                ],
+            ],
+        ]);
+
+        return array_map('intval', (array) $query->get_results());
+    }
+
+    /**
+     * Delete a user account. WordPress fires the `delete_user` action,
+     * which cascades to favorites + notifications cleanup via their
+     * existing listeners — no extra work here.
+     */
+    public function wipeAccount(int $userId, string $reason): bool
+    {
+        if ($userId <= 0) {
+            return false;
+        }
+
+        $user = get_userdata($userId);
+        if (!$user) {
+            return false;
+        }
+
+        // wp_delete_user is defined in wp-admin/includes/user.php — cron context
+        // doesn't load admin includes by default, so pull it in defensively.
+        if (!function_exists('wp_delete_user')) {
+            require_once ABSPATH . 'wp-admin/includes/user.php';
+        }
+
+        $context = [
+            'userId'     => $userId,
+            'email'      => $user->user_email,
+            'login'      => $user->user_login,
+            'registered' => $user->user_registered,
+            'reason'     => $reason,
+        ];
+
+        $deleted = wp_delete_user($userId, null);
+
+        if ($deleted) {
+            Logger::info('Users', 'Wiped inactive account', $context);
+        } else {
+            Logger::error('Users', 'Failed to wipe inactive account', $context);
+        }
+
+        return (bool) $deleted;
+    }
+
+    /**
+     * Cron entry point — transient-locked, batch-limited.
+     */
+    public function runCleanup(): void
+    {
+        if (get_transient(self::LOCK_KEY)) {
+            return;
+        }
+        set_transient(self::LOCK_KEY, 1, self::LOCK_TTL);
+
+        try {
+            $ids = $this->findInactiveAccounts();
+            if (empty($ids)) {
+                return;
+            }
+
+            $wiped = 0;
+            foreach ($ids as $userId) {
+                if ($this->wipeAccount($userId, 'inactive_over_2_days')) {
+                    $wiped++;
+                }
+            }
+
+            Logger::info('Users', 'Cleanup batch complete', [
+                'candidates' => count($ids),
+                'wiped'      => $wiped,
+            ]);
+        } finally {
+            delete_transient(self::LOCK_KEY);
+        }
+    }
+}

--- a/inc/users/Services/UserStateService.php
+++ b/inc/users/Services/UserStateService.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * UserStateService — owns is_activated + moderation_status reads/writes
+ * and a separate sw_user_source flag used by the cleanup job to skip
+ * admin-created accounts.
+ *
+ * Meta-value convention: values are stored as '1' / '0' / '' to stay
+ * interoperable with ACF's true_false field and with meta_query IN/=
+ * comparisons. Legacy users that predate this module have no meta value
+ * set — isActivated() treats them as activated (grandfathered in) so the
+ * login gate never locks them out.
+ *
+ * File: inc/users/Services/UserStateService.php
+ */
+
+declare(strict_types=1);
+
+namespace Users\Services;
+
+use Shared\Log\Logger;
+
+final class UserStateService
+{
+    public const META_ACTIVATED  = 'is_activated';
+    public const META_SOURCE     = 'sw_user_source';
+    public const META_MODERATION = 'moderation_status';
+
+    public const SOURCE_ADMIN = 'admin';
+
+    public const MODERATION_DEFAULT = 'normal';
+
+    /**
+     * True when the user is either explicitly activated ('1') or grandfathered
+     * in (no meta set — predates this module). Returns false only when the
+     * meta is explicitly '0' (set by initAsUnactivated at registration).
+     */
+    public function isActivated(int $userId): bool
+    {
+        if ($userId <= 0) {
+            return false;
+        }
+
+        $meta = get_user_meta($userId, self::META_ACTIVATED, true);
+
+        // '' => meta never set (pre-module user) → treat as activated
+        // '1' => explicitly activated
+        // '0' => explicitly not activated
+        return $meta === '' || $meta === '1';
+    }
+
+    public function activate(int $userId, array $context = []): void
+    {
+        if ($userId <= 0) {
+            return;
+        }
+
+        update_user_meta($userId, self::META_ACTIVATED, '1');
+
+        Logger::info('Users', 'Account activated', array_merge(
+            ['userId' => $userId],
+            $context
+        ));
+    }
+
+    public function initAsUnactivated(int $userId): void
+    {
+        if ($userId <= 0) {
+            return;
+        }
+
+        update_user_meta($userId, self::META_ACTIVATED, '0');
+    }
+
+    public function markAdminCreated(int $userId): void
+    {
+        if ($userId <= 0) {
+            return;
+        }
+
+        update_user_meta($userId, self::META_SOURCE, self::SOURCE_ADMIN);
+    }
+
+    public function isAdminCreated(int $userId): bool
+    {
+        if ($userId <= 0) {
+            return false;
+        }
+
+        return get_user_meta($userId, self::META_SOURCE, true) === self::SOURCE_ADMIN;
+    }
+
+    /**
+     * Scaffolded for future moderation enforcement. Returns 'normal' when no
+     * explicit status is set. Not consumed anywhere yet — Comments/Opportunities
+     * will call this in a later iteration.
+     */
+    public function getModerationStatus(int $userId): string
+    {
+        if ($userId <= 0) {
+            return self::MODERATION_DEFAULT;
+        }
+
+        $status = (string) get_user_meta($userId, self::META_MODERATION, true);
+        return $status !== '' ? $status : self::MODERATION_DEFAULT;
+    }
+}

--- a/inc/users/helpers.php
+++ b/inc/users/helpers.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Global helper function to access Users instance.
+ *
+ * @return \Users\Core\UsersCore
+ */
+function users(): \Users\Core\UsersCore
+{
+    return \Users\Core\UsersCore::instance();
+}

--- a/inc/users/setup.php
+++ b/inc/users/setup.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Setup for Users module.
+ *
+ * Owns user-lifecycle state: is_activated (registration → activation),
+ * moderation_status (future), and the inactive-account cleanup cron.
+ *
+ * Version: 0.7.5
+ * Author: DevFrappe
+ * Email: dev.frappe@proton.me
+ * License: GPL v2 or later
+ *
+ * Include from functions.php (before Gateway):
+ * require_once get_template_directory() . '/inc/users/setup.php';
+ */
+
+declare(strict_types=1);
+
+namespace Users;
+
+// Load helper function first so function_exists('users') becomes true immediately.
+require_once __DIR__ . '/helpers.php';
+
+// PSR-4 style autoloader for Users namespace
+spl_autoload_register(function (string $class): void {
+    $prefix = 'Users\\';
+    $base_dir = __DIR__ . '/';
+
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+
+    $relative_class = substr($class, $len);
+    $file = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
+
+    if (file_exists($file)) {
+        require $file;
+    }
+});
+
+// Initialize Users singleton BEFORE Gateway (priority 5) so hook registration
+// precedes any user_register / after_password_reset / login events Gateway triggers.
+add_action('after_setup_theme', function (): void {
+    \users();
+}, 3);

--- a/vendor/composer/autoload_psr4.php
+++ b/vendor/composer/autoload_psr4.php
@@ -8,7 +8,9 @@ $baseDir = dirname($vendorDir);
 return array(
     'Symfony\\Polyfill\\Intl\\Normalizer\\' => array($vendorDir . '/symfony/polyfill-intl-normalizer'),
     'Symfony\\Polyfill\\Intl\\Idn\\' => array($vendorDir . '/symfony/polyfill-intl-idn'),
+    'Psr\\Log\\' => array($vendorDir . '/psr/log/src'),
     'Psr\\Http\\Message\\' => array($vendorDir . '/psr/http-factory/src', $vendorDir . '/psr/http-message/src'),
+    'Monolog\\' => array($vendorDir . '/monolog/monolog/src/Monolog'),
     'League\\Uri\\' => array($vendorDir . '/league/uri', $vendorDir . '/league/uri-interfaces'),
     'Egulias\\EmailValidator\\' => array($vendorDir . '/egulias/email-validator/src'),
     'Doctrine\\Common\\Lexer\\' => array($vendorDir . '/doctrine/lexer/src'),

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -19,7 +19,12 @@ class ComposerStaticInitfeb7c198389c10d6222848451ed19cb5
         ),
         'P' =>
         array (
+            'Psr\\Log\\' => 8,
             'Psr\\Http\\Message\\' => 17,
+        ),
+        'M' =>
+        array (
+            'Monolog\\' => 8,
         ),
         'L' =>
         array (
@@ -44,10 +49,18 @@ class ComposerStaticInitfeb7c198389c10d6222848451ed19cb5
         array (
             0 => __DIR__ . '/..' . '/symfony/polyfill-intl-idn',
         ),
+        'Psr\\Log\\' =>
+        array (
+            0 => __DIR__ . '/..' . '/psr/log/src',
+        ),
         'Psr\\Http\\Message\\' =>
         array (
             0 => __DIR__ . '/..' . '/psr/http-factory/src',
             1 => __DIR__ . '/..' . '/psr/http-message/src',
+        ),
+        'Monolog\\' =>
+        array (
+            0 => __DIR__ . '/..' . '/monolog/monolog/src/Monolog',
         ),
         'League\\Uri\\' =>
         array (

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -339,6 +339,112 @@
             "install-path": "../league/uri-interfaces"
         },
         {
+            "name": "monolog/monolog",
+            "version": "3.10.0",
+            "version_normalized": "3.10.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8 || ^2.0",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "php-console/php-console": "^3.1.8",
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^10.5.17 || ^11.0.7",
+                "predis/predis": "^1.1 || ^2",
+                "rollbar/rollbar": "^4.0",
+                "ruflin/elastica": "^7 || ^8",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "time": "2026-01-02T08:56:05+00:00",
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "installation-source": "dist",
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "install-path": "../monolog/monolog"
+        },
+        {
             "name": "psr/http-factory",
             "version": "1.1.0",
             "version_normalized": "1.1.0.0",
@@ -451,6 +557,59 @@
                 "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
             "install-path": "../psr/http-message"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "version_normalized": "3.0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "time": "2024-09-11T13:17:53+00:00",
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "installation-source": "dist",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "install-path": "../psr/log"
         },
         {
             "name": "symfony/polyfill-intl-idn",

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => '__root__',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '86d5ffa1d2ab605471bcb654c505e3cb6d80c4b6',
+        'reference' => '85c5b0061ca21baec9e35e30fc2b0f7dfc8b8a12',
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         '__root__' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '86d5ffa1d2ab605471bcb654c505e3cb6d80c4b6',
+            'reference' => '85c5b0061ca21baec9e35e30fc2b0f7dfc8b8a12',
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),
@@ -55,6 +55,15 @@
             'aliases' => array(),
             'dev_requirement' => false,
         ),
+        'monolog/monolog' => array(
+            'pretty_version' => '3.10.0',
+            'version' => '3.10.0.0',
+            'reference' => 'b321dd6749f0bf7189444158a3ce785cc16d69b0',
+            'type' => 'library',
+            'install_path' => __DIR__ . '/../monolog/monolog',
+            'aliases' => array(),
+            'dev_requirement' => false,
+        ),
         'psr/http-factory' => array(
             'pretty_version' => '1.1.0',
             'version' => '1.1.0.0',
@@ -72,6 +81,21 @@
             'install_path' => __DIR__ . '/../psr/http-message',
             'aliases' => array(),
             'dev_requirement' => false,
+        ),
+        'psr/log' => array(
+            'pretty_version' => '3.0.2',
+            'version' => '3.0.2.0',
+            'reference' => 'f16e1d5863e37f8d8c2a01719f5b34baa2b714d3',
+            'type' => 'library',
+            'install_path' => __DIR__ . '/../psr/log',
+            'aliases' => array(),
+            'dev_requirement' => false,
+        ),
+        'psr/log-implementation' => array(
+            'dev_requirement' => false,
+            'provided' => array(
+                0 => '3.0.0',
+            ),
         ),
         'symfony/polyfill-intl-idn' => array(
             'pretty_version' => 'v1.34.0',

--- a/vendor/monolog/monolog/CHANGELOG.md
+++ b/vendor/monolog/monolog/CHANGELOG.md
@@ -1,0 +1,810 @@
+### 3.10.0 (2026-01-02)
+
+  * Added automatic directory cleanup in RotatingFileHandler (#2000)
+  * Added timezone-aware file rotation to RotatingFileHandler (#1982)
+  * Added support for mongodb/mongodb 2.0+ (#1998)
+  * Added NoDiscard attribute to TestHandler methods to ensure the result is used (#2013)
+  * Fixed JsonFormatter crashing if __toString throws while normalizing data (#1968)
+  * Fixed PHP 8.5 deprecation warnings (#1997, #2009)
+  * Fixed DeduplicatingHandler collecting duplicate logs if the file cannot be locked (2e97231)
+  * Fixed GelfMessageFormatter to use integers instead of bool for gelf 1.1 support (#1973)
+  * Fixed empty stack traces being output anyway (#1979)
+  * Fixed StreamHandler not reopening the file if the inode changed (#1963)
+  * Fixed TelegramBotHandler sending empty messages (#1992)
+  * Fixed file paths in stack traces containing backslashes on windows, always using / now to unify logs (#1980)
+  * Fixed RotatingFileHandler unlink errors not being suppressed correctly (#1999)
+
+### 3.9.0 (2025-03-24)
+
+  * BC Warning: Fixed SendGridHandler to use the V3 API as V2 is now shut down, but this requires a new API key (#1952)
+  * Deprecated Monolog\Test\TestCase in favor of Monolog\Test\MonologTestCase (#1953)
+  * Added extension point for NativeMailerHandler::mail (#1948)
+  * Added setHandler method to BufferHandler to modify the nested handler at runtime (#1946)
+  * Fixed date format in ElasticsearchFormatter to use +00:00 vs +0000 tz identifiers (#1942)
+  * Fixed GelfMessageFormatter handling numeric context/extra keys (#1932)
+
+### 3.8.1 (2024-12-05)
+
+  * Deprecated Monolog\DateTimeImmutable in favor of Monolog\JsonSerializableDateTimeImmutable (#1928)
+  * Fixed gelf keys not being valid when context/extra data keys have spaces in them (#1927)
+  * Fixed empty lines appearing in the stack traces when a custom formatter returned null (#1925)
+
+### 3.8.0 (2024-11-12)
+
+  * Added `$fileOpenMode` param to `StreamHandler` to define a custom fopen mode to open the log file (#1913)
+  * Fixed PHP 8.4 deprecation notices (#1903)
+  * Added ability to extend/override `IntrospectionProcessor` (#1899)
+  * Added `$timeout` param to `ProcessHandler` to configure the stream_select() timeout to avoid blocking too long (default is 1.0 sec) (#1916)
+  * Fixed JsonFormatter batch handling to normalize records individually to make sure they look the same as if they were handled one by one (#1906)
+  * Fixed `StreamHandler` handling of write failures so that it now closes/reopens the stream and retries the write once before failing (#1882)
+  * Fixed `StreamHandler` error handler causing issues if a stream handler triggers an error (#1866)
+  * Fixed `StreamHandler::reset` not closing the stream, so that it would fail to write in some cases with long running processes (#1862)
+  * Fixed `RotatingFileHandler` issue where rotation does not happen in some long running processes (#1905)
+  * Fixed `JsonFormatter` handling of incomplete classes (#1834)
+  * Fixed `RotatingFileHandler` bug where rotation could sometimes not happen correctly (#1905)
+
+### 3.7.0 (2024-06-28)
+
+  * Added `NormalizerFormatter->setBasePath(...)` (and `JsonFormatter` by extension) that allows removing the project's path from the stack trace output (47e301d3e)
+  * Fixed JsonFormatter handling of incomplete classes (#1834)
+  * Fixed private error handlers causing problems with custom StreamHandler implementations (#1866)
+
+### 3.6.0 (2024-04-12)
+
+  * Added `LineFormatter->setBasePath(...)` that allows removing the project's path from the stack trace output (#1873)
+  * Added `$includeExtra` option in `PsrHandler` to also use extra data to replace placeholder values in the message (#1852)
+  * Added ability to customize what is a duplicated message by extending the `DeduplicationHandler` (#1879)
+  * Added handling for using `GelfMessageFormatter` together with the `AmqpHandler` (#1869)
+  * Added ability to extend `GoogleCloudLoggingFormatter` (#1859)
+  * Fixed `__toString` failures in context data crashing the normalization process (#1868)
+  * Fixed PHP 8.4 deprecation warnings (#1874)
+
+### 3.5.0 (2023-10-27)
+
+  * Added ability to indent stack traces in LineFormatter via e.g. `indentStacktraces('  ')` (#1835)
+  * Added ability to configure a max level name length in LineFormatter via e.g. `setMaxLevelNameLength(3)` (#1850)
+  * Added support for indexed arrays (i.e. `[]` and not `{}` arrays once json serialized) containing inline linebreaks in LineFormatter (#1818)
+  * Added `WithMonologChannel` attribute for integrators to use to configure autowiring (#1847)
+  * Fixed log record `extra` data leaking between handlers that have handler-specific processors set (#1819)
+  * Fixed LogglyHandler issue with record level filtering (#1841)
+  * Fixed display_errors parsing in ErrorHandler which did not support string values (#1804)
+  * Fixed bug where the previous error handler would not be restored in some cases where StreamHandler fails (#1815)
+  * Fixed normalization error when normalizing incomplete classes (#1833)
+
+### 3.4.0 (2023-06-21)
+
+  * Added `LoadAverageProcessor` to track one of the 1, 5 or 15min load averages (#1803)
+  * Added support for priority to the `AsMonologProcessor` attribute (#1797)
+  * Added `TelegramBotHandler` `topic`/`message_thread_id` support (#1802)
+  * Fixed `FingersCrossedHandler` passthruLevel checking (#1801)
+  * Fixed support of yearly and monthly rotation log file to rotate only once a month/year (#1805)
+  * Fixed `TestHandler` method docs (#1794)
+  * Fixed handling of falsey `display_errors` string values (#1804)
+
+### 3.3.1 (2023-02-06)
+
+  * Fixed Logger not being serializable anymore (#1792)
+
+### 3.3.0 (2023-02-06)
+
+  * Deprecated FlowdockHandler & Formatter as the flowdock service was shutdown (#1748)
+  * Added `ClosureContextProcessor` to allow delaying the creation of context data by setting a Closure in context which is called when the log record is used (#1745)
+  * Added an ElasticsearchHandler option to set the `op_type` to `create` instead of the default `index` (#1766)
+  * Added support for enum context values in PsrLogMessageProcessor (#1773)
+  * Added graylog2/gelf-php 2.x support (#1747)
+  * Improved `BrowserConsoleHandler` logging to use more appropriate methods than just console.log in the browser (#1739)
+  * Fixed GitProcessor not filtering correctly based on Level (#1749)
+  * Fixed `WhatFailureGroupHandler` not catching errors happening inside `close()` (#1791)
+  * Fixed datetime field in `GoogleCloudLoggingFormatter` (#1758)
+  * Fixed infinite loop detection within Fibers (#1753)
+  * Fixed `AmqpHandler->setExtraAttributes` not working with buffering handler wrappers (#1781)
+
+### 3.2.0 (2022-07-24)
+
+  * Deprecated `CubeHandler` and `PHPConsoleHandler` as both projects are abandoned and those should not be used anymore (#1734)
+  * Marked `Logger` `@final` as it should not be extended, prefer composition or talk to us if you are missing something
+  * Added RFC 5424 level (`7` to `0`) support to `Logger::log` and `Logger::addRecord` to increase interoperability (#1723)
+  * Added `SyslogFormatter` to output syslog-like files which can be consumed by tools like [lnav](https://lnav.org/) (#1689)
+  * Added support for `__toString` for objects which are not json serializable in `JsonFormatter` (#1733)
+  * Added `GoogleCloudLoggingFormatter` (#1719)
+  * Added support for Predis 2.x (#1732)
+  * Added `AmqpHandler->setExtraAttributes` to allow configuring attributes when using an AMQPExchange (#1724)
+  * Fixed serialization/unserialization of handlers to make sure private properties are included (#1727)
+  * Fixed allowInlineLineBreaks in LineFormatter causing issues with windows paths containing `\n` or `\r` sequences (#1720)
+  * Fixed max normalization depth not being taken into account when formatting exceptions with a deep chain of previous exceptions (#1726)
+  * Fixed PHP 8.2 deprecation warnings (#1722)
+  * Fixed rare race condition or filesystem issue where StreamHandler is unable to create the directory the log should go into yet it exists already (#1678)
+
+### 3.1.0 (2022-06-09)
+
+  * Added `$datetime` parameter to `Logger::addRecord` as low level API to allow logging into the past or future (#1682)
+  * Added `Logger::useLoggingLoopDetection` to allow disabling cyclic logging detection in concurrent frameworks (#1681)
+  * Fixed handling of fatal errors if callPrevious is disabled in ErrorHandler (#1670)
+  * Fixed interop issue by removing the need for a return type in ProcessorInterface (#1680)
+  * Marked the reusable `Monolog\Test\TestCase` class as `@internal` to make sure PHPStorm does not show it above PHPUnit, you may still use it to test your own handlers/etc though (#1677)
+  * Fixed RotatingFileHandler issue when the date format contained slashes (#1671)
+
+### 3.0.0 (2022-05-10)
+
+Changes from RC1
+
+- The `Monolog\LevelName` enum does not exist anymore, use `Monolog\Level->getName()` instead.
+
+### 3.0.0-RC1 (2022-05-08)
+
+This is mostly a cleanup release offering stronger type guarantees for integrators with the
+array->object/enum changes, but there is no big new feature for end users.
+
+See [UPGRADE notes](UPGRADE.md#300) for details on all breaking changes especially if you are extending/implementing Monolog classes/interfaces.
+
+Noteworthy BC Breaks:
+
+- The minimum supported PHP version is now `8.1.0`.
+- Log records have been converted from an array to a [`Monolog\LogRecord` object](src/Monolog/LogRecord.php)
+  with public (and mostly readonly) properties. e.g. instead of doing
+  `$record['context']` use `$record->context`.
+  In formatters or handlers if you rather need an array to work with you can use `$record->toArray()`
+  to get back a Monolog 1/2 style record array. This will contain the enum values instead of enum cases
+  in the `level` and `level_name` keys to be more backwards compatible and use simpler data types.
+- `FormatterInterface`, `HandlerInterface`, `ProcessorInterface`, etc. changed to contain `LogRecord $record`
+  instead of `array $record` parameter types. If you want to support multiple Monolog versions this should
+  be possible by type-hinting nothing, or `array|LogRecord` if you support PHP 8.0+. You can then code
+  against the $record using Monolog 2 style as LogRecord implements ArrayAccess for BC.
+  The interfaces do not require a `LogRecord` return type even where it would be applicable, but if you only
+  support Monolog 3 in integration code I would recommend you use `LogRecord` return types wherever fitting
+  to ensure forward compatibility as it may be added in Monolog 4.
+- Log levels are now enums [`Monolog\Level`](src/Monolog/Level.php) and [`Monolog\LevelName`](src/Monolog/LevelName.php)
+- Removed deprecated SwiftMailerHandler, migrate to SymfonyMailerHandler instead.
+- `ResettableInterface::reset()` now requires a void return type.
+- All properties have had types added, which may require you to do so as well if you extended
+  a Monolog class and declared the same property.
+
+New deprecations:
+
+- `Logger::DEBUG`, `Logger::ERROR`, etc. are now deprecated in favor of the `Monolog\Level` enum.
+  e.g. instead of `Logger::WARNING` use `Level::Warning` if you need to pass the enum case
+  to Monolog or one of its handlers, or `Level::Warning->value` if you need the integer
+  value equal to what `Logger::WARNING` was giving you.
+- `Logger::getLevelName()` is now deprecated.
+
+### 2.10.0 (2024-11-12)
+
+  * Added `$fileOpenMode` to `StreamHandler` to define a custom fopen mode to open the log file (#1913)
+  * Fixed `StreamHandler` handling of write failures so that it now closes/reopens the stream and retries the write once before failing (#1882)
+  * Fixed `StreamHandler` error handler causing issues if a stream handler triggers an error (#1866)
+  * Fixed `JsonFormatter` handling of incomplete classes (#1834)
+  * Fixed `RotatingFileHandler` bug where rotation could sometimes not happen correctly (#1905)
+
+### 2.9.3 (2024-04-12)
+
+  * Fixed PHP 8.4 deprecation warnings (#1874)
+
+### 2.9.2 (2023-10-27)
+
+  * Fixed display_errors parsing in ErrorHandler which did not support string values (#1804)
+  * Fixed bug where the previous error handler would not be restored in some cases where StreamHandler fails (#1815)
+  * Fixed normalization error when normalizing incomplete classes (#1833)
+
+### 2.9.1 (2023-02-06)
+
+  * Fixed Logger not being serializable anymore (#1792)
+
+### 2.9.0 (2023-02-05)
+
+  * Deprecated FlowdockHandler & Formatter as the flowdock service was shutdown (#1748)
+  * Added support for enum context values in PsrLogMessageProcessor (#1773)
+  * Added graylog2/gelf-php 2.x support (#1747)
+  * Improved `BrowserConsoleHandler` logging to use more appropriate methods than just console.log in the browser (#1739)
+  * Fixed `WhatFailureGroupHandler` not catching errors happening inside `close()` (#1791)
+  * Fixed datetime field in `GoogleCloudLoggingFormatter` (#1758)
+  * Fixed infinite loop detection within Fibers (#1753)
+  * Fixed `AmqpHandler->setExtraAttributes` not working with buffering handler wrappers (#1781)
+
+### 2.8.0 (2022-07-24)
+
+  * Deprecated `CubeHandler` and `PHPConsoleHandler` as both projects are abandoned and those should not be used anymore (#1734)
+  * Added RFC 5424 level (`7` to `0`) support to `Logger::log` and `Logger::addRecord` to increase interoperability (#1723)
+  * Added support for `__toString` for objects which are not json serializable in `JsonFormatter` (#1733)
+  * Added `GoogleCloudLoggingFormatter` (#1719)
+  * Added support for Predis 2.x (#1732)
+  * Added `AmqpHandler->setExtraAttributes` to allow configuring attributes when using an AMQPExchange (#1724)
+  * Fixed serialization/unserialization of handlers to make sure private properties are included (#1727)
+  * Fixed allowInlineLineBreaks in LineFormatter causing issues with windows paths containing `\n` or `\r` sequences (#1720)
+  * Fixed max normalization depth not being taken into account when formatting exceptions with a deep chain of previous exceptions (#1726)
+  * Fixed PHP 8.2 deprecation warnings (#1722)
+  * Fixed rare race condition or filesystem issue where StreamHandler is unable to create the directory the log should go into yet it exists already (#1678)
+
+### 2.7.0 (2022-06-09)
+
+  * Added `$datetime` parameter to `Logger::addRecord` as low level API to allow logging into the past or future (#1682)
+  * Added `Logger::useLoggingLoopDetection` to allow disabling cyclic logging detection in concurrent frameworks (#1681)
+  * Fixed handling of fatal errors if callPrevious is disabled in ErrorHandler (#1670)
+  * Marked the reusable `Monolog\Test\TestCase` class as `@internal` to make sure PHPStorm does not show it above PHPUnit, you may still use it to test your own handlers/etc though (#1677)
+  * Fixed RotatingFileHandler issue when the date format contained slashes (#1671)
+
+### 2.6.0 (2022-05-10)
+
+  * Deprecated `SwiftMailerHandler`, use `SymfonyMailerHandler` instead
+  * Added `SymfonyMailerHandler` (#1663)
+  * Added ElasticSearch 8.x support to the ElasticsearchHandler (#1662)
+  * Added a way to filter/modify stack traces in LineFormatter (#1665)
+  * Fixed UdpSocket not being able to reopen/reconnect after close()
+  * Fixed infinite loops if a Handler is triggering logging while handling log records
+
+### 2.5.0 (2022-04-08)
+
+  * Added `callType` to IntrospectionProcessor (#1612)
+  * Fixed AsMonologProcessor syntax to be compatible with PHP 7.2 (#1651)
+
+### 2.4.0 (2022-03-14)
+
+  * Added [`Monolog\LogRecord`](src/Monolog/LogRecord.php) interface that can be used to type-hint records like `array|\Monolog\LogRecord $record` to be forward compatible with the upcoming Monolog 3 changes
+  * Added `includeStacktraces` constructor params to LineFormatter & JsonFormatter (#1603)
+  * Added `persistent`, `timeout`, `writingTimeout`, `connectionTimeout`, `chunkSize` constructor params to SocketHandler and derivatives (#1600)
+  * Added `AsMonologProcessor` PHP attribute which can help autowiring / autoconfiguration of processors if frameworks / integrations decide to make use of it. This is useless when used purely with Monolog (#1637)
+  * Added support for keeping native BSON types as is in MongoDBFormatter (#1620)
+  * Added support for a `user_agent` key in WebProcessor, disabled by default but you can use it by configuring the $extraFields you want (#1613)
+  * Added support for username/userIcon in SlackWebhookHandler (#1617)
+  * Added extension points to BrowserConsoleHandler (#1593)
+  * Added record message/context/extra info to exceptions thrown when a StreamHandler cannot open its stream to avoid completely losing the data logged (#1630)
+  * Fixed error handler signature to accept a null $context which happens with internal PHP errors (#1614)
+  * Fixed a few setter methods not returning `self` (#1609)
+  * Fixed handling of records going over the max Telegram message length (#1616)
+
+### 2.3.5 (2021-10-01)
+
+  * Fixed regression in StreamHandler since 2.3.3 on systems with the memory_limit set to >=20GB (#1592)
+
+### 2.3.4 (2021-09-15)
+
+  * Fixed support for psr/log 3.x (#1589)
+
+### 2.3.3 (2021-09-14)
+
+  * Fixed memory usage when using StreamHandler and calling stream_get_contents on the resource you passed to it (#1578, #1577)
+  * Fixed support for psr/log 2.x (#1587)
+  * Fixed some type annotations
+
+### 2.3.2 (2021-07-23)
+
+  * Fixed compatibility with PHP 7.2 - 7.4 when experiencing PCRE errors (#1568)
+
+### 2.3.1 (2021-07-14)
+
+  * Fixed Utils::getClass handling of anonymous classes not being fully compatible with PHP 8 (#1563)
+  * Fixed some `@inheritDoc` annotations having the wrong case
+
+### 2.3.0 (2021-07-05)
+
+  * Added a ton of PHPStan type annotations as well as type aliases on Monolog\Logger for Record, Level and LevelName that you can import (#1557)
+  * Added ability to customize date format when using JsonFormatter (#1561)
+  * Fixed FilterHandler not calling reset on its internal handler when reset() is called on it (#1531)
+  * Fixed SyslogUdpHandler not setting the timezone correctly on DateTimeImmutable instances (#1540)
+  * Fixed StreamHandler thread safety - chunk size set to 2GB now to avoid interlacing when doing concurrent writes (#1553)
+
+### 2.2.0 (2020-12-14)
+
+  * Added JSON_PARTIAL_OUTPUT_ON_ERROR to default json encoding flags, to avoid dropping entire context data or even records due to an invalid subset of it somewhere
+  * Added setDateFormat to NormalizerFormatter (and Line/Json formatters by extension) to allow changing this after object creation
+  * Added RedisPubSubHandler to log records to a Redis channel using PUBLISH
+  * Added support for Elastica 7, and deprecated the $type argument of ElasticaFormatter which is not in use anymore as of Elastica 7
+  * Added support for millisecond write timeouts in SocketHandler, you can now pass floats to setWritingTimeout, e.g. 0.2 is 200ms
+  * Added support for unix sockets in SyslogUdpHandler (set $port to 0 to make the $host a unix socket)
+  * Added handleBatch support for TelegramBotHandler
+  * Added RFC5424e extended date format including milliseconds to SyslogUdpHandler
+  * Added support for configuring handlers with numeric level values in strings (coming from e.g. env vars)
+  * Fixed Wildfire/FirePHP/ChromePHP handling of unicode characters
+  * Fixed PHP 8 issues in SyslogUdpHandler
+  * Fixed internal type error when mbstring is missing
+
+### 2.1.1 (2020-07-23)
+
+  * Fixed removing of json encoding options
+  * Fixed type hint of $level not accepting strings in SendGridHandler and OverflowHandler
+  * Fixed SwiftMailerHandler not accepting email templates with an empty subject
+  * Fixed array access on null in RavenHandler
+  * Fixed unique_id in WebProcessor not being disableable
+
+### 2.1.0 (2020-05-22)
+
+  * Added `JSON_INVALID_UTF8_SUBSTITUTE` to default json flags, so that invalid UTF8 characters now get converted to [�](https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character) instead of being converted from ISO-8859-15 to UTF8 as it was before, which was hardly a comprehensive solution
+  * Added `$ignoreEmptyContextAndExtra` option to JsonFormatter to skip empty context/extra entirely from the output
+  * Added `$parseMode`, `$disableWebPagePreview` and `$disableNotification` options to TelegramBotHandler
+  * Added tentative support for PHP 8
+  * NormalizerFormatter::addJsonEncodeOption and removeJsonEncodeOption are now public to allow modifying default json flags
+  * Fixed GitProcessor type error when there is no git repo present
+  * Fixed normalization of SoapFault objects containing deeply nested objects as "detail"
+  * Fixed support for relative paths in RotatingFileHandler
+
+### 2.0.2 (2019-12-20)
+
+  * Fixed ElasticsearchHandler swallowing exceptions details when failing to index log records
+  * Fixed normalization of SoapFault objects containing non-strings as "detail" in LineFormatter
+  * Fixed formatting of resources in JsonFormatter
+  * Fixed RedisHandler failing to use MULTI properly when passed a proxied Redis instance (e.g. in Symfony with lazy services)
+  * Fixed FilterHandler triggering a notice when handleBatch was filtering all records passed to it
+  * Fixed Turkish locale messing up the conversion of level names to their constant values
+
+### 2.0.1 (2019-11-13)
+
+  * Fixed normalization of Traversables to avoid traversing them as not all of them are rewindable
+  * Fixed setFormatter/getFormatter to forward to the nested handler in FilterHandler, FingersCrossedHandler, BufferHandler, OverflowHandler and SamplingHandler
+  * Fixed BrowserConsoleHandler formatting when using multiple styles
+  * Fixed normalization of exception codes to be always integers even for PDOException which have them as numeric strings
+  * Fixed normalization of SoapFault objects containing non-strings as "detail"
+  * Fixed json encoding across all handlers to always attempt recovery of non-UTF-8 strings instead of failing the whole encoding
+  * Fixed ChromePHPHandler to avoid sending more data than latest Chrome versions allow in headers (4KB down from 256KB).
+  * Fixed type error in BrowserConsoleHandler when the context array of log records was not associative.
+
+### 2.0.0 (2019-08-30)
+
+  * BC Break: This is a major release, see [UPGRADE.md](UPGRADE.md) for details if you are coming from a 1.x release
+  * BC Break: Logger methods log/debug/info/notice/warning/error/critical/alert/emergency now have explicit void return types
+  * Added FallbackGroupHandler which works like the WhatFailureGroupHandler but stops dispatching log records as soon as one handler accepted it
+  * Fixed support for UTF-8 when cutting strings to avoid cutting a multibyte-character in half
+  * Fixed normalizers handling of exception backtraces to avoid serializing arguments in some cases
+  * Fixed date timezone handling in SyslogUdpHandler
+
+### 2.0.0-beta2 (2019-07-06)
+
+  * BC Break: This is a major release, see [UPGRADE.md](UPGRADE.md) for details if you are coming from a 1.x release
+  * BC Break: PHP 7.2 is now the minimum required PHP version.
+  * BC Break: Removed SlackbotHandler, RavenHandler and HipChatHandler, see [UPGRADE.md](UPGRADE.md) for details
+  * Added OverflowHandler which will only flush log records to its nested handler when reaching a certain amount of logs (i.e. only pass through when things go really bad)
+  * Added TelegramBotHandler to log records to a [Telegram](https://core.telegram.org/bots/api) bot account
+  * Added support for JsonSerializable when normalizing exceptions
+  * Added support for RFC3164 (outdated BSD syslog protocol) to SyslogUdpHandler
+  * Added SoapFault details to formatted exceptions
+  * Fixed DeduplicationHandler silently failing to start when file could not be opened
+  * Fixed issue in GroupHandler and WhatFailureGroupHandler where setting multiple processors would duplicate records
+  * Fixed GelfFormatter losing some data when one attachment was too long
+  * Fixed issue in SignalHandler restarting syscalls functionality
+  * Improved performance of LogglyHandler when sending multiple logs in a single request
+
+### 2.0.0-beta1 (2018-12-08)
+
+  * BC Break: This is a major release, see [UPGRADE.md](UPGRADE.md) for details if you are coming from a 1.x release
+  * BC Break: PHP 7.1 is now the minimum required PHP version.
+  * BC Break: Quite a few interface changes, only relevant if you implemented your own handlers/processors/formatters
+  * BC Break: Removed non-PSR-3 methods to add records, all the `add*` (e.g. `addWarning`) methods as well as `emerg`, `crit`, `err` and `warn`
+  * BC Break: The record timezone is now set per Logger instance and not statically anymore
+  * BC Break: There is no more default handler configured on empty Logger instances
+  * BC Break: ElasticSearchHandler renamed to ElasticaHandler
+  * BC Break: Various handler-specific breaks, see [UPGRADE.md](UPGRADE.md) for details
+  * Added scalar type hints and return hints in all the places it was possible. Switched strict_types on for more reliability.
+  * Added DateTimeImmutable support, all record datetime are now immutable, and will toString/json serialize with the correct date format, including microseconds (unless disabled)
+  * Added timezone and microseconds to the default date format
+  * Added SendGridHandler to use the SendGrid API to send emails
+  * Added LogmaticHandler to use the Logmatic.io API to store log records
+  * Added SqsHandler to send log records to an AWS SQS queue
+  * Added ElasticsearchHandler to send records via the official ES library. Elastica users should now use ElasticaHandler instead of ElasticSearchHandler
+  * Added NoopHandler which is similar to the NullHandle but does not prevent the bubbling of log records to handlers further down the configuration, useful for temporarily disabling a handler in configuration files
+  * Added ProcessHandler to write log output to the STDIN of a given process
+  * Added HostnameProcessor that adds the machine's hostname to log records
+  * Added a `$dateFormat` option to the PsrLogMessageProcessor which lets you format DateTime instances nicely
+  * Added support for the PHP 7.x `mongodb` extension in the MongoDBHandler
+  * Fixed many minor issues in various handlers, and probably added a few regressions too
+
+### 1.26.1 (2021-05-28)
+
+  * Fixed PHP 8.1 deprecation warning
+
+### 1.26.0 (2020-12-14)
+
+  * Added $dateFormat and $removeUsedContextFields arguments to PsrLogMessageProcessor (backport from 2.x)
+
+### 1.25.5 (2020-07-23)
+
+  * Fixed array access on null in RavenHandler
+  * Fixed unique_id in WebProcessor not being disableable
+
+### 1.25.4 (2020-05-22)
+
+  * Fixed GitProcessor type error when there is no git repo present
+  * Fixed normalization of SoapFault objects containing deeply nested objects as "detail"
+  * Fixed support for relative paths in RotatingFileHandler
+
+### 1.25.3 (2019-12-20)
+
+  * Fixed formatting of resources in JsonFormatter
+  * Fixed RedisHandler failing to use MULTI properly when passed a proxied Redis instance (e.g. in Symfony with lazy services)
+  * Fixed FilterHandler triggering a notice when handleBatch was filtering all records passed to it
+  * Fixed Turkish locale messing up the conversion of level names to their constant values
+
+### 1.25.2 (2019-11-13)
+
+  * Fixed normalization of Traversables to avoid traversing them as not all of them are rewindable
+  * Fixed setFormatter/getFormatter to forward to the nested handler in FilterHandler, FingersCrossedHandler, BufferHandler and SamplingHandler
+  * Fixed BrowserConsoleHandler formatting when using multiple styles
+  * Fixed normalization of exception codes to be always integers even for PDOException which have them as numeric strings
+  * Fixed normalization of SoapFault objects containing non-strings as "detail"
+  * Fixed json encoding across all handlers to always attempt recovery of non-UTF-8 strings instead of failing the whole encoding
+
+### 1.25.1 (2019-09-06)
+
+  * Fixed forward-compatible interfaces to be compatible with Monolog 1.x too.
+
+### 1.25.0 (2019-09-06)
+
+  * Deprecated SlackbotHandler, use SlackWebhookHandler or SlackHandler instead
+  * Deprecated RavenHandler, use sentry/sentry 2.x and their Sentry\Monolog\Handler instead
+  * Deprecated HipChatHandler, migrate to Slack and use SlackWebhookHandler or SlackHandler instead
+  * Added forward-compatible interfaces and traits FormattableHandlerInterface, FormattableHandlerTrait, ProcessableHandlerInterface, ProcessableHandlerTrait. If you use modern PHP and want to make code compatible with Monolog 1 and 2 this can help. You will have to require at least Monolog 1.25 though.
+  * Added support for RFC3164 (outdated BSD syslog protocol) to SyslogUdpHandler
+  * Fixed issue in GroupHandler and WhatFailureGroupHandler where setting multiple processors would duplicate records
+  * Fixed issue in SignalHandler restarting syscalls functionality
+  * Fixed normalizers handling of exception backtraces to avoid serializing arguments in some cases
+  * Fixed ZendMonitorHandler to work with the latest Zend Server versions
+  * Fixed ChromePHPHandler to avoid sending more data than latest Chrome versions allow in headers (4KB down from 256KB).
+
+### 1.24.0 (2018-11-05)
+
+  * BC Notice: If you are extending any of the Monolog's Formatters' `normalize` method, make sure you add the new `$depth = 0` argument to your function signature to avoid strict PHP warnings.
+  * Added a `ResettableInterface` in order to reset/reset/clear/flush handlers and processors
+  * Added a `ProcessorInterface` as an optional way to label a class as being a processor (mostly useful for autowiring dependency containers)
+  * Added a way to log signals being received using Monolog\SignalHandler
+  * Added ability to customize error handling at the Logger level using Logger::setExceptionHandler
+  * Added InsightOpsHandler to migrate users of the LogEntriesHandler
+  * Added protection to NormalizerFormatter against circular and very deep structures, it now stops normalizing at a depth of 9
+  * Added capture of stack traces to ErrorHandler when logging PHP errors
+  * Added RavenHandler support for a `contexts` context or extra key to forward that to Sentry's contexts
+  * Added forwarding of context info to FluentdFormatter
+  * Added SocketHandler::setChunkSize to override the default chunk size in case you must send large log lines to rsyslog for example
+  * Added ability to extend/override BrowserConsoleHandler
+  * Added SlackWebhookHandler::getWebhookUrl and SlackHandler::getToken to enable class extensibility
+  * Added SwiftMailerHandler::getSubjectFormatter to enable class extensibility
+  * Dropped official support for HHVM in test builds
+  * Fixed normalization of exception traces when call_user_func is used to avoid serializing objects and the data they contain
+  * Fixed naming of fields in Slack handler, all field names are now capitalized in all cases
+  * Fixed HipChatHandler bug where slack dropped messages randomly
+  * Fixed normalization of objects in Slack handlers
+  * Fixed support for PHP7's Throwable in NewRelicHandler
+  * Fixed race bug when StreamHandler sometimes incorrectly reported it failed to create a directory
+  * Fixed table row styling issues in HtmlFormatter
+  * Fixed RavenHandler dropping the message when logging exception
+  * Fixed WhatFailureGroupHandler skipping processors when using handleBatch
+    and implement it where possible
+  * Fixed display of anonymous class names
+
+### 1.23.0 (2017-06-19)
+
+  * Improved SyslogUdpHandler's support for RFC5424 and added optional `$ident` argument
+  * Fixed GelfHandler truncation to be per field and not per message
+  * Fixed compatibility issue with PHP <5.3.6
+  * Fixed support for headless Chrome in ChromePHPHandler
+  * Fixed support for latest Aws SDK in DynamoDbHandler
+  * Fixed support for SwiftMailer 6.0+ in SwiftMailerHandler
+
+### 1.22.1 (2017-03-13)
+
+  * Fixed lots of minor issues in the new Slack integrations
+  * Fixed support for allowInlineLineBreaks in LineFormatter when formatting exception backtraces
+
+### 1.22.0 (2016-11-26)
+
+  * Added SlackbotHandler and SlackWebhookHandler to set up Slack integration more easily
+  * Added MercurialProcessor to add mercurial revision and branch names to log records
+  * Added support for AWS SDK v3 in DynamoDbHandler
+  * Fixed fatal errors occurring when normalizing generators that have been fully consumed
+  * Fixed RollbarHandler to include a level (rollbar level), monolog_level (original name), channel and datetime (unix)
+  * Fixed RollbarHandler not flushing records automatically, calling close() explicitly is not necessary anymore
+  * Fixed SyslogUdpHandler to avoid sending empty frames
+  * Fixed a few PHP 7.0 and 7.1 compatibility issues
+
+### 1.21.0 (2016-07-29)
+
+  * Break: Reverted the addition of $context when the ErrorHandler handles regular php errors from 1.20.0 as it was causing issues
+  * Added support for more formats in RotatingFileHandler::setFilenameFormat as long as they have Y, m and d in order
+  * Added ability to format the main line of text the SlackHandler sends by explicitly setting a formatter on the handler
+  * Added information about SoapFault instances in NormalizerFormatter
+  * Added $handleOnlyReportedErrors option on ErrorHandler::registerErrorHandler (default true) to allow logging of all errors no matter the error_reporting level
+
+### 1.20.0 (2016-07-02)
+
+  * Added FingersCrossedHandler::activate() to manually trigger the handler regardless of the activation policy
+  * Added StreamHandler::getUrl to retrieve the stream's URL
+  * Added ability to override addRow/addTitle in HtmlFormatter
+  * Added the $context to context information when the ErrorHandler handles a regular php error
+  * Deprecated RotatingFileHandler::setFilenameFormat to only support 3 formats: Y, Y-m and Y-m-d
+  * Fixed WhatFailureGroupHandler to work with PHP7 throwables
+  * Fixed a few minor bugs
+
+### 1.19.0 (2016-04-12)
+
+  * Break: StreamHandler will not close streams automatically that it does not own. If you pass in a stream (not a path/url), then it will not close it for you. You can retrieve those using getStream() if needed
+  * Added DeduplicationHandler to remove duplicate records from notifications across multiple requests, useful for email or other notifications on errors
+  * Added ability to use `%message%` and other LineFormatter replacements in the subject line of emails sent with NativeMailHandler and SwiftMailerHandler
+  * Fixed HipChatHandler handling of long messages
+
+### 1.18.2 (2016-04-02)
+
+  * Fixed ElasticaFormatter to use more precise dates
+  * Fixed GelfMessageFormatter sending too long messages
+
+### 1.18.1 (2016-03-13)
+
+  * Fixed SlackHandler bug where slack dropped messages randomly
+  * Fixed RedisHandler issue when using with the PHPRedis extension
+  * Fixed AmqpHandler content-type being incorrectly set when using with the AMQP extension
+  * Fixed BrowserConsoleHandler regression
+
+### 1.18.0 (2016-03-01)
+
+  * Added optional reduction of timestamp precision via `Logger->useMicrosecondTimestamps(false)`, disabling it gets you a bit of performance boost but reduces the precision to the second instead of microsecond
+  * Added possibility to skip some extra stack frames in IntrospectionProcessor if you have some library wrapping Monolog that is always adding frames
+  * Added `Logger->withName` to clone a logger (keeping all handlers) with a new name
+  * Added FluentdFormatter for the Fluentd unix socket protocol
+  * Added HandlerWrapper base class to ease the creation of handler wrappers, just extend it and override as needed
+  * Added support for replacing context sub-keys using `%context.*%` in LineFormatter
+  * Added support for `payload` context value in RollbarHandler
+  * Added setRelease to RavenHandler to describe the application version, sent with every log
+  * Added support for `fingerprint` context value in RavenHandler
+  * Fixed JSON encoding errors that would gobble up the whole log record, we now handle those more gracefully by dropping chars as needed
+  * Fixed write timeouts in SocketHandler and derivatives, set to 10sec by default, lower it with `setWritingTimeout()`
+  * Fixed PHP7 compatibility with regard to Exception/Throwable handling in a few places
+
+### 1.17.2 (2015-10-14)
+
+  * Fixed ErrorHandler compatibility with non-Monolog PSR-3 loggers
+  * Fixed SlackHandler handling to use slack functionalities better
+  * Fixed SwiftMailerHandler bug when sending multiple emails they all had the same id
+  * Fixed 5.3 compatibility regression
+
+### 1.17.1 (2015-08-31)
+
+  * Fixed RollbarHandler triggering PHP notices
+
+### 1.17.0 (2015-08-30)
+
+  * Added support for `checksum` and `release` context/extra values in RavenHandler
+  * Added better support for exceptions in RollbarHandler
+  * Added UidProcessor::getUid
+  * Added support for showing the resource type in NormalizedFormatter
+  * Fixed IntrospectionProcessor triggering PHP notices
+
+### 1.16.0 (2015-08-09)
+
+  * Added IFTTTHandler to notify ifttt.com triggers
+  * Added Logger::setHandlers() to allow setting/replacing all handlers
+  * Added $capSize in RedisHandler to cap the log size
+  * Fixed StreamHandler creation of directory to only trigger when the first log write happens
+  * Fixed bug in the handling of curl failures
+  * Fixed duplicate logging of fatal errors when both error and fatal error handlers are registered in monolog's ErrorHandler
+  * Fixed missing fatal errors records with handlers that need to be closed to flush log records
+  * Fixed TagProcessor::addTags support for associative arrays
+
+### 1.15.0 (2015-07-12)
+
+  * Added addTags and setTags methods to change a TagProcessor
+  * Added automatic creation of directories if they are missing for a StreamHandler to open a log file
+  * Added retry functionality to Loggly, Cube and Mandrill handlers so they retry up to 5 times in case of network failure
+  * Fixed process exit code being incorrectly reset to 0 if ErrorHandler::registerExceptionHandler was used
+  * Fixed HTML/JS escaping in BrowserConsoleHandler
+  * Fixed JSON encoding errors being silently suppressed (PHP 5.5+ only)
+
+### 1.14.0 (2015-06-19)
+
+  * Added PHPConsoleHandler to send record to Chrome's PHP Console extension and library
+  * Added support for objects implementing __toString in the NormalizerFormatter
+  * Added support for HipChat's v2 API in HipChatHandler
+  * Added Logger::setTimezone() to initialize the timezone monolog should use in case date.timezone isn't correct for your app
+  * Added an option to send formatted message instead of the raw record on PushoverHandler via ->useFormattedMessage(true)
+  * Fixed curl errors being silently suppressed
+
+### 1.13.1 (2015-03-09)
+
+  * Fixed regression in HipChat requiring a new token to be created
+
+### 1.13.0 (2015-03-05)
+
+  * Added Registry::hasLogger to check for the presence of a logger instance
+  * Added context.user support to RavenHandler
+  * Added HipChat API v2 support in the HipChatHandler
+  * Added NativeMailerHandler::addParameter to pass params to the mail() process
+  * Added context data to SlackHandler when $includeContextAndExtra is true
+  * Added ability to customize the Swift_Message per-email in SwiftMailerHandler
+  * Fixed SwiftMailerHandler to lazily create message instances if a callback is provided
+  * Fixed serialization of INF and NaN values in Normalizer and LineFormatter
+
+### 1.12.0 (2014-12-29)
+
+  * Break: HandlerInterface::isHandling now receives a partial record containing only a level key. This was always the intent and does not break any Monolog handler but is strictly speaking a BC break and you should check if you relied on any other field in your own handlers.
+  * Added PsrHandler to forward records to another PSR-3 logger
+  * Added SamplingHandler to wrap around a handler and include only every Nth record
+  * Added MongoDBFormatter to support better storage with MongoDBHandler (it must be enabled manually for now)
+  * Added exception codes in the output of most formatters
+  * Added LineFormatter::includeStacktraces to enable exception stack traces in logs (uses more than one line)
+  * Added $useShortAttachment to SlackHandler to minify attachment size and $includeExtra to append extra data
+  * Added $host to HipChatHandler for users of private instances
+  * Added $transactionName to NewRelicHandler and support for a transaction_name context value
+  * Fixed MandrillHandler to avoid outputting API call responses
+  * Fixed some non-standard behaviors in SyslogUdpHandler
+
+### 1.11.0 (2014-09-30)
+
+  * Break: The NewRelicHandler extra and context data are now prefixed with extra_ and context_ to avoid clashes. Watch out if you have scripts reading those from the API and rely on names
+  * Added WhatFailureGroupHandler to suppress any exception coming from the wrapped handlers and avoid chain failures if a logging service fails
+  * Added MandrillHandler to send emails via the Mandrillapp.com API
+  * Added SlackHandler to log records to a Slack.com account
+  * Added FleepHookHandler to log records to a Fleep.io account
+  * Added LogglyHandler::addTag to allow adding tags to an existing handler
+  * Added $ignoreEmptyContextAndExtra to LineFormatter to avoid empty [] at the end
+  * Added $useLocking to StreamHandler and RotatingFileHandler to enable flock() while writing
+  * Added support for PhpAmqpLib in the AmqpHandler
+  * Added FingersCrossedHandler::clear and BufferHandler::clear to reset them between batches in long running jobs
+  * Added support for adding extra fields from $_SERVER in the WebProcessor
+  * Fixed support for non-string values in PrsLogMessageProcessor
+  * Fixed SwiftMailer messages being sent with the wrong date in long running scripts
+  * Fixed minor PHP 5.6 compatibility issues
+  * Fixed BufferHandler::close being called twice
+
+### 1.10.0 (2014-06-04)
+
+  * Added Logger::getHandlers() and Logger::getProcessors() methods
+  * Added $passthruLevel argument to FingersCrossedHandler to let it always pass some records through even if the trigger level is not reached
+  * Added support for extra data in NewRelicHandler
+  * Added $expandNewlines flag to the ErrorLogHandler to create multiple log entries when a message has multiple lines
+
+### 1.9.1 (2014-04-24)
+
+  * Fixed regression in RotatingFileHandler file permissions
+  * Fixed initialization of the BufferHandler to make sure it gets flushed after receiving records
+  * Fixed ChromePHPHandler and FirePHPHandler's activation strategies to be more conservative
+
+### 1.9.0 (2014-04-20)
+
+  * Added LogEntriesHandler to send logs to a LogEntries account
+  * Added $filePermissions to tweak file mode on StreamHandler and RotatingFileHandler
+  * Added $useFormatting flag to MemoryProcessor to make it send raw data in bytes
+  * Added support for table formatting in FirePHPHandler via the table context key
+  * Added a TagProcessor to add tags to records, and support for tags in RavenHandler
+  * Added $appendNewline flag to the JsonFormatter to enable using it when logging to files
+  * Added sound support to the PushoverHandler
+  * Fixed multi-threading support in StreamHandler
+  * Fixed empty headers issue when ChromePHPHandler received no records
+  * Fixed default format of the ErrorLogHandler
+
+### 1.8.0 (2014-03-23)
+
+  * Break: the LineFormatter now strips newlines by default because this was a bug, set $allowInlineLineBreaks to true if you need them
+  * Added BrowserConsoleHandler to send logs to any browser's console via console.log() injection in the output
+  * Added FilterHandler to filter records and only allow those of a given list of levels through to the wrapped handler
+  * Added FlowdockHandler to send logs to a Flowdock account
+  * Added RollbarHandler to send logs to a Rollbar account
+  * Added HtmlFormatter to send prettier log emails with colors for each log level
+  * Added GitProcessor to add the current branch/commit to extra record data
+  * Added a Monolog\Registry class to allow easier global access to pre-configured loggers
+  * Added support for the new official graylog2/gelf-php lib for GelfHandler, upgrade if you can by replacing the mlehner/gelf-php requirement
+  * Added support for HHVM
+  * Added support for Loggly batch uploads
+  * Added support for tweaking the content type and encoding in NativeMailerHandler
+  * Added $skipClassesPartials to tweak the ignored classes in the IntrospectionProcessor
+  * Fixed batch request support in GelfHandler
+
+### 1.7.0 (2013-11-14)
+
+  * Added ElasticSearchHandler to send logs to an Elastic Search server
+  * Added DynamoDbHandler and ScalarFormatter to send logs to Amazon's Dynamo DB
+  * Added SyslogUdpHandler to send logs to a remote syslogd server
+  * Added LogglyHandler to send logs to a Loggly account
+  * Added $level to IntrospectionProcessor so it only adds backtraces when needed
+  * Added $version to LogstashFormatter to allow using the new v1 Logstash format
+  * Added $appName to NewRelicHandler
+  * Added configuration of Pushover notification retries/expiry
+  * Added $maxColumnWidth to NativeMailerHandler to change the 70 chars default
+  * Added chainability to most setters for all handlers
+  * Fixed RavenHandler batch processing so it takes the message from the record with highest priority
+  * Fixed HipChatHandler batch processing so it sends all messages at once
+  * Fixed issues with eAccelerator
+  * Fixed and improved many small things
+
+### 1.6.0 (2013-07-29)
+
+  * Added HipChatHandler to send logs to a HipChat chat room
+  * Added ErrorLogHandler to send logs to PHP's error_log function
+  * Added NewRelicHandler to send logs to NewRelic's service
+  * Added Monolog\ErrorHandler helper class to register a Logger as exception/error/fatal handler
+  * Added ChannelLevelActivationStrategy for the FingersCrossedHandler to customize levels by channel
+  * Added stack traces output when normalizing exceptions (json output & co)
+  * Added Monolog\Logger::API constant (currently 1)
+  * Added support for ChromePHP's v4.0 extension
+  * Added support for message priorities in PushoverHandler, see $highPriorityLevel and $emergencyLevel
+  * Added support for sending messages to multiple users at once with the PushoverHandler
+  * Fixed RavenHandler's support for batch sending of messages (when behind a Buffer or FingersCrossedHandler)
+  * Fixed normalization of Traversables with very large data sets, only the first 1000 items are shown now
+  * Fixed issue in RotatingFileHandler when an open_basedir restriction is active
+  * Fixed minor issues in RavenHandler and bumped the API to Raven 0.5.0
+  * Fixed SyslogHandler issue when many were used concurrently with different facilities
+
+### 1.5.0 (2013-04-23)
+
+  * Added ProcessIdProcessor to inject the PID in log records
+  * Added UidProcessor to inject a unique identifier to all log records of one request/run
+  * Added support for previous exceptions in the LineFormatter exception serialization
+  * Added Monolog\Logger::getLevels() to get all available levels
+  * Fixed ChromePHPHandler so it avoids sending headers larger than Chrome can handle
+
+### 1.4.1 (2013-04-01)
+
+  * Fixed exception formatting in the LineFormatter to be more minimalistic
+  * Fixed RavenHandler's handling of context/extra data, requires Raven client >0.1.0
+  * Fixed log rotation in RotatingFileHandler to work with long running scripts spanning multiple days
+  * Fixed WebProcessor array access so it checks for data presence
+  * Fixed Buffer, Group and FingersCrossed handlers to make use of their processors
+
+### 1.4.0 (2013-02-13)
+
+  * Added RedisHandler to log to Redis via the Predis library or the phpredis extension
+  * Added ZendMonitorHandler to log to the Zend Server monitor
+  * Added the possibility to pass arrays of handlers and processors directly in the Logger constructor
+  * Added `$useSSL` option to the PushoverHandler which is enabled by default
+  * Fixed ChromePHPHandler and FirePHPHandler issue when multiple instances are used simultaneously
+  * Fixed header injection capability in the NativeMailHandler
+
+### 1.3.1 (2013-01-11)
+
+  * Fixed LogstashFormatter to be usable with stream handlers
+  * Fixed GelfMessageFormatter levels on Windows
+
+### 1.3.0 (2013-01-08)
+
+  * Added PSR-3 compliance, the `Monolog\Logger` class is now an instance of `Psr\Log\LoggerInterface`
+  * Added PsrLogMessageProcessor that you can selectively enable for full PSR-3 compliance
+  * Added LogstashFormatter (combine with SocketHandler or StreamHandler to send logs to Logstash)
+  * Added PushoverHandler to send mobile notifications
+  * Added CouchDBHandler and DoctrineCouchDBHandler
+  * Added RavenHandler to send data to Sentry servers
+  * Added support for the new MongoClient class in MongoDBHandler
+  * Added microsecond precision to log records' timestamps
+  * Added `$flushOnOverflow` param to BufferHandler to flush by batches instead of losing
+    the oldest entries
+  * Fixed normalization of objects with cyclic references
+
+### 1.2.1 (2012-08-29)
+
+  * Added new $logopts arg to SyslogHandler to provide custom openlog options
+  * Fixed fatal error in SyslogHandler
+
+### 1.2.0 (2012-08-18)
+
+  * Added AmqpHandler (for use with AMQP servers)
+  * Added CubeHandler
+  * Added NativeMailerHandler::addHeader() to send custom headers in mails
+  * Added the possibility to specify more than one recipient in NativeMailerHandler
+  * Added the possibility to specify float timeouts in SocketHandler
+  * Added NOTICE and EMERGENCY levels to conform with RFC 5424
+  * Fixed the log records to use the php default timezone instead of UTC
+  * Fixed BufferHandler not being flushed properly on PHP fatal errors
+  * Fixed normalization of exotic resource types
+  * Fixed the default format of the SyslogHandler to avoid duplicating datetimes in syslog
+
+### 1.1.0 (2012-04-23)
+
+  * Added Monolog\Logger::isHandling() to check if a handler will
+    handle the given log level
+  * Added ChromePHPHandler
+  * Added MongoDBHandler
+  * Added GelfHandler (for use with Graylog2 servers)
+  * Added SocketHandler (for use with syslog-ng for example)
+  * Added NormalizerFormatter
+  * Added the possibility to change the activation strategy of the FingersCrossedHandler
+  * Added possibility to show microseconds in logs
+  * Added `server` and `referer` to WebProcessor output
+
+### 1.0.2 (2011-10-24)
+
+  * Fixed bug in IE with large response headers and FirePHPHandler
+
+### 1.0.1 (2011-08-25)
+
+  * Added MemoryPeakUsageProcessor and MemoryUsageProcessor
+  * Added Monolog\Logger::getName() to get a logger's channel name
+
+### 1.0.0 (2011-07-06)
+
+  * Added IntrospectionProcessor to get info from where the logger was called
+  * Fixed WebProcessor in CLI
+
+### 1.0.0-RC1 (2011-07-01)
+
+  * Initial release

--- a/vendor/monolog/monolog/LICENSE
+++ b/vendor/monolog/monolog/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2011-2020 Jordi Boggiano
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/monolog/monolog/README.md
+++ b/vendor/monolog/monolog/README.md
@@ -1,0 +1,136 @@
+<p align="center"><img src="logo.jpg" alt="Monolog" width="400"></p>
+
+# Monolog - Logging for PHP [![Continuous Integration](https://github.com/Seldaek/monolog/workflows/Continuous%20Integration/badge.svg?branch=main)](https://github.com/Seldaek/monolog/actions)
+
+[![Total Downloads](https://img.shields.io/packagist/dt/monolog/monolog.svg)](https://packagist.org/packages/monolog/monolog)
+[![Latest Stable Version](https://img.shields.io/packagist/v/monolog/monolog.svg)](https://packagist.org/packages/monolog/monolog)
+
+>**Note** This is the **documentation for Monolog 3.x**, if you are using older releases
+>see the documentation for [Monolog 2.x](https://github.com/Seldaek/monolog/blob/2.x/README.md) or [Monolog 1.x](https://github.com/Seldaek/monolog/blob/1.x/README.md)
+
+Monolog sends your logs to files, sockets, inboxes, databases and various
+web services. See the complete list of handlers below. Special handlers
+allow you to build advanced logging strategies.
+
+This library implements the [PSR-3](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md)
+interface that you can type-hint against in your own libraries to keep
+a maximum of interoperability. You can also use it in your applications to
+make sure you can always use another compatible logger at a later time.
+As of 1.11.0 Monolog public APIs will also accept PSR-3 log levels.
+Internally Monolog still uses its own level scheme since it predates PSR-3.
+
+<div align="center">
+  <hr>
+  <sup><b>Sponsored by:</b></sup>
+  <br>
+  <a href="https://betterstack.com">
+    <div>
+      <img src="https://github.com/Seldaek/monolog/assets/183678/7de58ce0-2fa2-45c0-b3e8-e60cebb3c4cf" width="200" alt="Better Stack">
+    </div>
+    <div>
+      Better Stack lets you centralize, search, and visualize your logs.
+    </div>
+  </a>
+  <br>
+  <hr>
+</div>
+
+## Installation
+
+Install the latest version with
+
+```bash
+composer require monolog/monolog
+```
+
+## Basic Usage
+
+```php
+<?php
+
+use Monolog\Level;
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+
+// create a log channel
+$log = new Logger('name');
+$log->pushHandler(new StreamHandler('path/to/your.log', Level::Warning));
+
+// add records to the log
+$log->warning('Foo');
+$log->error('Bar');
+```
+
+## Documentation
+
+- [Usage Instructions](doc/01-usage.md)
+- [Handlers, Formatters and Processors](doc/02-handlers-formatters-processors.md)
+- [Utility Classes](doc/03-utilities.md)
+- [Extending Monolog](doc/04-extending.md)
+- [Log Record Structure](doc/message-structure.md)
+
+## Support Monolog Financially
+
+Get supported Monolog and help fund the project with the [Tidelift Subscription](https://tidelift.com/subscription/pkg/packagist-monolog-monolog?utm_source=packagist-monolog-monolog&utm_medium=referral&utm_campaign=enterprise) or via [GitHub sponsorship](https://github.com/sponsors/Seldaek).
+
+Tidelift delivers commercial support and maintenance for the open source dependencies you use to build your applications. Save time, reduce risk, and improve code health, while paying the maintainers of the exact dependencies you use.
+
+## Third Party Packages
+
+Third party handlers, formatters and processors are
+[listed in the wiki](https://github.com/Seldaek/monolog/wiki/Third-Party-Packages). You
+can also add your own there if you publish one.
+
+## About
+
+### Requirements
+
+- Monolog `^3.0` works with PHP 8.1 or above.
+- Monolog `^2.5` works with PHP 7.2 or above.
+- Monolog `^1.25` works with PHP 5.3 up to 8.1, but is not very maintained anymore and will not receive PHP support fixes anymore.
+
+### Support
+
+Monolog 1.x support is somewhat limited at this point and only important fixes will be done. You should migrate to Monolog 2 or 3 where possible to benefit from all the latest features and fixes.
+
+### Submitting bugs and feature requests
+
+Bugs and feature request are tracked on [GitHub](https://github.com/Seldaek/monolog/issues)
+
+### Framework Integrations
+
+- Frameworks and libraries using [PSR-3](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md)
+  can be used very easily with Monolog since it implements the interface.
+- [Symfony](http://symfony.com) comes out of the box with Monolog.
+- [Laravel](http://laravel.com/) comes out of the box with Monolog.
+- [Lumen](http://lumen.laravel.com/) comes out of the box with Monolog.
+- [PPI](https://github.com/ppi/framework) comes out of the box with Monolog.
+- [CakePHP](http://cakephp.org/) is usable with Monolog via the [cakephp-monolog](https://github.com/jadb/cakephp-monolog) plugin.
+- [XOOPS 2.6](http://xoops.org/) comes out of the box with Monolog.
+- [Aura.Web_Project](https://github.com/auraphp/Aura.Web_Project) comes out of the box with Monolog.
+- [Nette Framework](http://nette.org/en/) is usable with Monolog via the [contributte/monolog](https://github.com/contributte/monolog) or [orisai/nette-monolog](https://github.com/orisai/nette-monolog) extensions.
+- [Proton Micro Framework](https://github.com/alexbilbie/Proton) comes out of the box with Monolog.
+- [FuelPHP](http://fuelphp.com/) comes out of the box with Monolog.
+- [Equip Framework](https://github.com/equip/framework) comes out of the box with Monolog.
+- [Yii 2](http://www.yiiframework.com/) is usable with Monolog via the [yii2-monolog](https://github.com/merorafael/yii2-monolog) or [yii2-psr-log-target](https://github.com/samdark/yii2-psr-log-target) plugins.
+- [Hawkbit Micro Framework](https://github.com/HawkBitPhp/hawkbit) comes out of the box with Monolog.
+- [SilverStripe 4](https://www.silverstripe.org/) comes out of the box with Monolog.
+- [Drupal](https://www.drupal.org/) is usable with Monolog via the [monolog](https://www.drupal.org/project/monolog) module.
+- [Aimeos ecommerce framework](https://aimeos.org/) is usable with Monolog via the [ai-monolog](https://github.com/aimeos/ai-monolog) extension.
+- [Magento](https://magento.com/) comes out of the box with Monolog.
+- [Spiral Framework](https://spiral.dev) comes out of the box with Monolog bridge.
+- [WebFramework](https://web-framework.com/) comes out of the box with Monolog.
+
+### Author
+
+Jordi Boggiano - <j.boggiano@seld.be> - <http://twitter.com/seldaek><br />
+See also the list of [contributors](https://github.com/Seldaek/monolog/contributors) who participated in this project.
+
+### License
+
+Monolog is licensed under the MIT License - see the [LICENSE](LICENSE) file for details
+
+### Acknowledgements
+
+This library is heavily inspired by Python's [Logbook](https://logbook.readthedocs.io/en/stable/)
+library, although most concepts have been adjusted to fit to the PHP world.

--- a/vendor/monolog/monolog/composer.json
+++ b/vendor/monolog/monolog/composer.json
@@ -1,0 +1,82 @@
+{
+    "name": "monolog/monolog",
+    "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+    "keywords": ["log", "logging", "psr-3"],
+    "homepage": "https://github.com/Seldaek/monolog",
+    "type": "library",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Jordi Boggiano",
+            "email": "j.boggiano@seld.be",
+            "homepage": "https://seld.be"
+        }
+    ],
+    "require": {
+        "php": ">=8.1",
+        "psr/log": "^2.0 || ^3.0"
+    },
+    "require-dev": {
+        "ext-json": "*",
+        "aws/aws-sdk-php": "^3.0",
+        "doctrine/couchdb": "~1.0@dev",
+        "elasticsearch/elasticsearch": "^7 || ^8",
+        "graylog2/gelf-php": "^1.4.2 || ^2.0",
+        "guzzlehttp/guzzle": "^7.4.5",
+        "guzzlehttp/psr7": "^2.2",
+        "mongodb/mongodb": "^1.8 || ^2.0",
+        "php-amqplib/php-amqplib": "~2.4 || ^3",
+        "php-console/php-console": "^3.1.8",
+        "phpstan/phpstan": "^2",
+        "phpstan/phpstan-deprecation-rules": "^2",
+        "phpstan/phpstan-strict-rules": "^2",
+        "phpunit/phpunit": "^10.5.17 || ^11.0.7",
+        "predis/predis": "^1.1 || ^2",
+        "rollbar/rollbar": "^4.0",
+        "ruflin/elastica": "^7 || ^8",
+        "symfony/mailer": "^5.4 || ^6",
+        "symfony/mime": "^5.4 || ^6"
+    },
+    "suggest": {
+        "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+        "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+        "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+        "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+        "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+        "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+        "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+        "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+        "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+        "rollbar/rollbar": "Allow sending log messages to Rollbar",
+        "ext-mbstring": "Allow to work properly with unicode symbols",
+        "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+        "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+        "ext-openssl": "Required to send log messages using SSL"
+    },
+    "autoload": {
+        "psr-4": {"Monolog\\": "src/Monolog"}
+    },
+    "autoload-dev": {
+        "psr-4": {"Monolog\\": "tests/Monolog"}
+    },
+    "provide": {
+        "psr/log-implementation": "3.0.0"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "3.x-dev"
+        }
+    },
+    "scripts": {
+        "test": "@php vendor/bin/phpunit",
+        "phpstan": "@php vendor/bin/phpstan analyse"
+    },
+    "config": {
+        "lock": false,
+        "sort-packages": true,
+        "platform-check": false,
+        "allow-plugins": {
+            "php-http/discovery": false
+        }
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Attribute/AsMonologProcessor.php
+++ b/vendor/monolog/monolog/src/Monolog/Attribute/AsMonologProcessor.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Attribute;
+
+/**
+ * A reusable attribute to help configure a class or a method as a processor.
+ *
+ * Using it offers no guarantee: it needs to be leveraged by a Monolog third-party consumer.
+ *
+ * Using it with the Monolog library only has no effect at all: processors should still be turned into a callable if
+ * needed and manually pushed to the loggers and to the processable handlers.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class AsMonologProcessor
+{
+    /**
+     * @param string|null $channel  The logging channel the processor should be pushed to.
+     * @param string|null $handler  The handler the processor should be pushed to.
+     * @param string|null $method   The method that processes the records (if the attribute is used at the class level).
+     * @param int|null    $priority The priority of the processor so the order can be determined.
+     */
+    public function __construct(
+        public readonly ?string $channel = null,
+        public readonly ?string $handler = null,
+        public readonly ?string $method = null,
+        public readonly ?int $priority = null
+    ) {
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Attribute/WithMonologChannel.php
+++ b/vendor/monolog/monolog/src/Monolog/Attribute/WithMonologChannel.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Attribute;
+
+/**
+ * A reusable attribute to help configure a class as expecting a given logger channel.
+ *
+ * Using it offers no guarantee: it needs to be leveraged by a Monolog third-party consumer.
+ *
+ * Using it with the Monolog library only has no effect at all: wiring the logger instance into
+ * other classes is not managed by Monolog.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class WithMonologChannel
+{
+    public function __construct(
+        public readonly string $channel
+    ) {
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/DateTimeImmutable.php
+++ b/vendor/monolog/monolog/src/Monolog/DateTimeImmutable.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog;
+
+class_alias(JsonSerializableDateTimeImmutable::class, 'Monolog\DateTimeImmutable');
+
+// @phpstan-ignore-next-line
+if (false) {
+    /**
+     * @deprecated Use \Monolog\JsonSerializableDateTimeImmutable instead.
+     */
+    class DateTimeImmutable extends JsonSerializableDateTimeImmutable
+    {
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/ErrorHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/ErrorHandler.php
@@ -1,0 +1,279 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog;
+
+use Closure;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+/**
+ * Monolog error handler
+ *
+ * A facility to enable logging of runtime errors, exceptions and fatal errors.
+ *
+ * Quick setup: <code>ErrorHandler::register($logger);</code>
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class ErrorHandler
+{
+    private Closure|null $previousExceptionHandler = null;
+
+    /** @var array<class-string, LogLevel::*> an array of class name to LogLevel::* constant mapping */
+    private array $uncaughtExceptionLevelMap = [];
+
+    /** @var Closure|true|null */
+    private Closure|bool|null $previousErrorHandler = null;
+
+    /** @var array<int, LogLevel::*> an array of E_* constant to LogLevel::* constant mapping */
+    private array $errorLevelMap = [];
+
+    private bool $handleOnlyReportedErrors = true;
+
+    private bool $hasFatalErrorHandler = false;
+
+    private string $fatalLevel = LogLevel::ALERT;
+
+    private string|null $reservedMemory = null;
+
+    /** @var ?array{type: int, message: string, file: string, line: int, trace: mixed} */
+    private array|null $lastFatalData = null;
+
+    private const FATAL_ERRORS = [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR];
+
+    public function __construct(
+        private LoggerInterface $logger
+    ) {
+    }
+
+    /**
+     * Registers a new ErrorHandler for a given Logger
+     *
+     * By default it will handle errors, exceptions and fatal errors
+     *
+     * @param  array<int, LogLevel::*>|false          $errorLevelMap     an array of E_* constant to LogLevel::* constant mapping, or false to disable error handling
+     * @param  array<class-string, LogLevel::*>|false $exceptionLevelMap an array of class name to LogLevel::* constant mapping, or false to disable exception handling
+     * @param  LogLevel::*|null|false                 $fatalLevel        a LogLevel::* constant, null to use the default LogLevel::ALERT or false to disable fatal error handling
+     * @return static
+     */
+    public static function register(LoggerInterface $logger, $errorLevelMap = [], $exceptionLevelMap = [], $fatalLevel = null): self
+    {
+        /** @phpstan-ignore-next-line */
+        $handler = new static($logger);
+        if ($errorLevelMap !== false) {
+            $handler->registerErrorHandler($errorLevelMap);
+        }
+        if ($exceptionLevelMap !== false) {
+            $handler->registerExceptionHandler($exceptionLevelMap);
+        }
+        if ($fatalLevel !== false) {
+            $handler->registerFatalHandler($fatalLevel);
+        }
+
+        return $handler;
+    }
+
+    /**
+     * @param  array<class-string, LogLevel::*> $levelMap an array of class name to LogLevel::* constant mapping
+     * @return $this
+     */
+    public function registerExceptionHandler(array $levelMap = [], bool $callPrevious = true): self
+    {
+        $prev = set_exception_handler(function (\Throwable $e): void {
+            $this->handleException($e);
+        });
+        $this->uncaughtExceptionLevelMap = $levelMap;
+        foreach ($this->defaultExceptionLevelMap() as $class => $level) {
+            if (!isset($this->uncaughtExceptionLevelMap[$class])) {
+                $this->uncaughtExceptionLevelMap[$class] = $level;
+            }
+        }
+        if ($callPrevious && null !== $prev) {
+            $this->previousExceptionHandler = $prev(...);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param  array<int, LogLevel::*> $levelMap an array of E_* constant to LogLevel::* constant mapping
+     * @return $this
+     */
+    public function registerErrorHandler(array $levelMap = [], bool $callPrevious = true, int $errorTypes = -1, bool $handleOnlyReportedErrors = true): self
+    {
+        $prev = set_error_handler($this->handleError(...), $errorTypes);
+        $this->errorLevelMap = array_replace($this->defaultErrorLevelMap(), $levelMap);
+        if ($callPrevious) {
+            $this->previousErrorHandler = $prev !== null ? $prev(...) : true;
+        } else {
+            $this->previousErrorHandler = null;
+        }
+
+        $this->handleOnlyReportedErrors = $handleOnlyReportedErrors;
+
+        return $this;
+    }
+
+    /**
+     * @param  LogLevel::*|null $level              a LogLevel::* constant, null to use the default LogLevel::ALERT
+     * @param  int              $reservedMemorySize Amount of KBs to reserve in memory so that it can be freed when handling fatal errors giving Monolog some room in memory to get its job done
+     * @return $this
+     */
+    public function registerFatalHandler($level = null, int $reservedMemorySize = 20): self
+    {
+        register_shutdown_function($this->handleFatalError(...));
+
+        $this->reservedMemory = str_repeat(' ', 1024 * $reservedMemorySize);
+        $this->fatalLevel = null === $level ? LogLevel::ALERT : $level;
+        $this->hasFatalErrorHandler = true;
+
+        return $this;
+    }
+
+    /**
+     * @return array<class-string, LogLevel::*>
+     */
+    protected function defaultExceptionLevelMap(): array
+    {
+        return [
+            'ParseError' => LogLevel::CRITICAL,
+            'Throwable' => LogLevel::ERROR,
+        ];
+    }
+
+    /**
+     * @return array<int, LogLevel::*>
+     */
+    protected function defaultErrorLevelMap(): array
+    {
+        return [
+            E_ERROR             => LogLevel::CRITICAL,
+            E_WARNING           => LogLevel::WARNING,
+            E_PARSE             => LogLevel::ALERT,
+            E_NOTICE            => LogLevel::NOTICE,
+            E_CORE_ERROR        => LogLevel::CRITICAL,
+            E_CORE_WARNING      => LogLevel::WARNING,
+            E_COMPILE_ERROR     => LogLevel::ALERT,
+            E_COMPILE_WARNING   => LogLevel::WARNING,
+            E_USER_ERROR        => LogLevel::ERROR,
+            E_USER_WARNING      => LogLevel::WARNING,
+            E_USER_NOTICE       => LogLevel::NOTICE,
+            2048                => LogLevel::NOTICE, // E_STRICT
+            E_RECOVERABLE_ERROR => LogLevel::ERROR,
+            E_DEPRECATED        => LogLevel::NOTICE,
+            E_USER_DEPRECATED   => LogLevel::NOTICE,
+        ];
+    }
+
+    private function handleException(\Throwable $e): never
+    {
+        $level = LogLevel::ERROR;
+        foreach ($this->uncaughtExceptionLevelMap as $class => $candidate) {
+            if ($e instanceof $class) {
+                $level = $candidate;
+                break;
+            }
+        }
+
+        $this->logger->log(
+            $level,
+            sprintf('Uncaught Exception %s: "%s" at %s line %s', Utils::getClass($e), $e->getMessage(), $e->getFile(), $e->getLine()),
+            ['exception' => $e]
+        );
+
+        if (null !== $this->previousExceptionHandler) {
+            ($this->previousExceptionHandler)($e);
+        }
+
+        if (!headers_sent() && \in_array(strtolower((string) \ini_get('display_errors')), ['0', '', 'false', 'off', 'none', 'no'], true)) {
+            http_response_code(500);
+        }
+
+        exit(255);
+    }
+
+    private function handleError(int $code, string $message, string $file = '', int $line = 0): bool
+    {
+        if ($this->handleOnlyReportedErrors && 0 === (error_reporting() & $code)) {
+            return false;
+        }
+
+        // fatal error codes are ignored if a fatal error handler is present as well to avoid duplicate log entries
+        if (!$this->hasFatalErrorHandler || !\in_array($code, self::FATAL_ERRORS, true)) {
+            $level = $this->errorLevelMap[$code] ?? LogLevel::CRITICAL;
+            $this->logger->log($level, self::codeToString($code).': '.$message, ['code' => $code, 'message' => $message, 'file' => $file, 'line' => $line]);
+        } else {
+            $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+            array_shift($trace); // Exclude handleError from trace
+            $this->lastFatalData = ['type' => $code, 'message' => $message, 'file' => $file, 'line' => $line, 'trace' => $trace];
+        }
+
+        if ($this->previousErrorHandler === true) {
+            return false;
+        }
+        if ($this->previousErrorHandler instanceof Closure) {
+            return (bool) ($this->previousErrorHandler)($code, $message, $file, $line);
+        }
+
+        return true;
+    }
+
+    /**
+     * @private
+     */
+    public function handleFatalError(): void
+    {
+        $this->reservedMemory = '';
+
+        if (\is_array($this->lastFatalData)) {
+            $lastError = $this->lastFatalData;
+        } else {
+            $lastError = error_get_last();
+        }
+        if (\is_array($lastError) && \in_array($lastError['type'], self::FATAL_ERRORS, true)) {
+            $trace = $lastError['trace'] ?? null;
+            $this->logger->log(
+                $this->fatalLevel,
+                'Fatal Error ('.self::codeToString($lastError['type']).'): '.$lastError['message'],
+                ['code' => $lastError['type'], 'message' => $lastError['message'], 'file' => $lastError['file'], 'line' => $lastError['line'], 'trace' => $trace]
+            );
+
+            if ($this->logger instanceof Logger) {
+                foreach ($this->logger->getHandlers() as $handler) {
+                    $handler->close();
+                }
+            }
+        }
+    }
+
+    private static function codeToString(int $code): string
+    {
+        return match ($code) {
+            E_ERROR => 'E_ERROR',
+            E_WARNING => 'E_WARNING',
+            E_PARSE => 'E_PARSE',
+            E_NOTICE => 'E_NOTICE',
+            E_CORE_ERROR => 'E_CORE_ERROR',
+            E_CORE_WARNING => 'E_CORE_WARNING',
+            E_COMPILE_ERROR => 'E_COMPILE_ERROR',
+            E_COMPILE_WARNING => 'E_COMPILE_WARNING',
+            E_USER_ERROR => 'E_USER_ERROR',
+            E_USER_WARNING => 'E_USER_WARNING',
+            E_USER_NOTICE => 'E_USER_NOTICE',
+            2048 => 'E_STRICT',
+            E_RECOVERABLE_ERROR => 'E_RECOVERABLE_ERROR',
+            E_DEPRECATED => 'E_DEPRECATED',
+            E_USER_DEPRECATED => 'E_USER_DEPRECATED',
+            default => 'Unknown PHP error',
+        };
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/ChromePHPFormatter.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/ChromePHPFormatter.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Monolog\Level;
+use Monolog\LogRecord;
+
+/**
+ * Formats a log message according to the ChromePHP array format
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class ChromePHPFormatter implements FormatterInterface
+{
+    /**
+     * Translates Monolog log levels to Wildfire levels.
+     *
+     * @return 'log'|'info'|'warn'|'error'
+     */
+    private function toWildfireLevel(Level $level): string
+    {
+        return match ($level) {
+            Level::Debug     => 'log',
+            Level::Info      => 'info',
+            Level::Notice    => 'info',
+            Level::Warning   => 'warn',
+            Level::Error     => 'error',
+            Level::Critical  => 'error',
+            Level::Alert     => 'error',
+            Level::Emergency => 'error',
+        };
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function format(LogRecord $record)
+    {
+        // Retrieve the line and file if set and remove them from the formatted extra
+        $backtrace = 'unknown';
+        if (isset($record->extra['file'], $record->extra['line'])) {
+            $backtrace = $record->extra['file'].' : '.$record->extra['line'];
+            unset($record->extra['file'], $record->extra['line']);
+        }
+
+        $message = ['message' => $record->message];
+        if (\count($record->context) > 0) {
+            $message['context'] = $record->context;
+        }
+        if (\count($record->extra) > 0) {
+            $message['extra'] = $record->extra;
+        }
+        if (\count($message) === 1) {
+            $message = reset($message);
+        }
+
+        return [
+            $record->channel,
+            $message,
+            $backtrace,
+            $this->toWildfireLevel($record->level),
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function formatBatch(array $records)
+    {
+        $formatted = [];
+
+        foreach ($records as $record) {
+            $formatted[] = $this->format($record);
+        }
+
+        return $formatted;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/ElasticaFormatter.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/ElasticaFormatter.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Elastica\Document;
+use Monolog\LogRecord;
+
+/**
+ * Format a log message into an Elastica Document
+ *
+ * @author Jelle Vink <jelle.vink@gmail.com>
+ */
+class ElasticaFormatter extends NormalizerFormatter
+{
+    /**
+     * @var string Elastic search index name
+     */
+    protected string $index;
+
+    /**
+     * @var string|null Elastic search document type
+     */
+    protected string|null $type;
+
+    /**
+     * @param string  $index Elastic Search index name
+     * @param ?string $type  Elastic Search document type, deprecated as of Elastica 7
+     */
+    public function __construct(string $index, ?string $type)
+    {
+        // elasticsearch requires a ISO 8601 format date with optional millisecond precision.
+        parent::__construct('Y-m-d\TH:i:s.uP');
+
+        $this->index = $index;
+        $this->type = $type;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function format(LogRecord $record)
+    {
+        $record = parent::format($record);
+
+        return $this->getDocument($record);
+    }
+
+    public function getIndex(): string
+    {
+        return $this->index;
+    }
+
+    /**
+     * @deprecated since Elastica 7 type has no effect
+     */
+    public function getType(): string
+    {
+        /** @phpstan-ignore-next-line */
+        return $this->type;
+    }
+
+    /**
+     * Convert a log message into an Elastica Document
+     *
+     * @param mixed[] $record
+     */
+    protected function getDocument(array $record): Document
+    {
+        $document = new Document();
+        $document->setData($record);
+        $document->setIndex($this->index);
+
+        return $document;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/ElasticsearchFormatter.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/ElasticsearchFormatter.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use DateTimeInterface;
+use Monolog\LogRecord;
+
+/**
+ * Format a log message into an Elasticsearch record
+ *
+ * @author Avtandil Kikabidze <akalongman@gmail.com>
+ */
+class ElasticsearchFormatter extends NormalizerFormatter
+{
+    /**
+     * @var string Elasticsearch index name
+     */
+    protected string $index;
+
+    /**
+     * @var string Elasticsearch record type
+     */
+    protected string $type;
+
+    /**
+     * @param string $index Elasticsearch index name
+     * @param string $type  Elasticsearch record type
+     */
+    public function __construct(string $index, string $type)
+    {
+        // Elasticsearch requires an ISO 8601 format date with optional millisecond precision.
+        parent::__construct(DateTimeInterface::ATOM);
+
+        $this->index = $index;
+        $this->type = $type;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function format(LogRecord $record)
+    {
+        $record = parent::format($record);
+
+        return $this->getDocument($record);
+    }
+
+    /**
+     * Getter index
+     */
+    public function getIndex(): string
+    {
+        return $this->index;
+    }
+
+    /**
+     * Getter type
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * Convert a log message into an Elasticsearch record
+     *
+     * @param  mixed[] $record Log message
+     * @return mixed[]
+     */
+    protected function getDocument(array $record): array
+    {
+        $record['_index'] = $this->index;
+        $record['_type'] = $this->type;
+
+        return $record;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/FlowdockFormatter.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/FlowdockFormatter.php
@@ -1,0 +1,106 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Monolog\LogRecord;
+
+/**
+ * formats the record to be used in the FlowdockHandler
+ *
+ * @author Dominik Liebler <liebler.dominik@gmail.com>
+ * @deprecated Since 2.9.0 and 3.3.0, Flowdock was shutdown we will thus drop this handler in Monolog 4
+ */
+class FlowdockFormatter implements FormatterInterface
+{
+    private string $source;
+
+    private string $sourceEmail;
+
+    public function __construct(string $source, string $sourceEmail)
+    {
+        $this->source = $source;
+        $this->sourceEmail = $sourceEmail;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @return mixed[]
+     */
+    public function format(LogRecord $record): array
+    {
+        $tags = [
+            '#logs',
+            '#' . $record->level->toPsrLogLevel(),
+            '#' . $record->channel,
+        ];
+
+        foreach ($record->extra as $value) {
+            $tags[] = '#' . $value;
+        }
+
+        $subject = sprintf(
+            'in %s: %s - %s',
+            $this->source,
+            $record->level->getName(),
+            $this->getShortMessage($record->message)
+        );
+
+        return [
+            'source' => $this->source,
+            'from_address' => $this->sourceEmail,
+            'subject' => $subject,
+            'content' => $record->message,
+            'tags' => $tags,
+            'project' => $this->source,
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @return mixed[][]
+     */
+    public function formatBatch(array $records): array
+    {
+        $formatted = [];
+
+        foreach ($records as $record) {
+            $formatted[] = $this->format($record);
+        }
+
+        return $formatted;
+    }
+
+    public function getShortMessage(string $message): string
+    {
+        static $hasMbString;
+
+        if (null === $hasMbString) {
+            $hasMbString = \function_exists('mb_strlen');
+        }
+
+        $maxLength = 45;
+
+        if ($hasMbString) {
+            if (mb_strlen($message, 'UTF-8') > $maxLength) {
+                $message = mb_substr($message, 0, $maxLength - 4, 'UTF-8') . ' ...';
+            }
+        } else {
+            if (\strlen($message) > $maxLength) {
+                $message = substr($message, 0, $maxLength - 4) . ' ...';
+            }
+        }
+
+        return $message;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/FluentdFormatter.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/FluentdFormatter.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Monolog\Utils;
+use Monolog\LogRecord;
+
+/**
+ * Class FluentdFormatter
+ *
+ * Serializes a log message to Fluentd unix socket protocol
+ *
+ * Fluentd config:
+ *
+ * <source>
+ *  type unix
+ *  path /var/run/td-agent/td-agent.sock
+ * </source>
+ *
+ * Monolog setup:
+ *
+ * $logger = new Monolog\Logger('fluent.tag');
+ * $fluentHandler = new Monolog\Handler\SocketHandler('unix:///var/run/td-agent/td-agent.sock');
+ * $fluentHandler->setFormatter(new Monolog\Formatter\FluentdFormatter());
+ * $logger->pushHandler($fluentHandler);
+ *
+ * @author Andrius Putna <fordnox@gmail.com>
+ */
+class FluentdFormatter implements FormatterInterface
+{
+    /**
+     * @var bool $levelTag should message level be a part of the fluentd tag
+     */
+    protected bool $levelTag = false;
+
+    public function __construct(bool $levelTag = false)
+    {
+        $this->levelTag = $levelTag;
+    }
+
+    public function isUsingLevelsInTag(): bool
+    {
+        return $this->levelTag;
+    }
+
+    public function format(LogRecord $record): string
+    {
+        $tag = $record->channel;
+        if ($this->levelTag) {
+            $tag .= '.' . $record->level->toPsrLogLevel();
+        }
+
+        $message = [
+            'message' => $record->message,
+            'context' => $record->context,
+            'extra' => $record->extra,
+        ];
+
+        if (!$this->levelTag) {
+            $message['level'] = $record->level->value;
+            $message['level_name'] = $record->level->getName();
+        }
+
+        return Utils::jsonEncode([$tag, $record->datetime->getTimestamp(), $message]);
+    }
+
+    public function formatBatch(array $records): string
+    {
+        $message = '';
+        foreach ($records as $record) {
+            $message .= $this->format($record);
+        }
+
+        return $message;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/FormatterInterface.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/FormatterInterface.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Monolog\LogRecord;
+
+/**
+ * Interface for formatters
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+interface FormatterInterface
+{
+    /**
+     * Formats a log record.
+     *
+     * @param  LogRecord $record A record to format
+     * @return mixed     The formatted record
+     */
+    public function format(LogRecord $record);
+
+    /**
+     * Formats a set of log records.
+     *
+     * @param  array<LogRecord> $records A set of records to format
+     * @return mixed            The formatted set of records
+     */
+    public function formatBatch(array $records);
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/GelfMessageFormatter.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/GelfMessageFormatter.php
@@ -1,0 +1,152 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Monolog\Level;
+use Gelf\Message;
+use Monolog\Utils;
+use Monolog\LogRecord;
+
+/**
+ * Serializes a log message to GELF
+ * @see http://docs.graylog.org/en/latest/pages/gelf.html
+ *
+ * @author Matt Lehner <mlehner@gmail.com>
+ */
+class GelfMessageFormatter extends NormalizerFormatter
+{
+    protected const DEFAULT_MAX_LENGTH = 32766;
+
+    /**
+     * @var string the name of the system for the Gelf log message
+     */
+    protected string $systemName;
+
+    /**
+     * @var string a prefix for 'extra' fields from the Monolog record (optional)
+     */
+    protected string $extraPrefix;
+
+    /**
+     * @var string a prefix for 'context' fields from the Monolog record (optional)
+     */
+    protected string $contextPrefix;
+
+    /**
+     * @var int max length per field
+     */
+    protected int $maxLength;
+
+    /**
+     * Translates Monolog log levels to Graylog2 log priorities.
+     */
+    private function getGraylog2Priority(Level $level): int
+    {
+        return match ($level) {
+            Level::Debug     => 7,
+            Level::Info      => 6,
+            Level::Notice    => 5,
+            Level::Warning   => 4,
+            Level::Error     => 3,
+            Level::Critical  => 2,
+            Level::Alert     => 1,
+            Level::Emergency => 0,
+        };
+    }
+
+    /**
+     * @throws \RuntimeException
+     */
+    public function __construct(?string $systemName = null, ?string $extraPrefix = null, string $contextPrefix = 'ctxt_', ?int $maxLength = null)
+    {
+        if (!class_exists(Message::class)) {
+            throw new \RuntimeException('Composer package graylog2/gelf-php is required to use Monolog\'s GelfMessageFormatter');
+        }
+
+        parent::__construct('U.u');
+
+        $this->systemName = (null === $systemName || $systemName === '') ? (string) gethostname() : $systemName;
+
+        $this->extraPrefix = null === $extraPrefix ? '' : $extraPrefix;
+        $this->contextPrefix = $contextPrefix;
+        $this->maxLength = null === $maxLength ? self::DEFAULT_MAX_LENGTH : $maxLength;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function format(LogRecord $record): Message
+    {
+        $context = $extra = [];
+        if (isset($record->context)) {
+            /** @var array<array<mixed>|bool|float|int|string|null> $context */
+            $context = parent::normalize($record->context);
+        }
+        if (isset($record->extra)) {
+            /** @var array<array<mixed>|bool|float|int|string|null> $extra */
+            $extra = parent::normalize($record->extra);
+        }
+
+        $message = new Message();
+        $message
+            ->setTimestamp($record->datetime)
+            ->setShortMessage($record->message)
+            ->setHost($this->systemName)
+            ->setLevel($this->getGraylog2Priority($record->level));
+
+        // message length + system name length + 200 for padding / metadata
+        $len = 200 + \strlen($record->message) + \strlen($this->systemName);
+
+        if ($len > $this->maxLength) {
+            $message->setShortMessage(Utils::substr($record->message, 0, $this->maxLength));
+        }
+
+        if (isset($record->channel)) {
+            $message->setAdditional('facility', $record->channel);
+        }
+
+        foreach ($extra as $key => $val) {
+            $key = (string) preg_replace('#[^\w.-]#', '-', (string) $key);
+            $val = \is_bool($val) ? ($val ? 1 : 0) : $val;
+            $val = \is_scalar($val) || null === $val ? $val : $this->toJson($val);
+            $len = \strlen($this->extraPrefix . $key . $val);
+            if ($len > $this->maxLength) {
+                $message->setAdditional($this->extraPrefix . $key, Utils::substr((string) $val, 0, $this->maxLength));
+
+                continue;
+            }
+            $message->setAdditional($this->extraPrefix . $key, $val);
+        }
+
+        foreach ($context as $key => $val) {
+            $key = (string) preg_replace('#[^\w.-]#', '-', (string) $key);
+            $val = \is_bool($val) ? ($val ? 1 : 0) : $val;
+            $val = \is_scalar($val) || null === $val ? $val : $this->toJson($val);
+            $len = \strlen($this->contextPrefix . $key . $val);
+            if ($len > $this->maxLength) {
+                $message->setAdditional($this->contextPrefix . $key, Utils::substr((string) $val, 0, $this->maxLength));
+
+                continue;
+            }
+            $message->setAdditional($this->contextPrefix . $key, $val);
+        }
+
+        if (!$message->hasAdditional('file') && isset($context['exception']['file'])) {
+            if (1 === preg_match("/^(.+):([0-9]+)$/", $context['exception']['file'], $matches)) {
+                $message->setAdditional('file', $matches[1]);
+                $message->setAdditional('line', $matches[2]);
+            }
+        }
+
+        return $message;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/GoogleCloudLoggingFormatter.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/GoogleCloudLoggingFormatter.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use DateTimeInterface;
+use Monolog\LogRecord;
+
+/**
+ * Encodes message information into JSON in a format compatible with Cloud logging.
+ *
+ * @see https://cloud.google.com/logging/docs/structured-logging
+ * @see https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
+ *
+ * @author Luís Cobucci <lcobucci@gmail.com>
+ */
+class GoogleCloudLoggingFormatter extends JsonFormatter
+{
+    protected function normalizeRecord(LogRecord $record): array
+    {
+        $normalized = parent::normalizeRecord($record);
+
+        // Re-key level for GCP logging
+        $normalized['severity'] = $normalized['level_name'];
+        $normalized['time'] = $record->datetime->format(DateTimeInterface::RFC3339_EXTENDED);
+
+        // Remove keys that are not used by GCP
+        unset($normalized['level'], $normalized['level_name'], $normalized['datetime']);
+
+        return $normalized;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/HtmlFormatter.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/HtmlFormatter.php
@@ -1,0 +1,142 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Monolog\Level;
+use Monolog\Utils;
+use Monolog\LogRecord;
+
+/**
+ * Formats incoming records into an HTML table
+ *
+ * This is especially useful for html email logging
+ *
+ * @author Tiago Brito <tlfbrito@gmail.com>
+ */
+class HtmlFormatter extends NormalizerFormatter
+{
+    /**
+     * Translates Monolog log levels to html color priorities.
+     */
+    protected function getLevelColor(Level $level): string
+    {
+        return match ($level) {
+            Level::Debug     => '#CCCCCC',
+            Level::Info      => '#28A745',
+            Level::Notice    => '#17A2B8',
+            Level::Warning   => '#FFC107',
+            Level::Error     => '#FD7E14',
+            Level::Critical  => '#DC3545',
+            Level::Alert     => '#821722',
+            Level::Emergency => '#000000',
+        };
+    }
+
+    /**
+     * @param string|null $dateFormat The format of the timestamp: one supported by DateTime::format
+     */
+    public function __construct(?string $dateFormat = null)
+    {
+        parent::__construct($dateFormat);
+    }
+
+    /**
+     * Creates an HTML table row
+     *
+     * @param string $th       Row header content
+     * @param string $td       Row standard cell content
+     * @param bool   $escapeTd false if td content must not be html escaped
+     */
+    protected function addRow(string $th, string $td = ' ', bool $escapeTd = true): string
+    {
+        $th = htmlspecialchars($th, ENT_NOQUOTES, 'UTF-8');
+        if ($escapeTd) {
+            $td = '<pre>'.htmlspecialchars($td, ENT_NOQUOTES, 'UTF-8').'</pre>';
+        }
+
+        return "<tr style=\"padding: 4px;text-align: left;\">\n<th style=\"vertical-align: top;background: #ccc;color: #000\" width=\"100\">$th:</th>\n<td style=\"padding: 4px;text-align: left;vertical-align: top;background: #eee;color: #000\">".$td."</td>\n</tr>";
+    }
+
+    /**
+     * Create a HTML h1 tag
+     *
+     * @param string $title Text to be in the h1
+     */
+    protected function addTitle(string $title, Level $level): string
+    {
+        $title = htmlspecialchars($title, ENT_NOQUOTES, 'UTF-8');
+
+        return '<h1 style="background: '.$this->getLevelColor($level).';color: #ffffff;padding: 5px;" class="monolog-output">'.$title.'</h1>';
+    }
+
+    /**
+     * Formats a log record.
+     *
+     * @return string The formatted record
+     */
+    public function format(LogRecord $record): string
+    {
+        $output = $this->addTitle($record->level->getName(), $record->level);
+        $output .= '<table cellspacing="1" width="100%" class="monolog-output">';
+
+        $output .= $this->addRow('Message', $record->message);
+        $output .= $this->addRow('Time', $this->formatDate($record->datetime));
+        $output .= $this->addRow('Channel', $record->channel);
+        if (\count($record->context) > 0) {
+            $embeddedTable = '<table cellspacing="1" width="100%">';
+            foreach ($record->context as $key => $value) {
+                $embeddedTable .= $this->addRow((string) $key, $this->convertToString($value));
+            }
+            $embeddedTable .= '</table>';
+            $output .= $this->addRow('Context', $embeddedTable, false);
+        }
+        if (\count($record->extra) > 0) {
+            $embeddedTable = '<table cellspacing="1" width="100%">';
+            foreach ($record->extra as $key => $value) {
+                $embeddedTable .= $this->addRow((string) $key, $this->convertToString($value));
+            }
+            $embeddedTable .= '</table>';
+            $output .= $this->addRow('Extra', $embeddedTable, false);
+        }
+
+        return $output.'</table>';
+    }
+
+    /**
+     * Formats a set of log records.
+     *
+     * @return string The formatted set of records
+     */
+    public function formatBatch(array $records): string
+    {
+        $message = '';
+        foreach ($records as $record) {
+            $message .= $this->format($record);
+        }
+
+        return $message;
+    }
+
+    /**
+     * @param mixed $data
+     */
+    protected function convertToString($data): string
+    {
+        if (null === $data || \is_scalar($data)) {
+            return (string) $data;
+        }
+
+        $data = $this->normalize($data);
+
+        return Utils::jsonEncode($data, JSON_PRETTY_PRINT | Utils::DEFAULT_JSON_FLAGS, true);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/JsonFormatter.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/JsonFormatter.php
@@ -1,0 +1,234 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Stringable;
+use Throwable;
+use Monolog\LogRecord;
+
+/**
+ * Encodes whatever record data is passed to it as json
+ *
+ * This can be useful to log to databases or remote APIs
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class JsonFormatter extends NormalizerFormatter
+{
+    public const BATCH_MODE_JSON = 1;
+    public const BATCH_MODE_NEWLINES = 2;
+
+    /** @var self::BATCH_MODE_* */
+    protected int $batchMode;
+
+    protected bool $appendNewline;
+
+    protected bool $ignoreEmptyContextAndExtra;
+
+    protected bool $includeStacktraces = false;
+
+    /**
+     * @param self::BATCH_MODE_* $batchMode
+     */
+    public function __construct(int $batchMode = self::BATCH_MODE_JSON, bool $appendNewline = true, bool $ignoreEmptyContextAndExtra = false, bool $includeStacktraces = false)
+    {
+        $this->batchMode = $batchMode;
+        $this->appendNewline = $appendNewline;
+        $this->ignoreEmptyContextAndExtra = $ignoreEmptyContextAndExtra;
+        $this->includeStacktraces = $includeStacktraces;
+
+        parent::__construct();
+    }
+
+    /**
+     * The batch mode option configures the formatting style for
+     * multiple records. By default, multiple records will be
+     * formatted as a JSON-encoded array. However, for
+     * compatibility with some API endpoints, alternative styles
+     * are available.
+     */
+    public function getBatchMode(): int
+    {
+        return $this->batchMode;
+    }
+
+    /**
+     * True if newlines are appended to every formatted record
+     */
+    public function isAppendingNewlines(): bool
+    {
+        return $this->appendNewline;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function format(LogRecord $record): string
+    {
+        $normalized = $this->normalizeRecord($record);
+
+        return $this->toJson($normalized, true) . ($this->appendNewline ? "\n" : '');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function formatBatch(array $records): string
+    {
+        return match ($this->batchMode) {
+            static::BATCH_MODE_NEWLINES => $this->formatBatchNewlines($records),
+            default => $this->formatBatchJson($records),
+        };
+    }
+
+    /**
+     * @return $this
+     */
+    public function includeStacktraces(bool $include = true): self
+    {
+        $this->includeStacktraces = $include;
+
+        return $this;
+    }
+
+    /**
+     * @return array<array<mixed>|bool|float|int|\stdClass|string|null>
+     */
+    protected function normalizeRecord(LogRecord $record): array
+    {
+        $normalized = parent::normalizeRecord($record);
+
+        if (isset($normalized['context']) && $normalized['context'] === []) {
+            if ($this->ignoreEmptyContextAndExtra) {
+                unset($normalized['context']);
+            } else {
+                $normalized['context'] = new \stdClass;
+            }
+        }
+        if (isset($normalized['extra']) && $normalized['extra'] === []) {
+            if ($this->ignoreEmptyContextAndExtra) {
+                unset($normalized['extra']);
+            } else {
+                $normalized['extra'] = new \stdClass;
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Return a JSON-encoded array of records.
+     *
+     * @phpstan-param LogRecord[] $records
+     */
+    protected function formatBatchJson(array $records): string
+    {
+        $formatted = array_map(fn (LogRecord $record) => $this->normalizeRecord($record), $records);
+
+        return $this->toJson($formatted, true);
+    }
+
+    /**
+     * Use new lines to separate records instead of a
+     * JSON-encoded array.
+     *
+     * @phpstan-param LogRecord[] $records
+     */
+    protected function formatBatchNewlines(array $records): string
+    {
+        $oldNewline = $this->appendNewline;
+        $this->appendNewline = false;
+        $formatted = array_map(fn (LogRecord $record) => $this->format($record), $records);
+        $this->appendNewline = $oldNewline;
+
+        return implode("\n", $formatted);
+    }
+
+    /**
+     * Normalizes given $data.
+     *
+     * @return null|scalar|array<mixed[]|scalar|null|object>|object
+     */
+    protected function normalize(mixed $data, int $depth = 0): mixed
+    {
+        if ($depth > $this->maxNormalizeDepth) {
+            return 'Over '.$this->maxNormalizeDepth.' levels deep, aborting normalization';
+        }
+
+        if (\is_array($data)) {
+            $normalized = [];
+
+            $count = 1;
+            foreach ($data as $key => $value) {
+                if ($count++ > $this->maxNormalizeItemCount) {
+                    $normalized['...'] = 'Over '.$this->maxNormalizeItemCount.' items ('.\count($data).' total), aborting normalization';
+                    break;
+                }
+
+                $normalized[$key] = $this->normalize($value, $depth + 1);
+            }
+
+            return $normalized;
+        }
+
+        if (\is_object($data)) {
+            if ($data instanceof \DateTimeInterface) {
+                return $this->formatDate($data);
+            }
+
+            if ($data instanceof Throwable) {
+                return $this->normalizeException($data, $depth);
+            }
+
+            // if the object has specific json serializability we want to make sure we skip the __toString treatment below
+            if ($data instanceof \JsonSerializable) {
+                return $data;
+            }
+
+            if ($data instanceof Stringable) {
+                try {
+                    return $data->__toString();
+                } catch (Throwable) {
+                    return $data::class;
+                }
+            }
+
+            if (\get_class($data) === '__PHP_Incomplete_Class') {
+                return new \ArrayObject($data);
+            }
+
+            return $data;
+        }
+
+        if (\is_resource($data)) {
+            return parent::normalize($data);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Normalizes given exception with or without its own stack trace based on
+     * `includeStacktraces` property.
+     *
+     * @return array<array-key, string|int|array<string|int|array<string>>>
+     */
+    protected function normalizeException(Throwable $e, int $depth = 0): array
+    {
+        $data = parent::normalizeException($e, $depth);
+        if (!$this->includeStacktraces) {
+            unset($data['trace']);
+        }
+
+        return $data;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/LineFormatter.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/LineFormatter.php
@@ -1,0 +1,317 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Closure;
+use Monolog\Utils;
+use Monolog\LogRecord;
+
+/**
+ * Formats incoming records into a one-line string
+ *
+ * This is especially useful for logging to files
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class LineFormatter extends NormalizerFormatter
+{
+    public const SIMPLE_FORMAT = "[%datetime%] %channel%.%level_name%: %message% %context% %extra%\n";
+
+    protected string $format;
+    protected bool $allowInlineLineBreaks;
+    protected bool $ignoreEmptyContextAndExtra;
+    protected bool $includeStacktraces;
+    protected ?int $maxLevelNameLength = null;
+    protected string $indentStacktraces = '';
+    protected Closure|null $stacktracesParser = null;
+    protected string $basePath = '';
+
+    /**
+     * @param string|null $format                The format of the message
+     * @param string|null $dateFormat            The format of the timestamp: one supported by DateTime::format
+     * @param bool        $allowInlineLineBreaks Whether to allow inline line breaks in log entries
+     */
+    public function __construct(?string $format = null, ?string $dateFormat = null, bool $allowInlineLineBreaks = false, bool $ignoreEmptyContextAndExtra = false, bool $includeStacktraces = false)
+    {
+        $this->format = $format === null ? static::SIMPLE_FORMAT : $format;
+        $this->allowInlineLineBreaks = $allowInlineLineBreaks;
+        $this->ignoreEmptyContextAndExtra = $ignoreEmptyContextAndExtra;
+        $this->includeStacktraces($includeStacktraces);
+        parent::__construct($dateFormat);
+    }
+
+    /**
+     * Setting a base path will hide the base path from exception and stack trace file names to shorten them
+     * @return $this
+     */
+    public function setBasePath(string $path = ''): self
+    {
+        if ($path !== '') {
+            $path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        }
+
+        $this->basePath = $path;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function includeStacktraces(bool $include = true, ?Closure $parser = null): self
+    {
+        $this->includeStacktraces = $include;
+        if ($this->includeStacktraces) {
+            $this->allowInlineLineBreaks = true;
+            $this->stacktracesParser = $parser;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Indent stack traces to separate them a bit from the main log record messages
+     *
+     * @param  string $indent The string used to indent, for example "    "
+     * @return $this
+     */
+    public function indentStacktraces(string $indent): self
+    {
+        $this->indentStacktraces = $indent;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function allowInlineLineBreaks(bool $allow = true): self
+    {
+        $this->allowInlineLineBreaks = $allow;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function ignoreEmptyContextAndExtra(bool $ignore = true): self
+    {
+        $this->ignoreEmptyContextAndExtra = $ignore;
+
+        return $this;
+    }
+
+    /**
+     * Allows cutting the level name to get fixed-length levels like INF for INFO, ERR for ERROR if you set this to 3 for example
+     *
+     * @param  int|null $maxLevelNameLength Maximum characters for the level name. Set null for infinite length (default)
+     * @return $this
+     */
+    public function setMaxLevelNameLength(?int $maxLevelNameLength = null): self
+    {
+        $this->maxLevelNameLength = $maxLevelNameLength;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function format(LogRecord $record): string
+    {
+        $vars = parent::format($record);
+
+        if ($this->maxLevelNameLength !== null) {
+            $vars['level_name'] = substr($vars['level_name'], 0, $this->maxLevelNameLength);
+        }
+
+        $output = $this->format;
+        foreach ($vars['extra'] as $var => $val) {
+            if (false !== strpos($output, '%extra.'.$var.'%')) {
+                $output = str_replace('%extra.'.$var.'%', $this->stringify($val), $output);
+                unset($vars['extra'][$var]);
+            }
+        }
+
+        foreach ($vars['context'] as $var => $val) {
+            if (false !== strpos($output, '%context.'.$var.'%')) {
+                $output = str_replace('%context.'.$var.'%', $this->stringify($val), $output);
+                unset($vars['context'][$var]);
+            }
+        }
+
+        if ($this->ignoreEmptyContextAndExtra) {
+            if (\count($vars['context']) === 0) {
+                unset($vars['context']);
+                $output = str_replace('%context%', '', $output);
+            }
+
+            if (\count($vars['extra']) === 0) {
+                unset($vars['extra']);
+                $output = str_replace('%extra%', '', $output);
+            }
+        }
+
+        foreach ($vars as $var => $val) {
+            if (false !== strpos($output, '%'.$var.'%')) {
+                $output = str_replace('%'.$var.'%', $this->stringify($val), $output);
+            }
+        }
+
+        // remove leftover %extra.xxx% and %context.xxx% if any
+        if (false !== strpos($output, '%')) {
+            $output = preg_replace('/%(?:extra|context)\..+?%/', '', $output);
+            if (null === $output) {
+                $pcreErrorCode = preg_last_error();
+
+                throw new \RuntimeException('Failed to run preg_replace: ' . $pcreErrorCode . ' / ' . preg_last_error_msg());
+            }
+        }
+
+        return $output;
+    }
+
+    public function formatBatch(array $records): string
+    {
+        $message = '';
+        foreach ($records as $record) {
+            $message .= $this->format($record);
+        }
+
+        return $message;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function stringify($value): string
+    {
+        return $this->replaceNewlines($this->convertToString($value));
+    }
+
+    protected function normalizeException(\Throwable $e, int $depth = 0): string
+    {
+        $str = $this->formatException($e);
+
+        $previous = $e->getPrevious();
+        while ($previous instanceof \Throwable) {
+            $depth++;
+            if ($depth > $this->maxNormalizeDepth) {
+                $str .= "\n[previous exception] Over " . $this->maxNormalizeDepth . ' levels deep, aborting normalization';
+                break;
+            }
+            $str .= "\n[previous exception] " . $this->formatException($previous);
+            $previous = $previous->getPrevious();
+        }
+
+        return $str;
+    }
+
+    /**
+     * @param mixed $data
+     */
+    protected function convertToString($data): string
+    {
+        if (null === $data || \is_bool($data)) {
+            return var_export($data, true);
+        }
+
+        if (\is_scalar($data)) {
+            return (string) $data;
+        }
+
+        return $this->toJson($data, true);
+    }
+
+    protected function replaceNewlines(string $str): string
+    {
+        if ($this->allowInlineLineBreaks) {
+            if (0 === strpos($str, '{') || 0 === strpos($str, '[')) {
+                $str = preg_replace('/(?<!\\\\)\\\\[rn]/', "\n", $str);
+                if (null === $str) {
+                    $pcreErrorCode = preg_last_error();
+
+                    throw new \RuntimeException('Failed to run preg_replace: ' . $pcreErrorCode . ' / ' . preg_last_error_msg());
+                }
+            }
+
+            return $str;
+        }
+
+        return str_replace(["\r\n", "\r", "\n"], ' ', $str);
+    }
+
+    private function formatException(\Throwable $e): string
+    {
+        $str = '[object] (' . Utils::getClass($e) . '(code: ' . $e->getCode();
+        if ($e instanceof \SoapFault) {
+            if (isset($e->faultcode)) {
+                $str .= ' faultcode: ' . $e->faultcode;
+            }
+
+            if (isset($e->faultactor)) {
+                $str .= ' faultactor: ' . $e->faultactor;
+            }
+
+            if (isset($e->detail)) {
+                if (\is_string($e->detail)) {
+                    $str .= ' detail: ' . $e->detail;
+                } elseif (\is_object($e->detail) || \is_array($e->detail)) {
+                    $str .= ' detail: ' . $this->toJson($e->detail, true);
+                }
+            }
+        }
+
+        $file = $e->getFile();
+        if ($this->basePath !== '') {
+            $file = preg_replace('{^'.preg_quote($this->basePath).'}', '', $file);
+        }
+
+        $str .= '): ' . $e->getMessage() . ' at ' . strtr((string) $file, DIRECTORY_SEPARATOR, '/') . ':' . $e->getLine() . ')';
+
+        if ($this->includeStacktraces) {
+            $str .= $this->stacktracesParser($e);
+        }
+
+        return $str;
+    }
+
+    private function stacktracesParser(\Throwable $e): string
+    {
+        $trace = $e->getTraceAsString();
+
+        if ($this->basePath !== '') {
+            $trace = preg_replace('{^(#\d+ )' . preg_quote($this->basePath) . '}m', '$1', $trace) ?? $trace;
+        }
+
+        if ($this->stacktracesParser !== null) {
+            $trace = $this->stacktracesParserCustom($trace);
+        }
+
+        if ($this->indentStacktraces !== '') {
+            $trace = str_replace("\n", "\n{$this->indentStacktraces}", $trace);
+        }
+
+        if (trim($trace) === '') {
+            return '';
+        }
+
+        return "\n{$this->indentStacktraces}[stacktrace]\n{$this->indentStacktraces}" . strtr($trace, DIRECTORY_SEPARATOR, '/') . "\n";
+    }
+
+    private function stacktracesParserCustom(string $trace): string
+    {
+        return implode("\n", array_filter(array_map($this->stacktracesParser, explode("\n", $trace)), fn ($line) => is_string($line) && trim($line) !== ''));
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/LogglyFormatter.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/LogglyFormatter.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Monolog\LogRecord;
+
+/**
+ * Encodes message information into JSON in a format compatible with Loggly.
+ *
+ * @author Adam Pancutt <adam@pancutt.com>
+ */
+class LogglyFormatter extends JsonFormatter
+{
+    /**
+     * Overrides the default batch mode to new lines for compatibility with the
+     * Loggly bulk API.
+     */
+    public function __construct(int $batchMode = self::BATCH_MODE_NEWLINES, bool $appendNewline = false)
+    {
+        parent::__construct($batchMode, $appendNewline);
+    }
+
+    /**
+     * Appends the 'timestamp' parameter for indexing by Loggly.
+     *
+     * @see https://www.loggly.com/docs/automated-parsing/#json
+     * @see \Monolog\Formatter\JsonFormatter::format()
+     */
+    protected function normalizeRecord(LogRecord $record): array
+    {
+        $recordData = parent::normalizeRecord($record);
+
+        $recordData["timestamp"] = $record->datetime->format("Y-m-d\TH:i:s.uO");
+        unset($recordData["datetime"]);
+
+        return $recordData;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/LogmaticFormatter.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/LogmaticFormatter.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Monolog\LogRecord;
+
+/**
+ * Encodes message information into JSON in a format compatible with Logmatic.
+ *
+ * @author Julien Breux <julien.breux@gmail.com>
+ */
+class LogmaticFormatter extends JsonFormatter
+{
+    protected const MARKERS = ["sourcecode", "php"];
+
+    protected string $hostname = '';
+
+    protected string $appName = '';
+
+    /**
+     * @return $this
+     */
+    public function setHostname(string $hostname): self
+    {
+        $this->hostname = $hostname;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setAppName(string $appName): self
+    {
+        $this->appName = $appName;
+
+        return $this;
+    }
+
+    /**
+     * Appends the 'hostname' and 'appname' parameter for indexing by Logmatic.
+     *
+     * @see http://doc.logmatic.io/docs/basics-to-send-data
+     * @see \Monolog\Formatter\JsonFormatter::format()
+     */
+    public function normalizeRecord(LogRecord $record): array
+    {
+        $record = parent::normalizeRecord($record);
+
+        if ($this->hostname !== '') {
+            $record["hostname"] = $this->hostname;
+        }
+        if ($this->appName !== '') {
+            $record["appname"] = $this->appName;
+        }
+
+        $record["@marker"] = static::MARKERS;
+
+        return $record;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/LogstashFormatter.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/LogstashFormatter.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Monolog\LogRecord;
+
+/**
+ * Serializes a log message to Logstash Event Format
+ *
+ * @see https://www.elastic.co/products/logstash
+ * @see https://github.com/elastic/logstash/blob/master/logstash-core/src/main/java/org/logstash/Event.java
+ *
+ * @author Tim Mower <timothy.mower@gmail.com>
+ */
+class LogstashFormatter extends NormalizerFormatter
+{
+    /**
+     * @var string the name of the system for the Logstash log message, used to fill the @source field
+     */
+    protected string $systemName;
+
+    /**
+     * @var string an application name for the Logstash log message, used to fill the @type field
+     */
+    protected string $applicationName;
+
+    /**
+     * @var string the key for 'extra' fields from the Monolog record
+     */
+    protected string $extraKey;
+
+    /**
+     * @var string the key for 'context' fields from the Monolog record
+     */
+    protected string $contextKey;
+
+    /**
+     * @param string      $applicationName The application that sends the data, used as the "type" field of logstash
+     * @param string|null $systemName      The system/machine name, used as the "source" field of logstash, defaults to the hostname of the machine
+     * @param string      $extraKey        The key for extra keys inside logstash "fields", defaults to extra
+     * @param string      $contextKey      The key for context keys inside logstash "fields", defaults to context
+     */
+    public function __construct(string $applicationName, ?string $systemName = null, string $extraKey = 'extra', string $contextKey = 'context')
+    {
+        // logstash requires a ISO 8601 format date with optional millisecond precision.
+        parent::__construct('Y-m-d\TH:i:s.uP');
+
+        $this->systemName = $systemName === null ? (string) gethostname() : $systemName;
+        $this->applicationName = $applicationName;
+        $this->extraKey = $extraKey;
+        $this->contextKey = $contextKey;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function format(LogRecord $record): string
+    {
+        $recordData = parent::format($record);
+
+        $message = [
+            '@timestamp' => $recordData['datetime'],
+            '@version' => 1,
+            'host' => $this->systemName,
+        ];
+        if (isset($recordData['message'])) {
+            $message['message'] = $recordData['message'];
+        }
+        if (isset($recordData['channel'])) {
+            $message['type'] = $recordData['channel'];
+            $message['channel'] = $recordData['channel'];
+        }
+        if (isset($recordData['level_name'])) {
+            $message['level'] = $recordData['level_name'];
+        }
+        if (isset($recordData['level'])) {
+            $message['monolog_level'] = $recordData['level'];
+        }
+        if ('' !== $this->applicationName) {
+            $message['type'] = $this->applicationName;
+        }
+        if (\count($recordData['extra']) > 0) {
+            $message[$this->extraKey] = $recordData['extra'];
+        }
+        if (\count($recordData['context']) > 0) {
+            $message[$this->contextKey] = $recordData['context'];
+        }
+
+        return $this->toJson($message) . "\n";
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/MongoDBFormatter.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/MongoDBFormatter.php
@@ -1,0 +1,129 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use MongoDB\BSON\Type;
+use MongoDB\BSON\UTCDateTime;
+use Monolog\Utils;
+use Monolog\LogRecord;
+
+/**
+ * Formats a record for use with the MongoDBHandler.
+ *
+ * @author Florian Plattner <me@florianplattner.de>
+ */
+class MongoDBFormatter implements FormatterInterface
+{
+    private bool $exceptionTraceAsString;
+    private int $maxNestingLevel;
+
+    /**
+     * @param int  $maxNestingLevel        0 means infinite nesting, the $record itself is level 1, $record->context is 2
+     * @param bool $exceptionTraceAsString set to false to log exception traces as a sub documents instead of strings
+     */
+    public function __construct(int $maxNestingLevel = 3, bool $exceptionTraceAsString = true)
+    {
+        $this->maxNestingLevel = max($maxNestingLevel, 0);
+        $this->exceptionTraceAsString = $exceptionTraceAsString;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @return mixed[]
+     */
+    public function format(LogRecord $record): array
+    {
+        /** @var mixed[] $res */
+        $res = $this->formatArray($record->toArray());
+
+        return $res;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @return array<mixed[]>
+     */
+    public function formatBatch(array $records): array
+    {
+        $formatted = [];
+        foreach ($records as $key => $record) {
+            $formatted[$key] = $this->format($record);
+        }
+
+        return $formatted;
+    }
+
+    /**
+     * @param  mixed[]        $array
+     * @return mixed[]|string Array except when max nesting level is reached then a string "[...]"
+     */
+    protected function formatArray(array $array, int $nestingLevel = 0)
+    {
+        if ($this->maxNestingLevel > 0 && $nestingLevel > $this->maxNestingLevel) {
+            return '[...]';
+        }
+
+        foreach ($array as $name => $value) {
+            if ($value instanceof \DateTimeInterface) {
+                $array[$name] = $this->formatDate($value, $nestingLevel + 1);
+            } elseif ($value instanceof \Throwable) {
+                $array[$name] = $this->formatException($value, $nestingLevel + 1);
+            } elseif (\is_array($value)) {
+                $array[$name] = $this->formatArray($value, $nestingLevel + 1);
+            } elseif (\is_object($value) && !$value instanceof Type) {
+                $array[$name] = $this->formatObject($value, $nestingLevel + 1);
+            }
+        }
+
+        return $array;
+    }
+
+    /**
+     * @param  mixed          $value
+     * @return mixed[]|string
+     */
+    protected function formatObject($value, int $nestingLevel)
+    {
+        $objectVars = get_object_vars($value);
+        $objectVars['class'] = Utils::getClass($value);
+
+        return $this->formatArray($objectVars, $nestingLevel);
+    }
+
+    /**
+     * @return mixed[]|string
+     */
+    protected function formatException(\Throwable $exception, int $nestingLevel)
+    {
+        $formattedException = [
+            'class' => Utils::getClass($exception),
+            'message' => $exception->getMessage(),
+            'code' => (int) $exception->getCode(),
+            'file' => $exception->getFile() . ':' . $exception->getLine(),
+        ];
+
+        if ($this->exceptionTraceAsString === true) {
+            $formattedException['trace'] = $exception->getTraceAsString();
+        } else {
+            $formattedException['trace'] = $exception->getTrace();
+        }
+
+        return $this->formatArray($formattedException, $nestingLevel);
+    }
+
+    protected function formatDate(\DateTimeInterface $value, int $nestingLevel): UTCDateTime
+    {
+        return new UTCDateTime((int) floor(((float) $value->format('U.u')) * 1000));
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/NormalizerFormatter.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/NormalizerFormatter.php
@@ -1,0 +1,353 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Monolog\JsonSerializableDateTimeImmutable;
+use Monolog\Utils;
+use Throwable;
+use Monolog\LogRecord;
+
+/**
+ * Normalizes incoming records to remove objects/resources so it's easier to dump to various targets
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class NormalizerFormatter implements FormatterInterface
+{
+    public const SIMPLE_DATE = "Y-m-d\TH:i:sP";
+
+    protected string $dateFormat;
+    protected int $maxNormalizeDepth = 9;
+    protected int $maxNormalizeItemCount = 1000;
+
+    private int $jsonEncodeOptions = Utils::DEFAULT_JSON_FLAGS;
+
+    protected string $basePath = '';
+
+    /**
+     * @param string|null $dateFormat The format of the timestamp: one supported by DateTime::format
+     */
+    public function __construct(?string $dateFormat = null)
+    {
+        $this->dateFormat = null === $dateFormat ? static::SIMPLE_DATE : $dateFormat;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function format(LogRecord $record)
+    {
+        return $this->normalizeRecord($record);
+    }
+
+    /**
+     * Normalize an arbitrary value to a scalar|array|null
+     *
+     * @return null|scalar|array<mixed[]|scalar|null>
+     */
+    public function normalizeValue(mixed $data): mixed
+    {
+        return $this->normalize($data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function formatBatch(array $records)
+    {
+        foreach ($records as $key => $record) {
+            $records[$key] = $this->format($record);
+        }
+
+        return $records;
+    }
+
+    public function getDateFormat(): string
+    {
+        return $this->dateFormat;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setDateFormat(string $dateFormat): self
+    {
+        $this->dateFormat = $dateFormat;
+
+        return $this;
+    }
+
+    /**
+     * The maximum number of normalization levels to go through
+     */
+    public function getMaxNormalizeDepth(): int
+    {
+        return $this->maxNormalizeDepth;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setMaxNormalizeDepth(int $maxNormalizeDepth): self
+    {
+        $this->maxNormalizeDepth = $maxNormalizeDepth;
+
+        return $this;
+    }
+
+    /**
+     * The maximum number of items to normalize per level
+     */
+    public function getMaxNormalizeItemCount(): int
+    {
+        return $this->maxNormalizeItemCount;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setMaxNormalizeItemCount(int $maxNormalizeItemCount): self
+    {
+        $this->maxNormalizeItemCount = $maxNormalizeItemCount;
+
+        return $this;
+    }
+
+    /**
+     * Enables `json_encode` pretty print.
+     *
+     * @return $this
+     */
+    public function setJsonPrettyPrint(bool $enable): self
+    {
+        if ($enable) {
+            $this->jsonEncodeOptions |= JSON_PRETTY_PRINT;
+        } else {
+            $this->jsonEncodeOptions &= ~JSON_PRETTY_PRINT;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Setting a base path will hide the base path from exception and stack trace file names to shorten them
+     * @return $this
+     */
+    public function setBasePath(string $path = ''): self
+    {
+        if ($path !== '') {
+            $path = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        }
+
+        $this->basePath = $path;
+
+        return $this;
+    }
+
+    /**
+     * Provided as extension point
+     *
+     * Because normalize is called with sub-values of context data etc, normalizeRecord can be
+     * extended when data needs to be appended on the record array but not to other normalized data.
+     *
+     * @return array<mixed[]|scalar|null>
+     */
+    protected function normalizeRecord(LogRecord $record): array
+    {
+        /** @var array<mixed[]|scalar|null> $normalized */
+        $normalized = $this->normalize($record->toArray());
+
+        return $normalized;
+    }
+
+    /**
+     * @return null|scalar|array<mixed[]|scalar|null>
+     */
+    protected function normalize(mixed $data, int $depth = 0): mixed
+    {
+        if ($depth > $this->maxNormalizeDepth) {
+            return 'Over ' . $this->maxNormalizeDepth . ' levels deep, aborting normalization';
+        }
+
+        if (null === $data || \is_scalar($data)) {
+            if (\is_float($data)) {
+                if (is_infinite($data)) {
+                    return ($data > 0 ? '' : '-') . 'INF';
+                }
+                if (is_nan($data)) {
+                    return 'NaN';
+                }
+            }
+
+            return $data;
+        }
+
+        if (\is_array($data)) {
+            $normalized = [];
+
+            $count = 1;
+            foreach ($data as $key => $value) {
+                if ($count++ > $this->maxNormalizeItemCount) {
+                    $normalized['...'] = 'Over ' . $this->maxNormalizeItemCount . ' items ('.\count($data).' total), aborting normalization';
+                    break;
+                }
+
+                $normalized[$key] = $this->normalize($value, $depth + 1);
+            }
+
+            return $normalized;
+        }
+
+        if ($data instanceof \DateTimeInterface) {
+            return $this->formatDate($data);
+        }
+
+        if (\is_object($data)) {
+            if ($data instanceof Throwable) {
+                return $this->normalizeException($data, $depth);
+            }
+
+            if ($data instanceof \JsonSerializable) {
+                /** @var null|scalar|array<mixed[]|scalar|null> $value */
+                $value = $data->jsonSerialize();
+            } elseif (\get_class($data) === '__PHP_Incomplete_Class') {
+                $accessor = new \ArrayObject($data);
+                $value = (string) $accessor['__PHP_Incomplete_Class_Name'];
+            } elseif (method_exists($data, '__toString')) {
+                try {
+                    /** @var string $value */
+                    $value = $data->__toString();
+                } catch (\Throwable) {
+                    // if the toString method is failing, use the default behavior
+                    /** @var null|scalar|array<mixed[]|scalar|null> $value */
+                    $value = json_decode($this->toJson($data, true), true);
+                }
+            } else {
+                // the rest is normalized by json encoding and decoding it
+                /** @var null|scalar|array<mixed[]|scalar|null> $value */
+                $value = json_decode($this->toJson($data, true), true);
+            }
+
+            return [Utils::getClass($data) => $value];
+        }
+
+        if (\is_resource($data)) {
+            return sprintf('[resource(%s)]', get_resource_type($data));
+        }
+
+        return '[unknown('.\gettype($data).')]';
+    }
+
+    /**
+     * @return array<array-key, string|int|array<string|int|array<string>>>
+     */
+    protected function normalizeException(Throwable $e, int $depth = 0)
+    {
+        if ($depth > $this->maxNormalizeDepth) {
+            return ['Over ' . $this->maxNormalizeDepth . ' levels deep, aborting normalization'];
+        }
+
+        if ($e instanceof \JsonSerializable) {
+            return (array) $e->jsonSerialize();
+        }
+
+        $file = $e->getFile();
+        if ($this->basePath !== '') {
+            $file = preg_replace('{^'.preg_quote($this->basePath).'}', '', $file);
+        }
+
+        $data = [
+            'class' => Utils::getClass($e),
+            'message' => $e->getMessage(),
+            'code' => (int) $e->getCode(),
+            'file' => $file.':'.$e->getLine(),
+        ];
+
+        if ($e instanceof \SoapFault) {
+            if (isset($e->faultcode)) {
+                $data['faultcode'] = $e->faultcode;
+            }
+
+            if (isset($e->faultactor)) {
+                $data['faultactor'] = $e->faultactor;
+            }
+
+            if (isset($e->detail)) {
+                if (\is_string($e->detail)) {
+                    $data['detail'] = $e->detail;
+                } elseif (\is_object($e->detail) || \is_array($e->detail)) {
+                    $data['detail'] = $this->toJson($e->detail, true);
+                }
+            }
+        }
+
+        $trace = $e->getTrace();
+        foreach ($trace as $frame) {
+            if (isset($frame['file'], $frame['line'])) {
+                $file = $frame['file'];
+                if ($this->basePath !== '') {
+                    $file = preg_replace('{^'.preg_quote($this->basePath).'}', '', $file);
+                }
+                $data['trace'][] = $file.':'.$frame['line'];
+            }
+        }
+
+        if (($previous = $e->getPrevious()) instanceof \Throwable) {
+            $data['previous'] = $this->normalizeException($previous, $depth + 1);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Return the JSON representation of a value
+     *
+     * @param  mixed             $data
+     * @throws \RuntimeException if encoding fails and errors are not ignored
+     * @return string            if encoding fails and ignoreErrors is true 'null' is returned
+     */
+    protected function toJson($data, bool $ignoreErrors = false): string
+    {
+        return Utils::jsonEncode($data, $this->jsonEncodeOptions, $ignoreErrors);
+    }
+
+    protected function formatDate(\DateTimeInterface $date): string
+    {
+        // in case the date format isn't custom then we defer to the custom JsonSerializableDateTimeImmutable
+        // formatting logic, which will pick the right format based on whether useMicroseconds is on
+        if ($this->dateFormat === self::SIMPLE_DATE && $date instanceof JsonSerializableDateTimeImmutable) {
+            return (string) $date;
+        }
+
+        return $date->format($this->dateFormat);
+    }
+
+    /**
+     * @return $this
+     */
+    public function addJsonEncodeOption(int $option): self
+    {
+        $this->jsonEncodeOptions |= $option;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function removeJsonEncodeOption(int $option): self
+    {
+        $this->jsonEncodeOptions &= ~$option;
+
+        return $this;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/ScalarFormatter.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/ScalarFormatter.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Monolog\LogRecord;
+
+/**
+ * Formats data into an associative array of scalar (+ null) values.
+ * Objects and arrays will be JSON encoded.
+ *
+ * @author Andrew Lawson <adlawson@gmail.com>
+ */
+class ScalarFormatter extends NormalizerFormatter
+{
+    /**
+     * @inheritDoc
+     *
+     * @phpstan-return array<string, scalar|null> $record
+     */
+    public function format(LogRecord $record): array
+    {
+        $result = [];
+        foreach ($record->toArray() as $key => $value) {
+            $result[$key] = $this->toScalar($value);
+        }
+
+        return $result;
+    }
+
+    protected function toScalar(mixed $value): string|int|float|bool|null
+    {
+        $normalized = $this->normalize($value);
+
+        if (\is_array($normalized)) {
+            return $this->toJson($normalized, true);
+        }
+
+        return $normalized;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/SyslogFormatter.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/SyslogFormatter.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Monolog\Level;
+use Monolog\LogRecord;
+
+/**
+ * Serializes a log message according to RFC 5424
+ *
+ * @author Dalibor Karlović <dalibor.karlovic@sigwin.hr>
+ * @author Renat Gabdullin <renatobyj@gmail.com>
+ */
+class SyslogFormatter extends LineFormatter
+{
+    private const SYSLOG_FACILITY_USER = 1;
+    private const FORMAT = "<%extra.priority%>1 %datetime% %extra.hostname% %extra.app-name% %extra.procid% %channel% %extra.structured-data% %level_name%: %message% %context% %extra%\n";
+    private const NILVALUE = '-';
+
+    private string $hostname;
+    private int $procid;
+
+    public function __construct(private string $applicationName = self::NILVALUE)
+    {
+        parent::__construct(self::FORMAT, 'Y-m-d\TH:i:s.uP', true, true);
+        $this->hostname = (string) gethostname();
+        $this->procid = (int) getmypid();
+    }
+
+    public function format(LogRecord $record): string
+    {
+        $record->extra = $this->formatExtra($record);
+
+        return parent::format($record);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function formatExtra(LogRecord $record): array
+    {
+        $extra = $record->extra;
+        $extra['app-name'] = $this->applicationName;
+        $extra['hostname'] = $this->hostname;
+        $extra['procid'] = $this->procid;
+        $extra['priority'] = self::calculatePriority($record->level);
+        $extra['structured-data'] = self::NILVALUE;
+
+        return $extra;
+    }
+
+    private static function calculatePriority(Level $level): int
+    {
+        return (self::SYSLOG_FACILITY_USER * 8) + $level->toRFC5424Level();
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Formatter/WildfireFormatter.php
+++ b/vendor/monolog/monolog/src/Monolog/Formatter/WildfireFormatter.php
@@ -1,0 +1,137 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Formatter;
+
+use Monolog\Level;
+use Monolog\LogRecord;
+
+/**
+ * Serializes a log message according to Wildfire's header requirements
+ *
+ * @author Eric Clemmons (@ericclemmons) <eric@uxdriven.com>
+ * @author Christophe Coevoet <stof@notk.org>
+ * @author Kirill chEbba Chebunin <iam@chebba.org>
+ */
+class WildfireFormatter extends NormalizerFormatter
+{
+    /**
+     * @param string|null $dateFormat The format of the timestamp: one supported by DateTime::format
+     */
+    public function __construct(?string $dateFormat = null)
+    {
+        parent::__construct($dateFormat);
+
+        // http headers do not like non-ISO-8559-1 characters
+        $this->removeJsonEncodeOption(JSON_UNESCAPED_UNICODE);
+    }
+
+    /**
+     * Translates Monolog log levels to Wildfire levels.
+     *
+     * @return 'LOG'|'INFO'|'WARN'|'ERROR'
+     */
+    private function toWildfireLevel(Level $level): string
+    {
+        return match ($level) {
+            Level::Debug     => 'LOG',
+            Level::Info      => 'INFO',
+            Level::Notice    => 'INFO',
+            Level::Warning   => 'WARN',
+            Level::Error     => 'ERROR',
+            Level::Critical  => 'ERROR',
+            Level::Alert     => 'ERROR',
+            Level::Emergency => 'ERROR',
+        };
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function format(LogRecord $record): string
+    {
+        // Retrieve the line and file if set and remove them from the formatted extra
+        $file = $line = '';
+        if (isset($record->extra['file'])) {
+            $file = $record->extra['file'];
+            unset($record->extra['file']);
+        }
+        if (isset($record->extra['line'])) {
+            $line = $record->extra['line'];
+            unset($record->extra['line']);
+        }
+
+        $message = ['message' => $record->message];
+        $handleError = false;
+        if (\count($record->context) > 0) {
+            $message['context'] = $this->normalize($record->context);
+            $handleError = true;
+        }
+        if (\count($record->extra) > 0) {
+            $message['extra'] = $this->normalize($record->extra);
+            $handleError = true;
+        }
+        if (\count($message) === 1) {
+            $message = reset($message);
+        }
+
+        if (is_array($message) && isset($message['context']) && \is_array($message['context']) && isset($message['context']['table'])) {
+            $type  = 'TABLE';
+            $label = $record->channel .': '. $record->message;
+            $message = $message['context']['table'];
+        } else {
+            $type  = $this->toWildfireLevel($record->level);
+            $label = $record->channel;
+        }
+
+        // Create JSON object describing the appearance of the message in the console
+        $json = $this->toJson([
+            [
+                'Type'  => $type,
+                'File'  => $file,
+                'Line'  => $line,
+                'Label' => $label,
+            ],
+            $message,
+        ], $handleError);
+
+        // The message itself is a serialization of the above JSON object + it's length
+        return sprintf(
+            '%d|%s|',
+            \strlen($json),
+            $json
+        );
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @phpstan-return never
+     */
+    public function formatBatch(array $records)
+    {
+        throw new \BadMethodCallException('Batch formatting does not make sense for the WildfireFormatter');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @return null|scalar|array<mixed[]|scalar|null>|object
+     */
+    protected function normalize(mixed $data, int $depth = 0): mixed
+    {
+        if (\is_object($data) && !$data instanceof \DateTimeInterface) {
+            return $data;
+        }
+
+        return parent::normalize($data, $depth);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/AbstractHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/AbstractHandler.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\Logger;
+use Monolog\ResettableInterface;
+use Psr\Log\LogLevel;
+use Monolog\LogRecord;
+
+/**
+ * Base Handler class providing basic level/bubble support
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+abstract class AbstractHandler extends Handler implements ResettableInterface
+{
+    protected Level $level = Level::Debug;
+    protected bool $bubble = true;
+
+    /**
+     * @param int|string|Level|LogLevel::* $level  The minimum logging level at which this handler will be triggered
+     * @param bool                         $bubble Whether the messages that are handled can bubble up the stack or not
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $level
+     */
+    public function __construct(int|string|Level $level = Level::Debug, bool $bubble = true)
+    {
+        $this->setLevel($level);
+        $this->bubble = $bubble;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isHandling(LogRecord $record): bool
+    {
+        return $record->level->value >= $this->level->value;
+    }
+
+    /**
+     * Sets minimum logging level at which this handler will be triggered.
+     *
+     * @param  Level|LogLevel::* $level Level or level name
+     * @return $this
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $level
+     */
+    public function setLevel(int|string|Level $level): self
+    {
+        $this->level = Logger::toMonologLevel($level);
+
+        return $this;
+    }
+
+    /**
+     * Gets minimum logging level at which this handler will be triggered.
+     */
+    public function getLevel(): Level
+    {
+        return $this->level;
+    }
+
+    /**
+     * Sets the bubbling behavior.
+     *
+     * @param  bool  $bubble true means that this handler allows bubbling.
+     *                       false means that bubbling is not permitted.
+     * @return $this
+     */
+    public function setBubble(bool $bubble): self
+    {
+        $this->bubble = $bubble;
+
+        return $this;
+    }
+
+    /**
+     * Gets the bubbling behavior.
+     *
+     * @return bool true means that this handler allows bubbling.
+     *              false means that bubbling is not permitted.
+     */
+    public function getBubble(): bool
+    {
+        return $this->bubble;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function reset(): void
+    {
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/AbstractProcessingHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/AbstractProcessingHandler.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\LogRecord;
+
+/**
+ * Base Handler class providing the Handler structure, including processors and formatters
+ *
+ * Classes extending it should (in most cases) only implement write($record)
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+abstract class AbstractProcessingHandler extends AbstractHandler implements ProcessableHandlerInterface, FormattableHandlerInterface
+{
+    use ProcessableHandlerTrait;
+    use FormattableHandlerTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function handle(LogRecord $record): bool
+    {
+        if (!$this->isHandling($record)) {
+            return false;
+        }
+
+        if (\count($this->processors) > 0) {
+            $record = $this->processRecord($record);
+        }
+
+        $record->formatted = $this->getFormatter()->format($record);
+
+        $this->write($record);
+
+        return false === $this->bubble;
+    }
+
+    /**
+     * Writes the (already formatted) record down to the log of the implementing handler
+     */
+    abstract protected function write(LogRecord $record): void;
+
+    public function reset(): void
+    {
+        parent::reset();
+
+        $this->resetProcessors();
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/AbstractSyslogHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/AbstractSyslogHandler.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\LineFormatter;
+
+/**
+ * Common syslog functionality
+ */
+abstract class AbstractSyslogHandler extends AbstractProcessingHandler
+{
+    protected int $facility;
+
+    /**
+     * List of valid log facility names.
+     * @var array<string, int>
+     */
+    protected array $facilities = [
+        'auth'     => \LOG_AUTH,
+        'authpriv' => \LOG_AUTHPRIV,
+        'cron'     => \LOG_CRON,
+        'daemon'   => \LOG_DAEMON,
+        'kern'     => \LOG_KERN,
+        'lpr'      => \LOG_LPR,
+        'mail'     => \LOG_MAIL,
+        'news'     => \LOG_NEWS,
+        'syslog'   => \LOG_SYSLOG,
+        'user'     => \LOG_USER,
+        'uucp'     => \LOG_UUCP,
+    ];
+
+    /**
+     * Translates Monolog log levels to syslog log priorities.
+     */
+    protected function toSyslogPriority(Level $level): int
+    {
+        return $level->toRFC5424Level();
+    }
+
+    /**
+     * @param string|int $facility Either one of the names of the keys in $this->facilities, or a LOG_* facility constant
+     */
+    public function __construct(string|int $facility = \LOG_USER, int|string|Level $level = Level::Debug, bool $bubble = true)
+    {
+        parent::__construct($level, $bubble);
+
+        if (!\defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->facilities['local0'] = \LOG_LOCAL0;
+            $this->facilities['local1'] = \LOG_LOCAL1;
+            $this->facilities['local2'] = \LOG_LOCAL2;
+            $this->facilities['local3'] = \LOG_LOCAL3;
+            $this->facilities['local4'] = \LOG_LOCAL4;
+            $this->facilities['local5'] = \LOG_LOCAL5;
+            $this->facilities['local6'] = \LOG_LOCAL6;
+            $this->facilities['local7'] = \LOG_LOCAL7;
+        } else {
+            $this->facilities['local0'] = 128; // LOG_LOCAL0
+            $this->facilities['local1'] = 136; // LOG_LOCAL1
+            $this->facilities['local2'] = 144; // LOG_LOCAL2
+            $this->facilities['local3'] = 152; // LOG_LOCAL3
+            $this->facilities['local4'] = 160; // LOG_LOCAL4
+            $this->facilities['local5'] = 168; // LOG_LOCAL5
+            $this->facilities['local6'] = 176; // LOG_LOCAL6
+            $this->facilities['local7'] = 184; // LOG_LOCAL7
+        }
+
+        // convert textual description of facility to syslog constant
+        if (\is_string($facility) && \array_key_exists(strtolower($facility), $this->facilities)) {
+            $facility = $this->facilities[strtolower($facility)];
+        } elseif (!\in_array($facility, array_values($this->facilities), true)) {
+            throw new \UnexpectedValueException('Unknown facility value "'.$facility.'" given');
+        }
+
+        $this->facility = $facility;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new LineFormatter('%channel%.%level_name%: %message% %context% %extra%');
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/AmqpHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/AmqpHandler.php
@@ -1,0 +1,170 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Gelf\Message as GelfMessage;
+use Monolog\Level;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\JsonFormatter;
+use PhpAmqpLib\Message\AMQPMessage;
+use PhpAmqpLib\Channel\AMQPChannel;
+use AMQPExchange;
+use Monolog\LogRecord;
+
+class AmqpHandler extends AbstractProcessingHandler
+{
+    protected AMQPExchange|AMQPChannel $exchange;
+
+    /** @var array<string, mixed> */
+    private array $extraAttributes = [];
+
+    protected string $exchangeName;
+
+    /**
+     * @param AMQPExchange|AMQPChannel $exchange     AMQPExchange (php AMQP ext) or PHP AMQP lib channel, ready for use
+     * @param string|null              $exchangeName Optional exchange name, for AMQPChannel (PhpAmqpLib) only
+     */
+    public function __construct(AMQPExchange|AMQPChannel $exchange, ?string $exchangeName = null, int|string|Level $level = Level::Debug, bool $bubble = true)
+    {
+        if ($exchange instanceof AMQPChannel) {
+            $this->exchangeName = (string) $exchangeName;
+        } elseif ($exchangeName !== null) {
+            @trigger_error('The $exchangeName parameter can only be passed when using PhpAmqpLib, if using an AMQPExchange instance configure it beforehand', E_USER_DEPRECATED);
+        }
+        $this->exchange = $exchange;
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getExtraAttributes(): array
+    {
+        return $this->extraAttributes;
+    }
+
+    /**
+     * Configure extra attributes to pass to the AMQPExchange (if you are using the amqp extension)
+     *
+     * @param  array<string, mixed> $extraAttributes One of content_type, content_encoding,
+     *                                               message_id, user_id, app_id, delivery_mode,
+     *                                               priority, timestamp, expiration, type
+     *                                               or reply_to, headers.
+     * @return $this
+     */
+    public function setExtraAttributes(array $extraAttributes): self
+    {
+        $this->extraAttributes = $extraAttributes;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        $data = $record->formatted;
+        $routingKey = $this->getRoutingKey($record);
+
+        if($data instanceof GelfMessage) {
+            $data = json_encode($data->toArray());
+        }
+
+        if ($this->exchange instanceof AMQPExchange) {
+            $attributes = [
+                'delivery_mode' => 2,
+                'content_type'  => 'application/json',
+            ];
+            if (\count($this->extraAttributes) > 0) {
+                $attributes = array_merge($attributes, $this->extraAttributes);
+            }
+            $this->exchange->publish(
+                $data,
+                $routingKey,
+                0,
+                $attributes
+            );
+        } else {
+            $this->exchange->basic_publish(
+                $this->createAmqpMessage($data),
+                $this->exchangeName,
+                $routingKey
+            );
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handleBatch(array $records): void
+    {
+        if ($this->exchange instanceof AMQPExchange) {
+            parent::handleBatch($records);
+
+            return;
+        }
+
+        foreach ($records as $record) {
+            if (!$this->isHandling($record)) {
+                continue;
+            }
+
+            $record = $this->processRecord($record);
+            $data = $this->getFormatter()->format($record);
+
+            if($data instanceof GelfMessage) {
+                $data = json_encode($data->toArray());
+            }
+
+            $this->exchange->batch_basic_publish(
+                $this->createAmqpMessage($data),
+                $this->exchangeName,
+                $this->getRoutingKey($record)
+            );
+        }
+
+        $this->exchange->publish_batch();
+    }
+
+    /**
+     * Gets the routing key for the AMQP exchange
+     */
+    protected function getRoutingKey(LogRecord $record): string
+    {
+        $routingKey = sprintf('%s.%s', $record->level->name, $record->channel);
+
+        return strtolower($routingKey);
+    }
+
+    private function createAmqpMessage(string $data): AMQPMessage
+    {
+        $attributes = [
+            'delivery_mode' => 2,
+            'content_type' => 'application/json',
+        ];
+        if (\count($this->extraAttributes) > 0) {
+            $attributes = array_merge($attributes, $this->extraAttributes);
+        }
+
+        return new AMQPMessage($data, $attributes);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new JsonFormatter(JsonFormatter::BATCH_MODE_JSON, false);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/BrowserConsoleHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/BrowserConsoleHandler.php
@@ -1,0 +1,300 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Utils;
+use Monolog\LogRecord;
+use Monolog\Level;
+
+use function headers_list;
+use function stripos;
+
+/**
+ * Handler sending logs to browser's javascript console with no browser extension required
+ *
+ * @author Olivier Poitrey <rs@dailymotion.com>
+ */
+class BrowserConsoleHandler extends AbstractProcessingHandler
+{
+    protected static bool $initialized = false;
+
+    /** @var LogRecord[] */
+    protected static array $records = [];
+
+    protected const FORMAT_HTML = 'html';
+    protected const FORMAT_JS = 'js';
+    protected const FORMAT_UNKNOWN = 'unknown';
+
+    /**
+     * @inheritDoc
+     *
+     * Formatted output may contain some formatting markers to be transferred to `console.log` using the %c format.
+     *
+     * Example of formatted string:
+     *
+     *     You can do [[blue text]]{color: blue} or [[green background]]{background-color: green; color: white}
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new LineFormatter('[[%channel%]]{macro: autolabel} [[%level_name%]]{font-weight: bold} %message%');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        // Accumulate records
+        static::$records[] = $record;
+
+        // Register shutdown handler if not already done
+        if (!static::$initialized) {
+            static::$initialized = true;
+            $this->registerShutdownFunction();
+        }
+    }
+
+    /**
+     * Convert records to javascript console commands and send it to the browser.
+     * This method is automatically called on PHP shutdown if output is HTML or Javascript.
+     */
+    public static function send(): void
+    {
+        $format = static::getResponseFormat();
+        if ($format === self::FORMAT_UNKNOWN) {
+            return;
+        }
+
+        if (\count(static::$records) > 0) {
+            if ($format === self::FORMAT_HTML) {
+                static::writeOutput('<script>' . self::generateScript() . '</script>');
+            } else { // js format
+                static::writeOutput(self::generateScript());
+            }
+            static::resetStatic();
+        }
+    }
+
+    public function close(): void
+    {
+        self::resetStatic();
+    }
+
+    public function reset(): void
+    {
+        parent::reset();
+
+        self::resetStatic();
+    }
+
+    /**
+     * Forget all logged records
+     */
+    public static function resetStatic(): void
+    {
+        static::$records = [];
+    }
+
+    /**
+     * Wrapper for register_shutdown_function to allow overriding
+     */
+    protected function registerShutdownFunction(): void
+    {
+        if (PHP_SAPI !== 'cli') {
+            register_shutdown_function(['Monolog\Handler\BrowserConsoleHandler', 'send']);
+        }
+    }
+
+    /**
+     * Wrapper for echo to allow overriding
+     */
+    protected static function writeOutput(string $str): void
+    {
+        echo $str;
+    }
+
+    /**
+     * Checks the format of the response
+     *
+     * If Content-Type is set to application/javascript or text/javascript -> js
+     * If Content-Type is set to text/html, or is unset -> html
+     * If Content-Type is anything else -> unknown
+     *
+     * @return string One of 'js', 'html' or 'unknown'
+     * @phpstan-return self::FORMAT_*
+     */
+    protected static function getResponseFormat(): string
+    {
+        // Check content type
+        foreach (headers_list() as $header) {
+            if (stripos($header, 'content-type:') === 0) {
+                return static::getResponseFormatFromContentType($header);
+            }
+        }
+
+        return self::FORMAT_HTML;
+    }
+
+    /**
+     * @return string One of 'js', 'html' or 'unknown'
+     * @phpstan-return self::FORMAT_*
+     */
+    protected static function getResponseFormatFromContentType(string $contentType): string
+    {
+        // This handler only works with HTML and javascript outputs
+        // text/javascript is obsolete in favour of application/javascript, but still used
+        if (stripos($contentType, 'application/javascript') !== false || stripos($contentType, 'text/javascript') !== false) {
+            return self::FORMAT_JS;
+        }
+
+        if (stripos($contentType, 'text/html') !== false) {
+            return self::FORMAT_HTML;
+        }
+
+        return self::FORMAT_UNKNOWN;
+    }
+
+    private static function generateScript(): string
+    {
+        $script = [];
+        foreach (static::$records as $record) {
+            $context = self::dump('Context', $record->context);
+            $extra = self::dump('Extra', $record->extra);
+
+            if (\count($context) === 0 && \count($extra) === 0) {
+                $script[] = self::call_array(self::getConsoleMethodForLevel($record->level), self::handleStyles($record->formatted));
+            } else {
+                $script = array_merge(
+                    $script,
+                    [self::call_array('groupCollapsed', self::handleStyles($record->formatted))],
+                    $context,
+                    $extra,
+                    [self::call('groupEnd')]
+                );
+            }
+        }
+
+        return "(function (c) {if (c && c.groupCollapsed) {\n" . implode("\n", $script) . "\n}})(console);";
+    }
+
+    private static function getConsoleMethodForLevel(Level $level): string
+    {
+        return match ($level) {
+            Level::Debug => 'debug',
+            Level::Info, Level::Notice => 'info',
+            Level::Warning => 'warn',
+            Level::Error, Level::Critical, Level::Alert, Level::Emergency => 'error',
+        };
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function handleStyles(string $formatted): array
+    {
+        $args = [];
+        $format = '%c' . $formatted;
+        preg_match_all('/\[\[(.*?)\]\]\{([^}]*)\}/s', $format, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+
+        foreach (array_reverse($matches) as $match) {
+            $args[] = '"font-weight: normal"';
+            $args[] = self::quote(self::handleCustomStyles($match[2][0], $match[1][0]));
+
+            $pos = $match[0][1];
+            $format = Utils::substr($format, 0, $pos) . '%c' . $match[1][0] . '%c' . Utils::substr($format, $pos + \strlen($match[0][0]));
+        }
+
+        $args[] = self::quote('font-weight: normal');
+        $args[] = self::quote($format);
+
+        return array_reverse($args);
+    }
+
+    private static function handleCustomStyles(string $style, string $string): string
+    {
+        static $colors = ['blue', 'green', 'red', 'magenta', 'orange', 'black', 'grey'];
+        static $labels = [];
+
+        $style = preg_replace_callback('/macro\s*:(.*?)(?:;|$)/', function (array $m) use ($string, &$colors, &$labels) {
+            if (trim($m[1]) === 'autolabel') {
+                // Format the string as a label with consistent auto assigned background color
+                if (!isset($labels[$string])) {
+                    $labels[$string] = $colors[\count($labels) % \count($colors)];
+                }
+                $color = $labels[$string];
+
+                return "background-color: $color; color: white; border-radius: 3px; padding: 0 2px 0 2px";
+            }
+
+            return $m[1];
+        }, $style);
+
+        if (null === $style) {
+            $pcreErrorCode = preg_last_error();
+
+            throw new \RuntimeException('Failed to run preg_replace_callback: ' . $pcreErrorCode . ' / ' . preg_last_error_msg());
+        }
+
+        return $style;
+    }
+
+    /**
+     * @param  mixed[] $dict
+     * @return mixed[]
+     */
+    private static function dump(string $title, array $dict): array
+    {
+        $script = [];
+        $dict = array_filter($dict, fn ($value) => $value !== null);
+        if (\count($dict) === 0) {
+            return $script;
+        }
+        $script[] = self::call('log', self::quote('%c%s'), self::quote('font-weight: bold'), self::quote($title));
+        foreach ($dict as $key => $value) {
+            $value = json_encode($value);
+            if (false === $value) {
+                $value = self::quote('');
+            }
+            $script[] = self::call('log', self::quote('%s: %o'), self::quote((string) $key), $value);
+        }
+
+        return $script;
+    }
+
+    private static function quote(string $arg): string
+    {
+        return '"' . addcslashes($arg, "\"\n\\") . '"';
+    }
+
+    /**
+     * @param mixed $args
+     */
+    private static function call(...$args): string
+    {
+        $method = array_shift($args);
+        if (!\is_string($method)) {
+            throw new \UnexpectedValueException('Expected the first arg to be a string, got: '.var_export($method, true));
+        }
+
+        return self::call_array($method, $args);
+    }
+
+    /**
+     * @param mixed[] $args
+     */
+    private static function call_array(string $method, array $args): string
+    {
+        return 'c.' . $method . '(' . implode(', ', $args) . ');';
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/BufferHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/BufferHandler.php
@@ -1,0 +1,170 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\ResettableInterface;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\LogRecord;
+
+/**
+ * Buffers all records until closing the handler and then pass them as batch.
+ *
+ * This is useful for a MailHandler to send only one mail per request instead of
+ * sending one per log message.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class BufferHandler extends AbstractHandler implements ProcessableHandlerInterface, FormattableHandlerInterface
+{
+    use ProcessableHandlerTrait;
+
+    protected HandlerInterface $handler;
+
+    protected int $bufferSize = 0;
+
+    protected int $bufferLimit;
+
+    protected bool $flushOnOverflow;
+
+    /** @var LogRecord[] */
+    protected array $buffer = [];
+
+    protected bool $initialized = false;
+
+    /**
+     * @param HandlerInterface $handler         Handler.
+     * @param int              $bufferLimit     How many entries should be buffered at most, beyond that the oldest items are removed from the buffer.
+     * @param bool             $flushOnOverflow If true, the buffer is flushed when the max size has been reached, by default oldest entries are discarded
+     */
+    public function __construct(HandlerInterface $handler, int $bufferLimit = 0, int|string|Level $level = Level::Debug, bool $bubble = true, bool $flushOnOverflow = false)
+    {
+        parent::__construct($level, $bubble);
+        $this->handler = $handler;
+        $this->bufferLimit = $bufferLimit;
+        $this->flushOnOverflow = $flushOnOverflow;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handle(LogRecord $record): bool
+    {
+        if ($record->level->isLowerThan($this->level)) {
+            return false;
+        }
+
+        if (!$this->initialized) {
+            // __destructor() doesn't get called on Fatal errors
+            register_shutdown_function([$this, 'close']);
+            $this->initialized = true;
+        }
+
+        if ($this->bufferLimit > 0 && $this->bufferSize === $this->bufferLimit) {
+            if ($this->flushOnOverflow) {
+                $this->flush();
+            } else {
+                array_shift($this->buffer);
+                $this->bufferSize--;
+            }
+        }
+
+        if (\count($this->processors) > 0) {
+            $record = $this->processRecord($record);
+        }
+
+        $this->buffer[] = $record;
+        $this->bufferSize++;
+
+        return false === $this->bubble;
+    }
+
+    public function flush(): void
+    {
+        if ($this->bufferSize === 0) {
+            return;
+        }
+
+        $this->handler->handleBatch($this->buffer);
+        $this->clear();
+    }
+
+    public function __destruct()
+    {
+        // suppress the parent behavior since we already have register_shutdown_function()
+        // to call close(), and the reference contained there will prevent this from being
+        // GC'd until the end of the request
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function close(): void
+    {
+        $this->flush();
+
+        $this->handler->close();
+    }
+
+    /**
+     * Clears the buffer without flushing any messages down to the wrapped handler.
+     */
+    public function clear(): void
+    {
+        $this->bufferSize = 0;
+        $this->buffer = [];
+    }
+
+    public function reset(): void
+    {
+        $this->flush();
+
+        parent::reset();
+
+        $this->resetProcessors();
+
+        if ($this->handler instanceof ResettableInterface) {
+            $this->handler->reset();
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface
+    {
+        if ($this->handler instanceof FormattableHandlerInterface) {
+            $this->handler->setFormatter($formatter);
+
+            return $this;
+        }
+
+        throw new \UnexpectedValueException('The nested handler of type '.\get_class($this->handler).' does not support formatters.');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFormatter(): FormatterInterface
+    {
+        if ($this->handler instanceof FormattableHandlerInterface) {
+            return $this->handler->getFormatter();
+        }
+
+        throw new \UnexpectedValueException('The nested handler of type '.\get_class($this->handler).' does not support formatters.');
+    }
+
+    public function setHandler(HandlerInterface $handler): void
+    {
+        $this->handler = $handler;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/ChromePHPHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/ChromePHPHandler.php
@@ -1,0 +1,186 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\ChromePHPFormatter;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Level;
+use Monolog\Utils;
+use Monolog\LogRecord;
+use Monolog\JsonSerializableDateTimeImmutable;
+
+/**
+ * Handler sending logs to the ChromePHP extension (http://www.chromephp.com/)
+ *
+ * This also works out of the box with Firefox 43+
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class ChromePHPHandler extends AbstractProcessingHandler
+{
+    use WebRequestRecognizerTrait;
+
+    /**
+     * Version of the extension
+     */
+    protected const VERSION = '4.0';
+
+    /**
+     * Header name
+     */
+    protected const HEADER_NAME = 'X-ChromeLogger-Data';
+
+    /**
+     * Regular expression to detect supported browsers (matches any Chrome, or Firefox 43+)
+     */
+    protected const USER_AGENT_REGEX = '{\b(?:Chrome/\d+(?:\.\d+)*|HeadlessChrome|Firefox/(?:4[3-9]|[5-9]\d|\d{3,})(?:\.\d)*)\b}';
+
+    protected static bool $initialized = false;
+
+    /**
+     * Tracks whether we sent too much data
+     *
+     * Chrome limits the headers to 4KB, so when we sent 3KB we stop sending
+     */
+    protected static bool $overflowed = false;
+
+    /** @var mixed[] */
+    protected static array $json = [
+        'version' => self::VERSION,
+        'columns' => ['label', 'log', 'backtrace', 'type'],
+        'rows' => [],
+    ];
+
+    protected static bool $sendHeaders = true;
+
+    public function __construct(int|string|Level $level = Level::Debug, bool $bubble = true)
+    {
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handleBatch(array $records): void
+    {
+        if (!$this->isWebRequest()) {
+            return;
+        }
+
+        $messages = [];
+
+        foreach ($records as $record) {
+            if ($record->level < $this->level) {
+                continue;
+            }
+
+            $message = $this->processRecord($record);
+            $messages[] = $message;
+        }
+
+        if (\count($messages) > 0) {
+            $messages = $this->getFormatter()->formatBatch($messages);
+            self::$json['rows'] = array_merge(self::$json['rows'], $messages);
+            $this->send();
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new ChromePHPFormatter();
+    }
+
+    /**
+     * Creates & sends header for a record
+     *
+     * @see sendHeader()
+     * @see send()
+     */
+    protected function write(LogRecord $record): void
+    {
+        if (!$this->isWebRequest()) {
+            return;
+        }
+
+        self::$json['rows'][] = $record->formatted;
+
+        $this->send();
+    }
+
+    /**
+     * Sends the log header
+     *
+     * @see sendHeader()
+     */
+    protected function send(): void
+    {
+        if (self::$overflowed || !self::$sendHeaders) {
+            return;
+        }
+
+        if (!self::$initialized) {
+            self::$initialized = true;
+
+            self::$sendHeaders = $this->headersAccepted();
+            if (!self::$sendHeaders) {
+                return;
+            }
+
+            self::$json['request_uri'] = $_SERVER['REQUEST_URI'] ?? '';
+        }
+
+        $json = Utils::jsonEncode(self::$json, Utils::DEFAULT_JSON_FLAGS & ~JSON_UNESCAPED_UNICODE, true);
+        $data = base64_encode($json);
+        if (\strlen($data) > 3 * 1024) {
+            self::$overflowed = true;
+
+            $record = new LogRecord(
+                message: 'Incomplete logs, chrome header size limit reached',
+                level: Level::Warning,
+                channel: 'monolog',
+                datetime: new JsonSerializableDateTimeImmutable(true),
+            );
+            self::$json['rows'][\count(self::$json['rows']) - 1] = $this->getFormatter()->format($record);
+            $json = Utils::jsonEncode(self::$json, Utils::DEFAULT_JSON_FLAGS & ~JSON_UNESCAPED_UNICODE, true);
+            $data = base64_encode($json);
+        }
+
+        if (trim($data) !== '') {
+            $this->sendHeader(static::HEADER_NAME, $data);
+        }
+    }
+
+    /**
+     * Send header string to the client
+     */
+    protected function sendHeader(string $header, string $content): void
+    {
+        if (!headers_sent() && self::$sendHeaders) {
+            header(sprintf('%s: %s', $header, $content));
+        }
+    }
+
+    /**
+     * Verifies if the headers are accepted by the current user agent
+     */
+    protected function headersAccepted(): bool
+    {
+        if (!isset($_SERVER['HTTP_USER_AGENT'])) {
+            return false;
+        }
+
+        return preg_match(static::USER_AGENT_REGEX, $_SERVER['HTTP_USER_AGENT']) === 1;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/CouchDBHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/CouchDBHandler.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\JsonFormatter;
+use Monolog\Level;
+use Monolog\LogRecord;
+
+/**
+ * CouchDB handler
+ *
+ * @author Markus Bachmann <markus.bachmann@bachi.biz>
+ * @phpstan-type Options array{
+ *     host: string,
+ *     port: int,
+ *     dbname: string,
+ *     username: string|null,
+ *     password: string|null
+ * }
+ * @phpstan-type InputOptions array{
+ *     host?: string,
+ *     port?: int,
+ *     dbname?: string,
+ *     username?: string|null,
+ *     password?: string|null
+ * }
+ */
+class CouchDBHandler extends AbstractProcessingHandler
+{
+    /**
+     * @var mixed[]
+     * @phpstan-var Options
+     */
+    private array $options;
+
+    /**
+     * @param mixed[] $options
+     *
+     * @phpstan-param InputOptions $options
+     */
+    public function __construct(array $options = [], int|string|Level $level = Level::Debug, bool $bubble = true)
+    {
+        $this->options = array_merge([
+            'host'     => 'localhost',
+            'port'     => 5984,
+            'dbname'   => 'logger',
+            'username' => null,
+            'password' => null,
+        ], $options);
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        $basicAuth = null;
+        if (null !== $this->options['username'] && null !== $this->options['password']) {
+            $basicAuth = sprintf('%s:%s@', $this->options['username'], $this->options['password']);
+        }
+
+        $url = 'http://'.$basicAuth.$this->options['host'].':'.$this->options['port'].'/'.$this->options['dbname'];
+        $context = stream_context_create([
+            'http' => [
+                'method'        => 'POST',
+                'content'       => $record->formatted,
+                'ignore_errors' => true,
+                'max_redirects' => 0,
+                'header'        => 'Content-type: application/json',
+            ],
+        ]);
+
+        if (false === @file_get_contents($url, false, $context)) {
+            throw new \RuntimeException(sprintf('Could not connect to %s', $url));
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new JsonFormatter(JsonFormatter::BATCH_MODE_JSON, false);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/CubeHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/CubeHandler.php
@@ -1,0 +1,167 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\Utils;
+use Monolog\LogRecord;
+
+/**
+ * Logs to Cube.
+ *
+ * @link https://github.com/square/cube/wiki
+ * @author Wan Chen <kami@kamisama.me>
+ * @deprecated Since 2.8.0 and 3.2.0, Cube appears abandoned and thus we will drop this handler in Monolog 4
+ */
+class CubeHandler extends AbstractProcessingHandler
+{
+    private ?\Socket $udpConnection = null;
+    private ?\CurlHandle $httpConnection = null;
+    private string $scheme;
+    private string $host;
+    private int $port;
+    /** @var string[] */
+    private array $acceptedSchemes = ['http', 'udp'];
+
+    /**
+     * Create a Cube handler
+     *
+     * @throws \UnexpectedValueException when given url is not a valid url.
+     *                                   A valid url must consist of three parts : protocol://host:port
+     *                                   Only valid protocols used by Cube are http and udp
+     */
+    public function __construct(string $url, int|string|Level $level = Level::Debug, bool $bubble = true)
+    {
+        $urlInfo = parse_url($url);
+
+        if ($urlInfo === false || !isset($urlInfo['scheme'], $urlInfo['host'], $urlInfo['port'])) {
+            throw new \UnexpectedValueException('URL "'.$url.'" is not valid');
+        }
+
+        if (!\in_array($urlInfo['scheme'], $this->acceptedSchemes, true)) {
+            throw new \UnexpectedValueException(
+                'Invalid protocol (' . $urlInfo['scheme']  . ').'
+                . ' Valid options are ' . implode(', ', $this->acceptedSchemes)
+            );
+        }
+
+        $this->scheme = $urlInfo['scheme'];
+        $this->host = $urlInfo['host'];
+        $this->port = $urlInfo['port'];
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * Establish a connection to an UDP socket
+     *
+     * @throws \LogicException           when unable to connect to the socket
+     * @throws MissingExtensionException when there is no socket extension
+     */
+    protected function connectUdp(): void
+    {
+        if (!\extension_loaded('sockets')) {
+            throw new MissingExtensionException('The sockets extension is required to use udp URLs with the CubeHandler');
+        }
+
+        $udpConnection = socket_create(AF_INET, SOCK_DGRAM, 0);
+        if (false === $udpConnection) {
+            throw new \LogicException('Unable to create a socket');
+        }
+
+        $this->udpConnection = $udpConnection;
+        if (!socket_connect($this->udpConnection, $this->host, $this->port)) {
+            throw new \LogicException('Unable to connect to the socket at ' . $this->host . ':' . $this->port);
+        }
+    }
+
+    /**
+     * Establish a connection to an http server
+     *
+     * @throws \LogicException           when unable to connect to the socket
+     * @throws MissingExtensionException when no curl extension
+     */
+    protected function connectHttp(): void
+    {
+        if (!\extension_loaded('curl')) {
+            throw new MissingExtensionException('The curl extension is required to use http URLs with the CubeHandler');
+        }
+
+        $httpConnection = curl_init('http://'.$this->host.':'.$this->port.'/1.0/event/put');
+        if (false === $httpConnection) {
+            throw new \LogicException('Unable to connect to ' . $this->host . ':' . $this->port);
+        }
+
+        $this->httpConnection = $httpConnection;
+        curl_setopt($this->httpConnection, CURLOPT_CUSTOMREQUEST, "POST");
+        curl_setopt($this->httpConnection, CURLOPT_RETURNTRANSFER, true);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        $date = $record->datetime;
+
+        $data = ['time' => $date->format('Y-m-d\TH:i:s.uO')];
+        $context = $record->context;
+
+        if (isset($context['type'])) {
+            $data['type'] = $context['type'];
+            unset($context['type']);
+        } else {
+            $data['type'] = $record->channel;
+        }
+
+        $data['data'] = $context;
+        $data['data']['level'] = $record->level;
+
+        if ($this->scheme === 'http') {
+            $this->writeHttp(Utils::jsonEncode($data));
+        } else {
+            $this->writeUdp(Utils::jsonEncode($data));
+        }
+    }
+
+    private function writeUdp(string $data): void
+    {
+        if (null === $this->udpConnection) {
+            $this->connectUdp();
+        }
+
+        if (null === $this->udpConnection) {
+            throw new \LogicException('No UDP socket could be opened');
+        }
+
+        socket_send($this->udpConnection, $data, \strlen($data), 0);
+    }
+
+    private function writeHttp(string $data): void
+    {
+        if (null === $this->httpConnection) {
+            $this->connectHttp();
+        }
+
+        if (null === $this->httpConnection) {
+            throw new \LogicException('No connection could be established');
+        }
+
+        curl_setopt($this->httpConnection, CURLOPT_POSTFIELDS, '['.$data.']');
+        curl_setopt($this->httpConnection, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/json',
+            'Content-Length: ' . \strlen('['.$data.']'),
+        ]);
+
+        Curl\Util::execute($this->httpConnection, 5);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/Curl/Util.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/Curl/Util.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler\Curl;
+
+use CurlHandle;
+
+/**
+ * This class is marked as internal and it is not under the BC promise of the package.
+ *
+ * @internal
+ */
+final class Util
+{
+    /** @var array<int> */
+    private static array $retriableErrorCodes = [
+        CURLE_COULDNT_RESOLVE_HOST,
+        CURLE_COULDNT_CONNECT,
+        CURLE_HTTP_NOT_FOUND,
+        CURLE_READ_ERROR,
+        CURLE_OPERATION_TIMEOUTED,
+        CURLE_HTTP_POST_ERROR,
+        CURLE_SSL_CONNECT_ERROR,
+    ];
+
+    /**
+     * Executes a CURL request with optional retries and exception on failure
+     *
+     * @param  CurlHandle  $ch curl handler
+     * @return bool|string @see curl_exec
+     */
+    public static function execute(CurlHandle $ch, int $retries = 5): bool|string
+    {
+        while ($retries > 0) {
+            $retries--;
+            $curlResponse = curl_exec($ch);
+            if ($curlResponse === false) {
+                $curlErrno = curl_errno($ch);
+
+                if (false === \in_array($curlErrno, self::$retriableErrorCodes, true) || $retries === 0) {
+                    $curlError = curl_error($ch);
+
+                    throw new \RuntimeException(sprintf('Curl error (code %d): %s', $curlErrno, $curlError));
+                }
+                continue;
+            }
+
+            return $curlResponse;
+        }
+        return false;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/DeduplicationHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/DeduplicationHandler.php
@@ -1,0 +1,176 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\Logger;
+use Psr\Log\LogLevel;
+use Monolog\LogRecord;
+
+/**
+ * Simple handler wrapper that deduplicates log records across multiple requests
+ *
+ * It also includes the BufferHandler functionality and will buffer
+ * all messages until the end of the request or flush() is called.
+ *
+ * This works by storing all log records' messages above $deduplicationLevel
+ * to the file specified by $deduplicationStore. When further logs come in at the end of the
+ * request (or when flush() is called), all those above $deduplicationLevel are checked
+ * against the existing stored logs. If they match and the timestamps in the stored log is
+ * not older than $time seconds, the new log record is discarded. If no log record is new, the
+ * whole data set is discarded.
+ *
+ * This is mainly useful in combination with Mail handlers or things like Slack or HipChat handlers
+ * that send messages to people, to avoid spamming with the same message over and over in case of
+ * a major component failure like a database server being down which makes all requests fail in the
+ * same way.
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class DeduplicationHandler extends BufferHandler
+{
+    protected string $deduplicationStore;
+
+    protected Level $deduplicationLevel;
+
+    protected int $time;
+    protected bool $gc = false;
+
+    /**
+     * @param HandlerInterface             $handler            Handler.
+     * @param string|null                  $deduplicationStore The file/path where the deduplication log should be kept
+     * @param int|string|Level|LogLevel::* $deduplicationLevel The minimum logging level for log records to be looked at for deduplication purposes
+     * @param int                          $time               The period (in seconds) during which duplicate entries should be suppressed after a given log is sent through
+     * @param bool                         $bubble             Whether the messages that are handled can bubble up the stack or not
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $deduplicationLevel
+     */
+    public function __construct(HandlerInterface $handler, ?string $deduplicationStore = null, int|string|Level $deduplicationLevel = Level::Error, int $time = 60, bool $bubble = true)
+    {
+        parent::__construct($handler, 0, Level::Debug, $bubble, false);
+
+        $this->deduplicationStore = $deduplicationStore === null ? sys_get_temp_dir() . '/monolog-dedup-' . substr(md5(__FILE__), 0, 20) .'.log' : $deduplicationStore;
+        $this->deduplicationLevel = Logger::toMonologLevel($deduplicationLevel);
+        $this->time = $time;
+    }
+
+    public function flush(): void
+    {
+        if ($this->bufferSize === 0) {
+            return;
+        }
+
+        $store = null;
+
+        if (file_exists($this->deduplicationStore)) {
+            $store = file($this->deduplicationStore, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        }
+
+        $passthru = null;
+
+        foreach ($this->buffer as $record) {
+            if ($record->level->value >= $this->deduplicationLevel->value) {
+                $passthru = $passthru === true || !\is_array($store) || !$this->isDuplicate($store, $record);
+                if ($passthru) {
+                    $line = $this->buildDeduplicationStoreEntry($record);
+                    file_put_contents($this->deduplicationStore, $line . "\n", FILE_APPEND);
+                    if (!\is_array($store)) {
+                        $store = [];
+                    }
+                    $store[] = $line;
+                }
+            }
+        }
+
+        // default of null is valid as well as if no record matches duplicationLevel we just pass through
+        if ($passthru === true || $passthru === null) {
+            $this->handler->handleBatch($this->buffer);
+        }
+
+        $this->clear();
+
+        if ($this->gc) {
+            $this->collectLogs();
+        }
+    }
+
+    /**
+     * If there is a store entry older than e.g. a day, this method should set `$this->gc` to `true` to trigger garbage collection.
+     * @param string[] $store The deduplication store
+     */
+    protected function isDuplicate(array $store, LogRecord $record): bool
+    {
+        $timestampValidity = $record->datetime->getTimestamp() - $this->time;
+        $expectedMessage = preg_replace('{[\r\n].*}', '', $record->message);
+        $yesterday = time() - 86400;
+
+        for ($i = \count($store) - 1; $i >= 0; $i--) {
+            list($timestamp, $level, $message) = explode(':', $store[$i], 3);
+
+            if ($level === $record->level->getName() && $message === $expectedMessage && $timestamp > $timestampValidity) {
+                return true;
+            }
+
+            if ($timestamp < $yesterday) {
+                $this->gc = true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return string The given record serialized as a single line of text
+     */
+    protected function buildDeduplicationStoreEntry(LogRecord $record): string
+    {
+        return $record->datetime->getTimestamp() . ':' . $record->level->getName() . ':' . preg_replace('{[\r\n].*}', '', $record->message);
+    }
+
+    private function collectLogs(): void
+    {
+        if (!file_exists($this->deduplicationStore)) {
+            return;
+        }
+
+        $handle = fopen($this->deduplicationStore, 'rw+');
+
+        if (false === $handle) {
+            throw new \RuntimeException('Failed to open file for reading and writing: ' . $this->deduplicationStore);
+        }
+
+        if (false === flock($handle, LOCK_EX)) {
+            return;
+        }
+        $validLogs = [];
+
+        $timestampValidity = time() - $this->time;
+
+        while (!feof($handle)) {
+            $log = fgets($handle);
+            if (\is_string($log) && '' !== $log && substr($log, 0, 10) >= $timestampValidity) {
+                $validLogs[] = $log;
+            }
+        }
+
+        ftruncate($handle, 0);
+        rewind($handle);
+        foreach ($validLogs as $log) {
+            fwrite($handle, $log);
+        }
+
+        flock($handle, LOCK_UN);
+        fclose($handle);
+
+        $this->gc = false;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/DoctrineCouchDBHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/DoctrineCouchDBHandler.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\Formatter\NormalizerFormatter;
+use Monolog\Formatter\FormatterInterface;
+use Doctrine\CouchDB\CouchDBClient;
+use Monolog\LogRecord;
+
+/**
+ * CouchDB handler for Doctrine CouchDB ODM
+ *
+ * @author Markus Bachmann <markus.bachmann@bachi.biz>
+ */
+class DoctrineCouchDBHandler extends AbstractProcessingHandler
+{
+    private CouchDBClient $client;
+
+    public function __construct(CouchDBClient $client, int|string|Level $level = Level::Debug, bool $bubble = true)
+    {
+        $this->client = $client;
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        $this->client->postDocument($record->formatted);
+    }
+
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new NormalizerFormatter;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/DynamoDbHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/DynamoDbHandler.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Aws\Sdk;
+use Aws\DynamoDb\DynamoDbClient;
+use Monolog\Formatter\FormatterInterface;
+use Aws\DynamoDb\Marshaler;
+use Monolog\Formatter\ScalarFormatter;
+use Monolog\Level;
+use Monolog\LogRecord;
+
+/**
+ * Amazon DynamoDB handler (http://aws.amazon.com/dynamodb/)
+ *
+ * @link https://github.com/aws/aws-sdk-php/
+ * @author Andrew Lawson <adlawson@gmail.com>
+ */
+class DynamoDbHandler extends AbstractProcessingHandler
+{
+    public const DATE_FORMAT = 'Y-m-d\TH:i:s.uO';
+
+    protected DynamoDbClient $client;
+
+    protected string $table;
+
+    protected Marshaler $marshaler;
+
+    public function __construct(DynamoDbClient $client, string $table, int|string|Level $level = Level::Debug, bool $bubble = true)
+    {
+        $this->marshaler = new Marshaler;
+
+        $this->client = $client;
+        $this->table = $table;
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        $filtered = $this->filterEmptyFields($record->formatted);
+        $formatted = $this->marshaler->marshalItem($filtered);
+
+        $this->client->putItem([
+            'TableName' => $this->table,
+            'Item' => $formatted,
+        ]);
+    }
+
+    /**
+     * @param  mixed[] $record
+     * @return mixed[]
+     */
+    protected function filterEmptyFields(array $record): array
+    {
+        return array_filter($record, function ($value) {
+            return [] !== $value;
+        });
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new ScalarFormatter(self::DATE_FORMAT);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/ElasticaHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/ElasticaHandler.php
@@ -1,0 +1,143 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Elastic\Transport\Exception\TransportException;
+use Elastica\Document;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\ElasticaFormatter;
+use Monolog\Level;
+use Elastica\Client;
+use Elastica\Exception\ExceptionInterface;
+use Monolog\LogRecord;
+
+/**
+ * Elastic Search handler
+ *
+ * Usage example:
+ *
+ *    $client = new \Elastica\Client();
+ *    $options = array(
+ *        'index' => 'elastic_index_name',
+ *        'type' => 'elastic_doc_type', Types have been removed in Elastica 7
+ *    );
+ *    $handler = new ElasticaHandler($client, $options);
+ *    $log = new Logger('application');
+ *    $log->pushHandler($handler);
+ *
+ * @author Jelle Vink <jelle.vink@gmail.com>
+ * @phpstan-type Options array{
+ *     index: string,
+ *     type: string,
+ *     ignore_error: bool
+ * }
+ * @phpstan-type InputOptions array{
+ *     index?: string,
+ *     type?: string,
+ *     ignore_error?: bool
+ * }
+ */
+class ElasticaHandler extends AbstractProcessingHandler
+{
+    protected Client $client;
+
+    /**
+     * @var mixed[] Handler config options
+     * @phpstan-var Options
+     */
+    protected array $options;
+
+    /**
+     * @param Client  $client  Elastica Client object
+     * @param mixed[] $options Handler configuration
+     *
+     * @phpstan-param InputOptions $options
+     */
+    public function __construct(Client $client, array $options = [], int|string|Level $level = Level::Debug, bool $bubble = true)
+    {
+        parent::__construct($level, $bubble);
+        $this->client = $client;
+        $this->options = array_merge(
+            [
+                'index'          => 'monolog',      // Elastic index name
+                'type'           => 'record',       // Elastic document type
+                'ignore_error'   => false,          // Suppress Elastica exceptions
+            ],
+            $options
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        $this->bulkSend([$record->formatted]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface
+    {
+        if ($formatter instanceof ElasticaFormatter) {
+            return parent::setFormatter($formatter);
+        }
+
+        throw new \InvalidArgumentException('ElasticaHandler is only compatible with ElasticaFormatter');
+    }
+
+    /**
+     * @return mixed[]
+     *
+     * @phpstan-return Options
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new ElasticaFormatter($this->options['index'], $this->options['type']);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handleBatch(array $records): void
+    {
+        $documents = $this->getFormatter()->formatBatch($records);
+        $this->bulkSend($documents);
+    }
+
+    /**
+     * Use Elasticsearch bulk API to send list of documents
+     *
+     * @param Document[] $documents
+     *
+     * @throws \RuntimeException
+     */
+    protected function bulkSend(array $documents): void
+    {
+        try {
+            $this->client->addDocuments($documents);
+        } catch (ExceptionInterface | TransportException $e) {
+            if (!$this->options['ignore_error']) {
+                throw new \RuntimeException("Error sending messages to Elasticsearch", 0, $e);
+            }
+        }
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/ElasticsearchHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/ElasticsearchHandler.php
@@ -1,0 +1,238 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Elastic\Elasticsearch\Response\Elasticsearch;
+use Throwable;
+use RuntimeException;
+use Monolog\Level;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\ElasticsearchFormatter;
+use InvalidArgumentException;
+use Elasticsearch\Common\Exceptions\RuntimeException as ElasticsearchRuntimeException;
+use Elasticsearch\Client;
+use Monolog\LogRecord;
+use Elastic\Elasticsearch\Exception\InvalidArgumentException as ElasticInvalidArgumentException;
+use Elastic\Elasticsearch\Client as Client8;
+
+/**
+ * Elasticsearch handler
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/index.html
+ *
+ * Simple usage example:
+ *
+ *    $client = \Elasticsearch\ClientBuilder::create()
+ *        ->setHosts($hosts)
+ *        ->build();
+ *
+ *    $options = array(
+ *        'index' => 'elastic_index_name',
+ *        'type'  => 'elastic_doc_type',
+ *    );
+ *    $handler = new ElasticsearchHandler($client, $options);
+ *    $log = new Logger('application');
+ *    $log->pushHandler($handler);
+ *
+ * @author Avtandil Kikabidze <akalongman@gmail.com>
+ * @phpstan-type Options array{
+ *     index: string,
+ *     type: string,
+ *     ignore_error: bool,
+ *     op_type: 'index'|'create'
+ * }
+ * @phpstan-type InputOptions array{
+ *     index?: string,
+ *     type?: string,
+ *     ignore_error?: bool,
+ *     op_type?: 'index'|'create'
+ * }
+ */
+class ElasticsearchHandler extends AbstractProcessingHandler
+{
+    protected Client|Client8 $client;
+
+    /**
+     * @var mixed[] Handler config options
+     * @phpstan-var Options
+     */
+    protected array $options;
+
+    /**
+     * @var bool
+     */
+    private $needsType;
+
+    /**
+     * @param Client|Client8 $client  Elasticsearch Client object
+     * @param mixed[]        $options Handler configuration
+     *
+     * @phpstan-param InputOptions $options
+     */
+    public function __construct(Client|Client8 $client, array $options = [], int|string|Level $level = Level::Debug, bool $bubble = true)
+    {
+        parent::__construct($level, $bubble);
+        $this->client = $client;
+        $this->options = array_merge(
+            [
+                'index'        => 'monolog', // Elastic index name
+                'type'         => '_doc',    // Elastic document type
+                'ignore_error' => false,     // Suppress Elasticsearch exceptions
+                'op_type'      => 'index',   // Elastic op_type (index or create) (https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#docs-index-api-op_type)
+            ],
+            $options
+        );
+
+        if ($client instanceof Client8 || $client::VERSION[0] === '7') {
+            $this->needsType = false;
+            // force the type to _doc for ES8/ES7
+            $this->options['type'] = '_doc';
+        } else {
+            $this->needsType = true;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        $this->bulkSend([$record->formatted]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface
+    {
+        if ($formatter instanceof ElasticsearchFormatter) {
+            return parent::setFormatter($formatter);
+        }
+
+        throw new InvalidArgumentException('ElasticsearchHandler is only compatible with ElasticsearchFormatter');
+    }
+
+    /**
+     * Getter options
+     *
+     * @return mixed[]
+     *
+     * @phpstan-return Options
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new ElasticsearchFormatter($this->options['index'], $this->options['type']);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handleBatch(array $records): void
+    {
+        $documents = $this->getFormatter()->formatBatch($records);
+        $this->bulkSend($documents);
+    }
+
+    /**
+     * Use Elasticsearch bulk API to send list of documents
+     *
+     * @param  array<array<mixed>> $records Records + _index/_type keys
+     * @throws \RuntimeException
+     */
+    protected function bulkSend(array $records): void
+    {
+        try {
+            $params = [
+                'body' => [],
+            ];
+
+            foreach ($records as $record) {
+                $params['body'][] = [
+                    $this->options['op_type'] => $this->needsType ? [
+                        '_index' => $record['_index'],
+                        '_type'  => $record['_type'],
+                    ] : [
+                        '_index' => $record['_index'],
+                    ],
+                ];
+                unset($record['_index'], $record['_type']);
+
+                $params['body'][] = $record;
+            }
+
+            /** @var Elasticsearch */
+            $responses = $this->client->bulk($params);
+
+            if ($responses['errors'] === true) {
+                throw $this->createExceptionFromResponses($responses);
+            }
+        } catch (Throwable $e) {
+            if (! $this->options['ignore_error']) {
+                throw new RuntimeException('Error sending messages to Elasticsearch', 0, $e);
+            }
+        }
+    }
+
+    /**
+     * Creates elasticsearch exception from responses array
+     *
+     * Only the first error is converted into an exception.
+     *
+     * @param mixed[]|Elasticsearch $responses returned by $this->client->bulk()
+     */
+    protected function createExceptionFromResponses($responses): Throwable
+    {
+        foreach ($responses['items'] ?? [] as $item) {
+            if (isset($item['index']['error'])) {
+                return $this->createExceptionFromError($item['index']['error']);
+            }
+        }
+
+        if (class_exists(ElasticInvalidArgumentException::class)) {
+            return new ElasticInvalidArgumentException('Elasticsearch failed to index one or more records.');
+        }
+
+        if (class_exists(ElasticsearchRuntimeException::class)) {
+            return new ElasticsearchRuntimeException('Elasticsearch failed to index one or more records.');
+        }
+
+        throw new \LogicException('Unsupported elastic search client version');
+    }
+
+    /**
+     * Creates elasticsearch exception from error array
+     *
+     * @param mixed[] $error
+     */
+    protected function createExceptionFromError(array $error): Throwable
+    {
+        $previous = isset($error['caused_by']) ? $this->createExceptionFromError($error['caused_by']) : null;
+
+        if (class_exists(ElasticInvalidArgumentException::class)) {
+            return new ElasticInvalidArgumentException($error['type'] . ': ' . $error['reason'], 0, $previous);
+        }
+
+        if (class_exists(ElasticsearchRuntimeException::class)) {
+            return new ElasticsearchRuntimeException($error['type'].': '.$error['reason'], 0, $previous);
+        }
+
+        throw new \LogicException('Unsupported elastic search client version');
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/ErrorLogHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/ErrorLogHandler.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\LineFormatter;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Level;
+use Monolog\Utils;
+use Monolog\LogRecord;
+
+/**
+ * Stores to PHP error_log() handler.
+ *
+ * @author Elan Ruusamäe <glen@delfi.ee>
+ */
+class ErrorLogHandler extends AbstractProcessingHandler
+{
+    public const OPERATING_SYSTEM = 0;
+    public const SAPI = 4;
+
+    /** @var 0|4 */
+    protected int $messageType;
+    protected bool $expandNewlines;
+
+    /**
+     * @param 0|4 $messageType    Says where the error should go.
+     * @param bool $expandNewlines If set to true, newlines in the message will be expanded to be take multiple log entries
+     *
+     * @throws \InvalidArgumentException If an unsupported message type is set
+     */
+    public function __construct(int $messageType = self::OPERATING_SYSTEM, int|string|Level $level = Level::Debug, bool $bubble = true, bool $expandNewlines = false)
+    {
+        parent::__construct($level, $bubble);
+
+        if (false === \in_array($messageType, self::getAvailableTypes(), true)) {
+            $message = sprintf('The given message type "%s" is not supported', print_r($messageType, true));
+
+            throw new \InvalidArgumentException($message);
+        }
+
+        $this->messageType = $messageType;
+        $this->expandNewlines = $expandNewlines;
+    }
+
+    /**
+     * @return int[] With all available types
+     */
+    public static function getAvailableTypes(): array
+    {
+        return [
+            self::OPERATING_SYSTEM,
+            self::SAPI,
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new LineFormatter('[%datetime%] %channel%.%level_name%: %message% %context% %extra%');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        if (!$this->expandNewlines) {
+            error_log((string) $record->formatted, $this->messageType);
+
+            return;
+        }
+
+        $lines = preg_split('{[\r\n]+}', (string) $record->formatted);
+        if ($lines === false) {
+            $pcreErrorCode = preg_last_error();
+
+            throw new \RuntimeException('Failed to preg_split formatted string: ' . $pcreErrorCode . ' / '. preg_last_error_msg());
+        }
+        foreach ($lines as $line) {
+            error_log($line, $this->messageType);
+        }
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/FallbackGroupHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/FallbackGroupHandler.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Throwable;
+use Monolog\LogRecord;
+
+/**
+ * Forwards records to at most one handler
+ *
+ * If a handler fails, the exception is suppressed and the record is forwarded to the next handler.
+ *
+ * As soon as one handler handles a record successfully, the handling stops there.
+ */
+class FallbackGroupHandler extends GroupHandler
+{
+    /**
+     * @inheritDoc
+     */
+    public function handle(LogRecord $record): bool
+    {
+        if (\count($this->processors) > 0) {
+            $record = $this->processRecord($record);
+        }
+        foreach ($this->handlers as $handler) {
+            try {
+                $handler->handle(clone $record);
+                break;
+            } catch (Throwable $e) {
+                // What throwable?
+            }
+        }
+
+        return false === $this->bubble;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handleBatch(array $records): void
+    {
+        if (\count($this->processors) > 0) {
+            $processed = [];
+            foreach ($records as $record) {
+                $processed[] = $this->processRecord($record);
+            }
+            $records = $processed;
+        }
+
+        foreach ($this->handlers as $handler) {
+            try {
+                $handler->handleBatch(array_map(fn ($record) => clone $record, $records));
+                break;
+            } catch (Throwable $e) {
+                // What throwable?
+            }
+        }
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/FilterHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/FilterHandler.php
@@ -1,0 +1,202 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Closure;
+use Monolog\Level;
+use Monolog\Logger;
+use Monolog\ResettableInterface;
+use Monolog\Formatter\FormatterInterface;
+use Psr\Log\LogLevel;
+use Monolog\LogRecord;
+
+/**
+ * Simple handler wrapper that filters records based on a list of levels
+ *
+ * It can be configured with an exact list of levels to allow, or a min/max level.
+ *
+ * @author Hennadiy Verkh
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class FilterHandler extends Handler implements ProcessableHandlerInterface, ResettableInterface, FormattableHandlerInterface
+{
+    use ProcessableHandlerTrait;
+
+    /**
+     * Handler or factory Closure($record, $this)
+     *
+     * @phpstan-var (Closure(LogRecord|null, HandlerInterface): HandlerInterface)|HandlerInterface
+     */
+    protected Closure|HandlerInterface $handler;
+
+    /**
+     * Minimum level for logs that are passed to handler
+     *
+     * @var bool[] Map of Level value => true
+     * @phpstan-var array<value-of<Level::VALUES>, true>
+     */
+    protected array $acceptedLevels;
+
+    /**
+     * Whether the messages that are handled can bubble up the stack or not
+     */
+    protected bool $bubble;
+
+    /**
+     * @phpstan-param (Closure(LogRecord|null, HandlerInterface): HandlerInterface)|HandlerInterface $handler
+     *
+     * @param Closure|HandlerInterface                             $handler        Handler or factory Closure($record|null, $filterHandler).
+     * @param int|string|Level|array<int|string|Level|LogLevel::*> $minLevelOrList A list of levels to accept or a minimum level if maxLevel is provided
+     * @param int|string|Level|LogLevel::*                         $maxLevel       Maximum level to accept, only used if $minLevelOrList is not an array
+     * @param bool                                                 $bubble         Whether the messages that are handled can bubble up the stack or not
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::*|array<value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::*> $minLevelOrList
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $maxLevel
+     */
+    public function __construct(Closure|HandlerInterface $handler, int|string|Level|array $minLevelOrList = Level::Debug, int|string|Level $maxLevel = Level::Emergency, bool $bubble = true)
+    {
+        $this->handler  = $handler;
+        $this->bubble   = $bubble;
+        $this->setAcceptedLevels($minLevelOrList, $maxLevel);
+    }
+
+    /**
+     * @phpstan-return list<Level> List of levels
+     */
+    public function getAcceptedLevels(): array
+    {
+        return array_map(fn (int $level) => Level::from($level), array_keys($this->acceptedLevels));
+    }
+
+    /**
+     * @param  int|string|Level|LogLevel::*|array<int|string|Level|LogLevel::*> $minLevelOrList A list of levels to accept or a minimum level or level name if maxLevel is provided
+     * @param  int|string|Level|LogLevel::*                                     $maxLevel       Maximum level or level name to accept, only used if $minLevelOrList is not an array
+     * @return $this
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::*|array<value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::*> $minLevelOrList
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $maxLevel
+     */
+    public function setAcceptedLevels(int|string|Level|array $minLevelOrList = Level::Debug, int|string|Level $maxLevel = Level::Emergency): self
+    {
+        if (\is_array($minLevelOrList)) {
+            $acceptedLevels = array_map(Logger::toMonologLevel(...), $minLevelOrList);
+        } else {
+            $minLevelOrList = Logger::toMonologLevel($minLevelOrList);
+            $maxLevel = Logger::toMonologLevel($maxLevel);
+            $acceptedLevels = array_values(array_filter(Level::cases(), fn (Level $level) => $level->value >= $minLevelOrList->value && $level->value <= $maxLevel->value));
+        }
+        $this->acceptedLevels = [];
+        foreach ($acceptedLevels as $level) {
+            $this->acceptedLevels[$level->value] = true;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isHandling(LogRecord $record): bool
+    {
+        return isset($this->acceptedLevels[$record->level->value]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handle(LogRecord $record): bool
+    {
+        if (!$this->isHandling($record)) {
+            return false;
+        }
+
+        if (\count($this->processors) > 0) {
+            $record = $this->processRecord($record);
+        }
+
+        $this->getHandler($record)->handle($record);
+
+        return false === $this->bubble;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handleBatch(array $records): void
+    {
+        $filtered = [];
+        foreach ($records as $record) {
+            if ($this->isHandling($record)) {
+                $filtered[] = $record;
+            }
+        }
+
+        if (\count($filtered) > 0) {
+            $this->getHandler($filtered[\count($filtered) - 1])->handleBatch($filtered);
+        }
+    }
+
+    /**
+     * Return the nested handler
+     *
+     * If the handler was provided as a factory, this will trigger the handler's instantiation.
+     */
+    public function getHandler(LogRecord|null $record = null): HandlerInterface
+    {
+        if (!$this->handler instanceof HandlerInterface) {
+            $handler = ($this->handler)($record, $this);
+            if (!$handler instanceof HandlerInterface) {
+                throw new \RuntimeException("The factory Closure should return a HandlerInterface");
+            }
+            $this->handler = $handler;
+        }
+
+        return $this->handler;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface
+    {
+        $handler = $this->getHandler();
+        if ($handler instanceof FormattableHandlerInterface) {
+            $handler->setFormatter($formatter);
+
+            return $this;
+        }
+
+        throw new \UnexpectedValueException('The nested handler of type '.\get_class($handler).' does not support formatters.');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFormatter(): FormatterInterface
+    {
+        $handler = $this->getHandler();
+        if ($handler instanceof FormattableHandlerInterface) {
+            return $handler->getFormatter();
+        }
+
+        throw new \UnexpectedValueException('The nested handler of type '.\get_class($handler).' does not support formatters.');
+    }
+
+    public function reset(): void
+    {
+        $this->resetProcessors();
+
+        if ($this->getHandler() instanceof ResettableInterface) {
+            $this->getHandler()->reset();
+        }
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/FingersCrossed/ActivationStrategyInterface.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/FingersCrossed/ActivationStrategyInterface.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler\FingersCrossed;
+
+use Monolog\LogRecord;
+
+/**
+ * Interface for activation strategies for the FingersCrossedHandler.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+interface ActivationStrategyInterface
+{
+    /**
+     * Returns whether the given record activates the handler.
+     */
+    public function isHandlerActivated(LogRecord $record): bool;
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/FingersCrossed/ChannelLevelActivationStrategy.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/FingersCrossed/ChannelLevelActivationStrategy.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler\FingersCrossed;
+
+use Monolog\Level;
+use Monolog\Logger;
+use Psr\Log\LogLevel;
+use Monolog\LogRecord;
+
+/**
+ * Channel and Error level based monolog activation strategy. Allows to trigger activation
+ * based on level per channel. e.g. trigger activation on level 'ERROR' by default, except
+ * for records of the 'sql' channel; those should trigger activation on level 'WARN'.
+ *
+ * Example:
+ *
+ * <code>
+ *   $activationStrategy = new ChannelLevelActivationStrategy(
+ *       Level::Critical,
+ *       array(
+ *           'request' => Level::Alert,
+ *           'sensitive' => Level::Error,
+ *       )
+ *   );
+ *   $handler = new FingersCrossedHandler(new StreamHandler('php://stderr'), $activationStrategy);
+ * </code>
+ *
+ * @author Mike Meessen <netmikey@gmail.com>
+ */
+class ChannelLevelActivationStrategy implements ActivationStrategyInterface
+{
+    private Level $defaultActionLevel;
+
+    /**
+     * @var array<string, Level>
+     */
+    private array $channelToActionLevel;
+
+    /**
+     * @param int|string|Level|LogLevel::*                $defaultActionLevel   The default action level to be used if the record's category doesn't match any
+     * @param array<string, int|string|Level|LogLevel::*> $channelToActionLevel An array that maps channel names to action levels.
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $defaultActionLevel
+     * @phpstan-param array<string, value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::*> $channelToActionLevel
+     */
+    public function __construct(int|string|Level $defaultActionLevel, array $channelToActionLevel = [])
+    {
+        $this->defaultActionLevel = Logger::toMonologLevel($defaultActionLevel);
+        $this->channelToActionLevel = array_map(Logger::toMonologLevel(...), $channelToActionLevel);
+    }
+
+    public function isHandlerActivated(LogRecord $record): bool
+    {
+        if (isset($this->channelToActionLevel[$record->channel])) {
+            return $record->level->value >= $this->channelToActionLevel[$record->channel]->value;
+        }
+
+        return $record->level->value >= $this->defaultActionLevel->value;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/FingersCrossed/ErrorLevelActivationStrategy.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/FingersCrossed/ErrorLevelActivationStrategy.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler\FingersCrossed;
+
+use Monolog\Level;
+use Monolog\LogRecord;
+use Monolog\Logger;
+use Psr\Log\LogLevel;
+
+/**
+ * Error level based activation strategy.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class ErrorLevelActivationStrategy implements ActivationStrategyInterface
+{
+    private Level $actionLevel;
+
+    /**
+     * @param int|string|Level $actionLevel Level or name or value
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $actionLevel
+     */
+    public function __construct(int|string|Level $actionLevel)
+    {
+        $this->actionLevel = Logger::toMonologLevel($actionLevel);
+    }
+
+    public function isHandlerActivated(LogRecord $record): bool
+    {
+        return $record->level->value >= $this->actionLevel->value;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/FingersCrossedHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/FingersCrossedHandler.php
@@ -1,0 +1,242 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Closure;
+use Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy;
+use Monolog\Handler\FingersCrossed\ActivationStrategyInterface;
+use Monolog\Level;
+use Monolog\Logger;
+use Monolog\ResettableInterface;
+use Monolog\Formatter\FormatterInterface;
+use Psr\Log\LogLevel;
+use Monolog\LogRecord;
+
+/**
+ * Buffers all records until a certain level is reached
+ *
+ * The advantage of this approach is that you don't get any clutter in your log files.
+ * Only requests which actually trigger an error (or whatever your actionLevel is) will be
+ * in the logs, but they will contain all records, not only those above the level threshold.
+ *
+ * You can then have a passthruLevel as well which means that at the end of the request,
+ * even if it did not get activated, it will still send through log records of e.g. at least a
+ * warning level.
+ *
+ * You can find the various activation strategies in the
+ * Monolog\Handler\FingersCrossed\ namespace.
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class FingersCrossedHandler extends Handler implements ProcessableHandlerInterface, ResettableInterface, FormattableHandlerInterface
+{
+    use ProcessableHandlerTrait;
+
+    /**
+     * Handler or factory Closure($record, $this)
+     *
+     * @phpstan-var (Closure(LogRecord|null, HandlerInterface): HandlerInterface)|HandlerInterface
+     */
+    protected Closure|HandlerInterface $handler;
+
+    protected ActivationStrategyInterface $activationStrategy;
+
+    protected bool $buffering = true;
+
+    protected int $bufferSize;
+
+    /** @var LogRecord[] */
+    protected array $buffer = [];
+
+    protected bool $stopBuffering;
+
+    protected Level|null $passthruLevel = null;
+
+    protected bool $bubble;
+
+    /**
+     * @phpstan-param (Closure(LogRecord|null, HandlerInterface): HandlerInterface)|HandlerInterface $handler
+     *
+     * @param Closure|HandlerInterface          $handler            Handler or factory Closure($record|null, $fingersCrossedHandler).
+     * @param int|string|Level|LogLevel::*|null $activationStrategy Strategy which determines when this handler takes action, or a level name/value at which the handler is activated
+     * @param int                               $bufferSize         How many entries should be buffered at most, beyond that the oldest items are removed from the buffer.
+     * @param bool                              $bubble             Whether the messages that are handled can bubble up the stack or not
+     * @param bool                              $stopBuffering      Whether the handler should stop buffering after being triggered (default true)
+     * @param int|string|Level|LogLevel::*|null $passthruLevel      Minimum level to always flush to handler on close, even if strategy not triggered
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::*|ActivationStrategyInterface|null $activationStrategy
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::*|null $passthruLevel
+     */
+    public function __construct(Closure|HandlerInterface $handler, int|string|Level|ActivationStrategyInterface|null $activationStrategy = null, int $bufferSize = 0, bool $bubble = true, bool $stopBuffering = true, int|string|Level|null $passthruLevel = null)
+    {
+        if (null === $activationStrategy) {
+            $activationStrategy = new ErrorLevelActivationStrategy(Level::Warning);
+        }
+
+        // convert simple int activationStrategy to an object
+        if (!$activationStrategy instanceof ActivationStrategyInterface) {
+            $activationStrategy = new ErrorLevelActivationStrategy($activationStrategy);
+        }
+
+        $this->handler = $handler;
+        $this->activationStrategy = $activationStrategy;
+        $this->bufferSize = $bufferSize;
+        $this->bubble = $bubble;
+        $this->stopBuffering = $stopBuffering;
+
+        if ($passthruLevel !== null) {
+            $this->passthruLevel = Logger::toMonologLevel($passthruLevel);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isHandling(LogRecord $record): bool
+    {
+        return true;
+    }
+
+    /**
+     * Manually activate this logger regardless of the activation strategy
+     */
+    public function activate(): void
+    {
+        if ($this->stopBuffering) {
+            $this->buffering = false;
+        }
+
+        $this->getHandler(end($this->buffer) ?: null)->handleBatch($this->buffer);
+        $this->buffer = [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handle(LogRecord $record): bool
+    {
+        if (\count($this->processors) > 0) {
+            $record = $this->processRecord($record);
+        }
+
+        if ($this->buffering) {
+            $this->buffer[] = $record;
+            if ($this->bufferSize > 0 && \count($this->buffer) > $this->bufferSize) {
+                array_shift($this->buffer);
+            }
+            if ($this->activationStrategy->isHandlerActivated($record)) {
+                $this->activate();
+            }
+        } else {
+            $this->getHandler($record)->handle($record);
+        }
+
+        return false === $this->bubble;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function close(): void
+    {
+        $this->flushBuffer();
+
+        $this->getHandler()->close();
+    }
+
+    public function reset(): void
+    {
+        $this->flushBuffer();
+
+        $this->resetProcessors();
+
+        if ($this->getHandler() instanceof ResettableInterface) {
+            $this->getHandler()->reset();
+        }
+    }
+
+    /**
+     * Clears the buffer without flushing any messages down to the wrapped handler.
+     *
+     * It also resets the handler to its initial buffering state.
+     */
+    public function clear(): void
+    {
+        $this->buffer = [];
+        $this->reset();
+    }
+
+    /**
+     * Resets the state of the handler. Stops forwarding records to the wrapped handler.
+     */
+    private function flushBuffer(): void
+    {
+        if (null !== $this->passthruLevel) {
+            $passthruLevel = $this->passthruLevel;
+            $this->buffer = array_filter($this->buffer, static function ($record) use ($passthruLevel) {
+                return $passthruLevel->includes($record->level);
+            });
+            if (\count($this->buffer) > 0) {
+                $this->getHandler(end($this->buffer))->handleBatch($this->buffer);
+            }
+        }
+
+        $this->buffer = [];
+        $this->buffering = true;
+    }
+
+    /**
+     * Return the nested handler
+     *
+     * If the handler was provided as a factory, this will trigger the handler's instantiation.
+     */
+    public function getHandler(LogRecord|null $record = null): HandlerInterface
+    {
+        if (!$this->handler instanceof HandlerInterface) {
+            $handler = ($this->handler)($record, $this);
+            if (!$handler instanceof HandlerInterface) {
+                throw new \RuntimeException("The factory Closure should return a HandlerInterface");
+            }
+            $this->handler = $handler;
+        }
+
+        return $this->handler;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface
+    {
+        $handler = $this->getHandler();
+        if ($handler instanceof FormattableHandlerInterface) {
+            $handler->setFormatter($formatter);
+
+            return $this;
+        }
+
+        throw new \UnexpectedValueException('The nested handler of type '.\get_class($handler).' does not support formatters.');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFormatter(): FormatterInterface
+    {
+        $handler = $this->getHandler();
+        if ($handler instanceof FormattableHandlerInterface) {
+            return $handler->getFormatter();
+        }
+
+        throw new \UnexpectedValueException('The nested handler of type '.\get_class($handler).' does not support formatters.');
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/FirePHPHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/FirePHPHandler.php
@@ -1,0 +1,174 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\WildfireFormatter;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\LogRecord;
+
+/**
+ * Simple FirePHP Handler (http://www.firephp.org/), which uses the Wildfire protocol.
+ *
+ * @author Eric Clemmons (@ericclemmons) <eric@uxdriven.com>
+ */
+class FirePHPHandler extends AbstractProcessingHandler
+{
+    use WebRequestRecognizerTrait;
+
+    /**
+     * WildFire JSON header message format
+     */
+    protected const PROTOCOL_URI = 'http://meta.wildfirehq.org/Protocol/JsonStream/0.2';
+
+    /**
+     * FirePHP structure for parsing messages & their presentation
+     */
+    protected const STRUCTURE_URI = 'http://meta.firephp.org/Wildfire/Structure/FirePHP/FirebugConsole/0.1';
+
+    /**
+     * Must reference a "known" plugin, otherwise headers won't display in FirePHP
+     */
+    protected const PLUGIN_URI = 'http://meta.firephp.org/Wildfire/Plugin/FirePHP/Library-FirePHPCore/0.3';
+
+    /**
+     * Header prefix for Wildfire to recognize & parse headers
+     */
+    protected const HEADER_PREFIX = 'X-Wf';
+
+    /**
+     * Whether or not Wildfire vendor-specific headers have been generated & sent yet
+     */
+    protected static bool $initialized = false;
+
+    /**
+     * Shared static message index between potentially multiple handlers
+     */
+    protected static int $messageIndex = 1;
+
+    protected static bool $sendHeaders = true;
+
+    /**
+     * Base header creation function used by init headers & record headers
+     *
+     * @param array<int|string> $meta    Wildfire Plugin, Protocol & Structure Indexes
+     * @param string            $message Log message
+     *
+     * @return array<string, string> Complete header string ready for the client as key and message as value
+     *
+     * @phpstan-return non-empty-array<string, string>
+     */
+    protected function createHeader(array $meta, string $message): array
+    {
+        $header = sprintf('%s-%s', static::HEADER_PREFIX, join('-', $meta));
+
+        return [$header => $message];
+    }
+
+    /**
+     * Creates message header from record
+     *
+     * @return array<string, string>
+     *
+     * @phpstan-return non-empty-array<string, string>
+     *
+     * @see createHeader()
+     */
+    protected function createRecordHeader(LogRecord $record): array
+    {
+        // Wildfire is extensible to support multiple protocols & plugins in a single request,
+        // but we're not taking advantage of that (yet), so we're using "1" for simplicity's sake.
+        return $this->createHeader(
+            [1, 1, 1, self::$messageIndex++],
+            $record->formatted
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new WildfireFormatter();
+    }
+
+    /**
+     * Wildfire initialization headers to enable message parsing
+     *
+     * @see createHeader()
+     * @see sendHeader()
+     *
+     * @return array<string, string>
+     */
+    protected function getInitHeaders(): array
+    {
+        // Initial payload consists of required headers for Wildfire
+        return array_merge(
+            $this->createHeader(['Protocol', 1], static::PROTOCOL_URI),
+            $this->createHeader([1, 'Structure', 1], static::STRUCTURE_URI),
+            $this->createHeader([1, 'Plugin', 1], static::PLUGIN_URI)
+        );
+    }
+
+    /**
+     * Send header string to the client
+     */
+    protected function sendHeader(string $header, string $content): void
+    {
+        if (!headers_sent() && self::$sendHeaders) {
+            header(sprintf('%s: %s', $header, $content));
+        }
+    }
+
+    /**
+     * Creates & sends header for a record, ensuring init headers have been sent prior
+     *
+     * @see sendHeader()
+     * @see sendInitHeaders()
+     */
+    protected function write(LogRecord $record): void
+    {
+        if (!self::$sendHeaders || !$this->isWebRequest()) {
+            return;
+        }
+
+        // WildFire-specific headers must be sent prior to any messages
+        if (!self::$initialized) {
+            self::$initialized = true;
+
+            self::$sendHeaders = $this->headersAccepted();
+            if (!self::$sendHeaders) {
+                return;
+            }
+
+            foreach ($this->getInitHeaders() as $header => $content) {
+                $this->sendHeader($header, $content);
+            }
+        }
+
+        $header = $this->createRecordHeader($record);
+        if (trim(current($header)) !== '') {
+            $this->sendHeader(key($header), current($header));
+        }
+    }
+
+    /**
+     * Verifies if the headers are accepted by the current user agent
+     */
+    protected function headersAccepted(): bool
+    {
+        if (isset($_SERVER['HTTP_USER_AGENT']) && 1 === preg_match('{\bFirePHP/\d+\.\d+\b}', $_SERVER['HTTP_USER_AGENT'])) {
+            return true;
+        }
+
+        return isset($_SERVER['HTTP_X_FIREPHP_VERSION']);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/FleepHookHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/FleepHookHandler.php
@@ -1,0 +1,132 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Level;
+use Monolog\LogRecord;
+
+/**
+ * Sends logs to Fleep.io using Webhook integrations
+ *
+ * You'll need a Fleep.io account to use this handler.
+ *
+ * @see https://fleep.io/integrations/webhooks/ Fleep Webhooks Documentation
+ * @author Ando Roots <ando@sqroot.eu>
+ */
+class FleepHookHandler extends SocketHandler
+{
+    protected const FLEEP_HOST = 'fleep.io';
+
+    protected const FLEEP_HOOK_URI = '/hook/';
+
+    /**
+     * @var string Webhook token (specifies the conversation where logs are sent)
+     */
+    protected string $token;
+
+    /**
+     * Construct a new Fleep.io Handler.
+     *
+     * For instructions on how to create a new web hook in your conversations
+     * see https://fleep.io/integrations/webhooks/
+     *
+     * @param  string                    $token Webhook token
+     * @throws MissingExtensionException if OpenSSL is missing
+     */
+    public function __construct(
+        string $token,
+        $level = Level::Debug,
+        bool $bubble = true,
+        bool $persistent = false,
+        float $timeout = 0.0,
+        float $writingTimeout = 10.0,
+        ?float $connectionTimeout = null,
+        ?int $chunkSize = null
+    ) {
+        if (!\extension_loaded('openssl')) {
+            throw new MissingExtensionException('The OpenSSL PHP extension is required to use the FleepHookHandler');
+        }
+
+        $this->token = $token;
+
+        $connectionString = 'ssl://' . static::FLEEP_HOST . ':443';
+        parent::__construct(
+            $connectionString,
+            $level,
+            $bubble,
+            $persistent,
+            $timeout,
+            $writingTimeout,
+            $connectionTimeout,
+            $chunkSize
+        );
+    }
+
+    /**
+     * Returns the default formatter to use with this handler
+     *
+     * Overloaded to remove empty context and extra arrays from the end of the log message.
+     *
+     * @return LineFormatter
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new LineFormatter(null, null, true, true);
+    }
+
+    /**
+     * Handles a log record
+     */
+    public function write(LogRecord $record): void
+    {
+        parent::write($record);
+        $this->closeSocket();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function generateDataStream(LogRecord $record): string
+    {
+        $content = $this->buildContent($record);
+
+        return $this->buildHeader($content) . $content;
+    }
+
+    /**
+     * Builds the header of the API Call
+     */
+    private function buildHeader(string $content): string
+    {
+        $header = "POST " . static::FLEEP_HOOK_URI . $this->token . " HTTP/1.1\r\n";
+        $header .= "Host: " . static::FLEEP_HOST . "\r\n";
+        $header .= "Content-Type: application/x-www-form-urlencoded\r\n";
+        $header .= "Content-Length: " . \strlen($content) . "\r\n";
+        $header .= "\r\n";
+
+        return $header;
+    }
+
+    /**
+     * Builds the body of API call
+     */
+    private function buildContent(LogRecord $record): string
+    {
+        $dataArray = [
+            'message' => $record->formatted,
+        ];
+
+        return http_build_query($dataArray);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/FlowdockHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/FlowdockHandler.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\Utils;
+use Monolog\Formatter\FlowdockFormatter;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\LogRecord;
+
+/**
+ * Sends notifications through the Flowdock push API
+ *
+ * This must be configured with a FlowdockFormatter instance via setFormatter()
+ *
+ * Notes:
+ * API token - Flowdock API token
+ *
+ * @author Dominik Liebler <liebler.dominik@gmail.com>
+ * @see https://www.flowdock.com/api/push
+ * @deprecated Since 2.9.0 and 3.3.0, Flowdock was shutdown we will thus drop this handler in Monolog 4
+ */
+class FlowdockHandler extends SocketHandler
+{
+    protected string $apiToken;
+
+    /**
+     * @throws MissingExtensionException if OpenSSL is missing
+     */
+    public function __construct(
+        string $apiToken,
+        $level = Level::Debug,
+        bool $bubble = true,
+        bool $persistent = false,
+        float $timeout = 0.0,
+        float $writingTimeout = 10.0,
+        ?float $connectionTimeout = null,
+        ?int $chunkSize = null
+    ) {
+        if (!\extension_loaded('openssl')) {
+            throw new MissingExtensionException('The OpenSSL PHP extension is required to use the FlowdockHandler');
+        }
+
+        parent::__construct(
+            'ssl://api.flowdock.com:443',
+            $level,
+            $bubble,
+            $persistent,
+            $timeout,
+            $writingTimeout,
+            $connectionTimeout,
+            $chunkSize
+        );
+        $this->apiToken = $apiToken;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface
+    {
+        if (!$formatter instanceof FlowdockFormatter) {
+            throw new \InvalidArgumentException('The FlowdockHandler requires an instance of Monolog\Formatter\FlowdockFormatter to function correctly');
+        }
+
+        return parent::setFormatter($formatter);
+    }
+
+    /**
+     * Gets the default formatter.
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        throw new \InvalidArgumentException('The FlowdockHandler must be configured (via setFormatter) with an instance of Monolog\Formatter\FlowdockFormatter to function correctly');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        parent::write($record);
+
+        $this->closeSocket();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function generateDataStream(LogRecord $record): string
+    {
+        $content = $this->buildContent($record);
+
+        return $this->buildHeader($content) . $content;
+    }
+
+    /**
+     * Builds the body of API call
+     */
+    private function buildContent(LogRecord $record): string
+    {
+        return Utils::jsonEncode($record->formatted);
+    }
+
+    /**
+     * Builds the header of the API Call
+     */
+    private function buildHeader(string $content): string
+    {
+        $header = "POST /v1/messages/team_inbox/" . $this->apiToken . " HTTP/1.1\r\n";
+        $header .= "Host: api.flowdock.com\r\n";
+        $header .= "Content-Type: application/json\r\n";
+        $header .= "Content-Length: " . \strlen($content) . "\r\n";
+        $header .= "\r\n";
+
+        return $header;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/FormattableHandlerInterface.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/FormattableHandlerInterface.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\FormatterInterface;
+
+/**
+ * Interface to describe loggers that have a formatter
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+interface FormattableHandlerInterface
+{
+    /**
+     * Sets the formatter.
+     *
+     * @return HandlerInterface self
+     */
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface;
+
+    /**
+     * Gets the formatter.
+     */
+    public function getFormatter(): FormatterInterface;
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/FormattableHandlerTrait.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/FormattableHandlerTrait.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\LineFormatter;
+
+/**
+ * Helper trait for implementing FormattableInterface
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+trait FormattableHandlerTrait
+{
+    protected FormatterInterface|null $formatter = null;
+
+    /**
+     * @inheritDoc
+     */
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface
+    {
+        $this->formatter = $formatter;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFormatter(): FormatterInterface
+    {
+        if (null === $this->formatter) {
+            $this->formatter = $this->getDefaultFormatter();
+        }
+
+        return $this->formatter;
+    }
+
+    /**
+     * Gets the default formatter.
+     *
+     * Overwrite this if the LineFormatter is not a good default for your handler.
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new LineFormatter();
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/GelfHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/GelfHandler.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Gelf\PublisherInterface;
+use Monolog\Level;
+use Monolog\Formatter\GelfMessageFormatter;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\LogRecord;
+
+/**
+ * Handler to send messages to a Graylog2 (http://www.graylog2.org) server
+ *
+ * @author Matt Lehner <mlehner@gmail.com>
+ * @author Benjamin Zikarsky <benjamin@zikarsky.de>
+ */
+class GelfHandler extends AbstractProcessingHandler
+{
+    /**
+     * @var PublisherInterface the publisher object that sends the message to the server
+     */
+    protected PublisherInterface $publisher;
+
+    /**
+     * @param PublisherInterface $publisher a gelf publisher object
+     */
+    public function __construct(PublisherInterface $publisher, int|string|Level $level = Level::Debug, bool $bubble = true)
+    {
+        parent::__construct($level, $bubble);
+
+        $this->publisher = $publisher;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        $this->publisher->publish($record->formatted);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new GelfMessageFormatter();
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/GroupHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/GroupHandler.php
@@ -1,0 +1,130 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\ResettableInterface;
+use Monolog\LogRecord;
+
+/**
+ * Forwards records to multiple handlers
+ *
+ * @author Lenar Lõhmus <lenar@city.ee>
+ */
+class GroupHandler extends Handler implements ProcessableHandlerInterface, ResettableInterface
+{
+    use ProcessableHandlerTrait;
+
+    /** @var HandlerInterface[] */
+    protected array $handlers;
+    protected bool $bubble;
+
+    /**
+     * @param HandlerInterface[] $handlers Array of Handlers.
+     * @param bool               $bubble   Whether the messages that are handled can bubble up the stack or not
+     *
+     * @throws \InvalidArgumentException if an unsupported handler is set
+     */
+    public function __construct(array $handlers, bool $bubble = true)
+    {
+        foreach ($handlers as $handler) {
+            if (!$handler instanceof HandlerInterface) {
+                throw new \InvalidArgumentException('The first argument of the GroupHandler must be an array of HandlerInterface instances.');
+            }
+        }
+
+        $this->handlers = $handlers;
+        $this->bubble = $bubble;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isHandling(LogRecord $record): bool
+    {
+        foreach ($this->handlers as $handler) {
+            if ($handler->isHandling($record)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handle(LogRecord $record): bool
+    {
+        if (\count($this->processors) > 0) {
+            $record = $this->processRecord($record);
+        }
+
+        foreach ($this->handlers as $handler) {
+            $handler->handle(clone $record);
+        }
+
+        return false === $this->bubble;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handleBatch(array $records): void
+    {
+        if (\count($this->processors) > 0) {
+            $processed = [];
+            foreach ($records as $record) {
+                $processed[] = $this->processRecord($record);
+            }
+            $records = $processed;
+        }
+
+        foreach ($this->handlers as $handler) {
+            $handler->handleBatch(array_map(fn ($record) => clone $record, $records));
+        }
+    }
+
+    public function reset(): void
+    {
+        $this->resetProcessors();
+
+        foreach ($this->handlers as $handler) {
+            if ($handler instanceof ResettableInterface) {
+                $handler->reset();
+            }
+        }
+    }
+
+    public function close(): void
+    {
+        parent::close();
+
+        foreach ($this->handlers as $handler) {
+            $handler->close();
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface
+    {
+        foreach ($this->handlers as $handler) {
+            if ($handler instanceof FormattableHandlerInterface) {
+                $handler->setFormatter($formatter);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/Handler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/Handler.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+/**
+ * Base Handler class providing basic close() support as well as handleBatch
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+abstract class Handler implements HandlerInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function handleBatch(array $records): void
+    {
+        foreach ($records as $record) {
+            $this->handle($record);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function close(): void
+    {
+    }
+
+    public function __destruct()
+    {
+        try {
+            $this->close();
+        } catch (\Throwable $e) {
+            // do nothing
+        }
+    }
+
+    public function __serialize(): array
+    {
+        $this->close();
+
+        return (array) $this;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/HandlerInterface.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/HandlerInterface.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\LogRecord;
+
+/**
+ * Interface that all Monolog Handlers must implement
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+interface HandlerInterface
+{
+    /**
+     * Checks whether the given record will be handled by this handler.
+     *
+     * This is mostly done for performance reasons, to avoid calling processors for nothing.
+     *
+     * Handlers should still check the record levels within handle(), returning false in isHandling()
+     * is no guarantee that handle() will not be called, and isHandling() might not be called
+     * for a given record.
+     *
+     * @param LogRecord $record Partial log record having only a level initialized
+     */
+    public function isHandling(LogRecord $record): bool;
+
+    /**
+     * Handles a record.
+     *
+     * All records may be passed to this method, and the handler should discard
+     * those that it does not want to handle.
+     *
+     * The return value of this function controls the bubbling process of the handler stack.
+     * Unless the bubbling is interrupted (by returning true), the Logger class will keep on
+     * calling further handlers in the stack with a given log record.
+     *
+     * @param  LogRecord $record The record to handle
+     * @return bool      true means that this handler handled the record, and that bubbling is not permitted.
+     *                   false means the record was either not processed or that this handler allows bubbling.
+     */
+    public function handle(LogRecord $record): bool;
+
+    /**
+     * Handles a set of records at once.
+     *
+     * @param array<LogRecord> $records The records to handle
+     */
+    public function handleBatch(array $records): void;
+
+    /**
+     * Closes the handler.
+     *
+     * Ends a log cycle and frees all resources used by the handler.
+     *
+     * Closing a Handler means flushing all buffers and freeing any open resources/handles.
+     *
+     * Implementations have to be idempotent (i.e. it should be possible to call close several times without breakage)
+     * and ideally handlers should be able to reopen themselves on handle() after they have been closed.
+     *
+     * This is useful at the end of a request and will be called automatically when the object
+     * is destroyed if you extend Monolog\Handler\Handler.
+     *
+     * If you are thinking of calling this method yourself, most likely you should be
+     * calling ResettableInterface::reset instead. Have a look.
+     */
+    public function close(): void;
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/HandlerWrapper.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/HandlerWrapper.php
@@ -1,0 +1,134 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\ResettableInterface;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\LogRecord;
+
+/**
+ * This simple wrapper class can be used to extend handlers functionality.
+ *
+ * Example: A custom filtering that can be applied to any handler.
+ *
+ * Inherit from this class and override handle() like this:
+ *
+ *   public function handle(LogRecord $record)
+ *   {
+ *        if ($record meets certain conditions) {
+ *            return false;
+ *        }
+ *        return $this->handler->handle($record);
+ *   }
+ *
+ * @author Alexey Karapetov <alexey@karapetov.com>
+ */
+class HandlerWrapper implements HandlerInterface, ProcessableHandlerInterface, FormattableHandlerInterface, ResettableInterface
+{
+    protected HandlerInterface $handler;
+
+    public function __construct(HandlerInterface $handler)
+    {
+        $this->handler = $handler;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isHandling(LogRecord $record): bool
+    {
+        return $this->handler->isHandling($record);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handle(LogRecord $record): bool
+    {
+        return $this->handler->handle($record);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handleBatch(array $records): void
+    {
+        $this->handler->handleBatch($records);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function close(): void
+    {
+        $this->handler->close();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function pushProcessor(callable $callback): HandlerInterface
+    {
+        if ($this->handler instanceof ProcessableHandlerInterface) {
+            $this->handler->pushProcessor($callback);
+
+            return $this;
+        }
+
+        throw new \LogicException('The wrapped handler does not implement ' . ProcessableHandlerInterface::class);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function popProcessor(): callable
+    {
+        if ($this->handler instanceof ProcessableHandlerInterface) {
+            return $this->handler->popProcessor();
+        }
+
+        throw new \LogicException('The wrapped handler does not implement ' . ProcessableHandlerInterface::class);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface
+    {
+        if ($this->handler instanceof FormattableHandlerInterface) {
+            $this->handler->setFormatter($formatter);
+
+            return $this;
+        }
+
+        throw new \LogicException('The wrapped handler does not implement ' . FormattableHandlerInterface::class);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFormatter(): FormatterInterface
+    {
+        if ($this->handler instanceof FormattableHandlerInterface) {
+            return $this->handler->getFormatter();
+        }
+
+        throw new \LogicException('The wrapped handler does not implement ' . FormattableHandlerInterface::class);
+    }
+
+    public function reset(): void
+    {
+        if ($this->handler instanceof ResettableInterface) {
+            $this->handler->reset();
+        }
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/IFTTTHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/IFTTTHandler.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\Utils;
+use Monolog\LogRecord;
+
+/**
+ * IFTTTHandler uses cURL to trigger IFTTT Maker actions
+ *
+ * Register a secret key and trigger/event name at https://ifttt.com/maker
+ *
+ * value1 will be the channel from monolog's Logger constructor,
+ * value2 will be the level name (ERROR, WARNING, ..)
+ * value3 will be the log record's message
+ *
+ * @author Nehal Patel <nehal@nehalpatel.me>
+ */
+class IFTTTHandler extends AbstractProcessingHandler
+{
+    private string $eventName;
+    private string $secretKey;
+
+    /**
+     * @param string $eventName The name of the IFTTT Maker event that should be triggered
+     * @param string $secretKey A valid IFTTT secret key
+     *
+     * @throws MissingExtensionException If the curl extension is missing
+     */
+    public function __construct(string $eventName, string $secretKey, int|string|Level $level = Level::Error, bool $bubble = true)
+    {
+        if (!\extension_loaded('curl')) {
+            throw new MissingExtensionException('The curl extension is needed to use the IFTTTHandler');
+        }
+
+        $this->eventName = $eventName;
+        $this->secretKey = $secretKey;
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function write(LogRecord $record): void
+    {
+        $postData = [
+            "value1" => $record->channel,
+            "value2" => $record["level_name"],
+            "value3" => $record->message,
+        ];
+        $postString = Utils::jsonEncode($postData);
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, "https://maker.ifttt.com/trigger/" . $this->eventName . "/with/key/" . $this->secretKey);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $postString);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            "Content-Type: application/json",
+        ]);
+
+        Curl\Util::execute($ch);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/InsightOpsHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/InsightOpsHandler.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\LogRecord;
+
+/**
+ * Inspired on LogEntriesHandler.
+ *
+ * @author Robert Kaufmann III <rok3@rok3.me>
+ * @author Gabriel Machado <gabriel.ms1@hotmail.com>
+ */
+class InsightOpsHandler extends SocketHandler
+{
+    protected string $logToken;
+
+    /**
+     * @param string $token  Log token supplied by InsightOps
+     * @param string $region Region where InsightOps account is hosted. Could be 'us' or 'eu'.
+     * @param bool   $useSSL Whether or not SSL encryption should be used
+     *
+     * @throws MissingExtensionException If SSL encryption is set to true and OpenSSL is missing
+     */
+    public function __construct(
+        string $token,
+        string $region = 'us',
+        bool $useSSL = true,
+        $level = Level::Debug,
+        bool $bubble = true,
+        bool $persistent = false,
+        float $timeout = 0.0,
+        float $writingTimeout = 10.0,
+        ?float $connectionTimeout = null,
+        ?int $chunkSize = null
+    ) {
+        if ($useSSL && !\extension_loaded('openssl')) {
+            throw new MissingExtensionException('The OpenSSL PHP plugin is required to use SSL encrypted connection for InsightOpsHandler');
+        }
+
+        $endpoint = $useSSL
+            ? 'ssl://' . $region . '.data.logs.insight.rapid7.com:443'
+            : $region . '.data.logs.insight.rapid7.com:80';
+
+        parent::__construct(
+            $endpoint,
+            $level,
+            $bubble,
+            $persistent,
+            $timeout,
+            $writingTimeout,
+            $connectionTimeout,
+            $chunkSize
+        );
+        $this->logToken = $token;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function generateDataStream(LogRecord $record): string
+    {
+        return $this->logToken . ' ' . $record->formatted;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/LogEntriesHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/LogEntriesHandler.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\LogRecord;
+
+/**
+ * @author Robert Kaufmann III <rok3@rok3.me>
+ */
+class LogEntriesHandler extends SocketHandler
+{
+    protected string $logToken;
+
+    /**
+     * @param string $token  Log token supplied by LogEntries
+     * @param bool   $useSSL Whether or not SSL encryption should be used.
+     * @param string $host   Custom hostname to send the data to if needed
+     *
+     * @throws MissingExtensionException If SSL encryption is set to true and OpenSSL is missing
+     */
+    public function __construct(
+        string $token,
+        bool $useSSL = true,
+        $level = Level::Debug,
+        bool $bubble = true,
+        string $host = 'data.logentries.com',
+        bool $persistent = false,
+        float $timeout = 0.0,
+        float $writingTimeout = 10.0,
+        ?float $connectionTimeout = null,
+        ?int $chunkSize = null
+    ) {
+        if ($useSSL && !\extension_loaded('openssl')) {
+            throw new MissingExtensionException('The OpenSSL PHP plugin is required to use SSL encrypted connection for LogEntriesHandler');
+        }
+
+        $endpoint = $useSSL ? 'ssl://' . $host . ':443' : $host . ':80';
+        parent::__construct(
+            $endpoint,
+            $level,
+            $bubble,
+            $persistent,
+            $timeout,
+            $writingTimeout,
+            $connectionTimeout,
+            $chunkSize
+        );
+        $this->logToken = $token;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function generateDataStream(LogRecord $record): string
+    {
+        return $this->logToken . ' ' . $record->formatted;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/LogglyHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/LogglyHandler.php
@@ -1,0 +1,156 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\LogglyFormatter;
+use CurlHandle;
+use Monolog\LogRecord;
+
+/**
+ * Sends errors to Loggly.
+ *
+ * @author Przemek Sobstel <przemek@sobstel.org>
+ * @author Adam Pancutt <adam@pancutt.com>
+ * @author Gregory Barchard <gregory@barchard.net>
+ */
+class LogglyHandler extends AbstractProcessingHandler
+{
+    protected const HOST = 'logs-01.loggly.com';
+    protected const ENDPOINT_SINGLE = 'inputs';
+    protected const ENDPOINT_BATCH = 'bulk';
+
+    /**
+     * Caches the curl handlers for every given endpoint.
+     *
+     * @var CurlHandle[]
+     */
+    protected array $curlHandlers = [];
+
+    protected string $token;
+
+    /** @var string[] */
+    protected array $tag = [];
+
+    /**
+     * @param string $token API token supplied by Loggly
+     *
+     * @throws MissingExtensionException If the curl extension is missing
+     */
+    public function __construct(string $token, int|string|Level $level = Level::Debug, bool $bubble = true)
+    {
+        if (!\extension_loaded('curl')) {
+            throw new MissingExtensionException('The curl extension is needed to use the LogglyHandler');
+        }
+
+        $this->token = $token;
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * Loads and returns the shared curl handler for the given endpoint.
+     */
+    protected function getCurlHandler(string $endpoint): CurlHandle
+    {
+        if (!\array_key_exists($endpoint, $this->curlHandlers)) {
+            $this->curlHandlers[$endpoint] = $this->loadCurlHandle($endpoint);
+        }
+
+        return $this->curlHandlers[$endpoint];
+    }
+
+    /**
+     * Starts a fresh curl session for the given endpoint and returns its handler.
+     */
+    private function loadCurlHandle(string $endpoint): CurlHandle
+    {
+        $url = sprintf("https://%s/%s/%s/", static::HOST, $endpoint, $this->token);
+
+        $ch = curl_init();
+
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+        return $ch;
+    }
+
+    /**
+     * @param  string[]|string $tag
+     * @return $this
+     */
+    public function setTag(string|array $tag): self
+    {
+        if ('' === $tag || [] === $tag) {
+            $this->tag = [];
+        } else {
+            $this->tag = \is_array($tag) ? $tag : [$tag];
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param  string[]|string $tag
+     * @return $this
+     */
+    public function addTag(string|array $tag): self
+    {
+        if ('' !== $tag) {
+            $tag = \is_array($tag) ? $tag : [$tag];
+            $this->tag = array_unique(array_merge($this->tag, $tag));
+        }
+
+        return $this;
+    }
+
+    protected function write(LogRecord $record): void
+    {
+        $this->send($record->formatted, static::ENDPOINT_SINGLE);
+    }
+
+    public function handleBatch(array $records): void
+    {
+        $level = $this->level;
+
+        $records = array_filter($records, function ($record) use ($level) {
+            return ($record->level->value >= $level->value);
+        });
+
+        if (\count($records) > 0) {
+            $this->send($this->getFormatter()->formatBatch($records), static::ENDPOINT_BATCH);
+        }
+    }
+
+    protected function send(string $data, string $endpoint): void
+    {
+        $ch = $this->getCurlHandler($endpoint);
+
+        $headers = ['Content-Type: application/json'];
+
+        if (\count($this->tag) > 0) {
+            $headers[] = 'X-LOGGLY-TAG: '.implode(',', $this->tag);
+        }
+
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+
+        Curl\Util::execute($ch, 5);
+    }
+
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new LogglyFormatter();
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/LogmaticHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/LogmaticHandler.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\LogmaticFormatter;
+use Monolog\LogRecord;
+
+/**
+ * @author Julien Breux <julien.breux@gmail.com>
+ */
+class LogmaticHandler extends SocketHandler
+{
+    private string $logToken;
+
+    private string $hostname;
+
+    private string $appName;
+
+    /**
+     * @param string $token    Log token supplied by Logmatic.
+     * @param string $hostname Host name supplied by Logmatic.
+     * @param string $appName  Application name supplied by Logmatic.
+     * @param bool   $useSSL   Whether or not SSL encryption should be used.
+     *
+     * @throws MissingExtensionException If SSL encryption is set to true and OpenSSL is missing
+     */
+    public function __construct(
+        string $token,
+        string $hostname = '',
+        string $appName = '',
+        bool $useSSL = true,
+        $level = Level::Debug,
+        bool $bubble = true,
+        bool $persistent = false,
+        float $timeout = 0.0,
+        float $writingTimeout = 10.0,
+        ?float $connectionTimeout = null,
+        ?int $chunkSize = null
+    ) {
+        if ($useSSL && !\extension_loaded('openssl')) {
+            throw new MissingExtensionException('The OpenSSL PHP extension is required to use SSL encrypted connection for LogmaticHandler');
+        }
+
+        $endpoint = $useSSL ? 'ssl://api.logmatic.io:10515' : 'api.logmatic.io:10514';
+        $endpoint .= '/v1/';
+
+        parent::__construct(
+            $endpoint,
+            $level,
+            $bubble,
+            $persistent,
+            $timeout,
+            $writingTimeout,
+            $connectionTimeout,
+            $chunkSize
+        );
+
+        $this->logToken = $token;
+        $this->hostname = $hostname;
+        $this->appName  = $appName;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function generateDataStream(LogRecord $record): string
+    {
+        return $this->logToken . ' ' . $record->formatted;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        $formatter = new LogmaticFormatter();
+
+        if ($this->hostname !== '') {
+            $formatter->setHostname($this->hostname);
+        }
+        if ($this->appName !== '') {
+            $formatter->setAppName($this->appName);
+        }
+
+        return $formatter;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/MailHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/MailHandler.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\HtmlFormatter;
+use Monolog\LogRecord;
+
+/**
+ * Base class for all mail handlers
+ *
+ * @author Gyula Sallai
+ */
+abstract class MailHandler extends AbstractProcessingHandler
+{
+    /**
+     * @inheritDoc
+     */
+    public function handleBatch(array $records): void
+    {
+        $messages = [];
+
+        foreach ($records as $record) {
+            if ($record->level->isLowerThan($this->level)) {
+                continue;
+            }
+
+            $message = $this->processRecord($record);
+            $messages[] = $message;
+        }
+
+        if (\count($messages) > 0) {
+            $this->send((string) $this->getFormatter()->formatBatch($messages), $messages);
+        }
+    }
+
+    /**
+     * Send a mail with the given content
+     *
+     * @param string $content formatted email body to be sent
+     * @param array  $records the array of log records that formed this content
+     *
+     * @phpstan-param non-empty-array<LogRecord> $records
+     */
+    abstract protected function send(string $content, array $records): void;
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        $this->send((string) $record->formatted, [$record]);
+    }
+
+    /**
+     * @phpstan-param non-empty-array<LogRecord> $records
+     */
+    protected function getHighestRecord(array $records): LogRecord
+    {
+        $highestRecord = null;
+        foreach ($records as $record) {
+            if ($highestRecord === null || $record->level->isHigherThan($highestRecord->level)) {
+                $highestRecord = $record;
+            }
+        }
+
+        return $highestRecord;
+    }
+
+    protected function isHtmlBody(string $body): bool
+    {
+        return ($body[0] ?? null) === '<';
+    }
+
+    /**
+     * Gets the default formatter.
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new HtmlFormatter();
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/MandrillHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/MandrillHandler.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Swift;
+use Swift_Message;
+
+/**
+ * MandrillHandler uses cURL to send the emails to the Mandrill API
+ *
+ * @author Adam Nicholson <adamnicholson10@gmail.com>
+ */
+class MandrillHandler extends MailHandler
+{
+    protected Swift_Message $message;
+    protected string $apiKey;
+
+    /**
+     * @phpstan-param (Swift_Message|callable(): Swift_Message) $message
+     *
+     * @param string                 $apiKey  A valid Mandrill API key
+     * @param callable|Swift_Message $message An example message for real messages, only the body will be replaced
+     *
+     * @throws \InvalidArgumentException if not a Swift Message is set
+     */
+    public function __construct(string $apiKey, callable|Swift_Message $message, int|string|Level $level = Level::Error, bool $bubble = true)
+    {
+        parent::__construct($level, $bubble);
+
+        if (!$message instanceof Swift_Message) {
+            $message = $message();
+        }
+        if (!$message instanceof Swift_Message) {
+            throw new \InvalidArgumentException('You must provide either a Swift_Message instance or a callable returning it');
+        }
+        $this->message = $message;
+        $this->apiKey = $apiKey;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function send(string $content, array $records): void
+    {
+        $mime = 'text/plain';
+        if ($this->isHtmlBody($content)) {
+            $mime = 'text/html';
+        }
+
+        $message = clone $this->message;
+        $message->setBody($content, $mime);
+        /** @phpstan-ignore-next-line */
+        if (version_compare(Swift::VERSION, '6.0.0', '>=')) {
+            $message->setDate(new \DateTimeImmutable());
+        } else {
+            /** @phpstan-ignore-next-line */
+            $message->setDate(time());
+        }
+
+        $ch = curl_init();
+
+        curl_setopt($ch, CURLOPT_URL, 'https://mandrillapp.com/api/1.0/messages/send-raw.json');
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
+            'key' => $this->apiKey,
+            'raw_message' => (string) $message,
+            'async' => false,
+        ]));
+
+        Curl\Util::execute($ch);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/MissingExtensionException.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/MissingExtensionException.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+/**
+ * Exception can be thrown if an extension for a handler is missing
+ *
+ * @author Christian Bergau <cbergau86@gmail.com>
+ */
+class MissingExtensionException extends \Exception
+{
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/MongoDBHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/MongoDBHandler.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use MongoDB\Client;
+use MongoDB\Collection;
+use MongoDB\Driver\BulkWrite;
+use MongoDB\Driver\Manager;
+use Monolog\Level;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\MongoDBFormatter;
+use Monolog\LogRecord;
+
+/**
+ * Logs to a MongoDB database.
+ *
+ * Usage example:
+ *
+ *   $log = new \Monolog\Logger('application');
+ *   $client = new \MongoDB\Client('mongodb://localhost:27017');
+ *   $mongodb = new \Monolog\Handler\MongoDBHandler($client, 'logs', 'prod');
+ *   $log->pushHandler($mongodb);
+ *
+ * The above examples uses the MongoDB PHP library's client class; however, the
+ * MongoDB\Driver\Manager class from ext-mongodb is also supported.
+ */
+class MongoDBHandler extends AbstractProcessingHandler
+{
+    private Collection $collection;
+
+    private Client|Manager $manager;
+
+    private string|null $namespace = null;
+
+    /**
+     * Constructor.
+     *
+     * @param Client|Manager $mongodb    MongoDB library or driver client
+     * @param string         $database   Database name
+     * @param string         $collection Collection name
+     */
+    public function __construct(Client|Manager $mongodb, string $database, string $collection, int|string|Level $level = Level::Debug, bool $bubble = true)
+    {
+        if ($mongodb instanceof Client) {
+            $this->collection = method_exists($mongodb, 'getCollection') ? $mongodb->getCollection($database, $collection) : $mongodb->selectCollection($database, $collection);
+        } else {
+            $this->manager = $mongodb;
+            $this->namespace = $database . '.' . $collection;
+        }
+
+        parent::__construct($level, $bubble);
+    }
+
+    protected function write(LogRecord $record): void
+    {
+        if (isset($this->collection)) {
+            $this->collection->insertOne($record->formatted);
+        }
+
+        if (isset($this->manager, $this->namespace)) {
+            $bulk = new BulkWrite;
+            $bulk->insert($record->formatted);
+            $this->manager->executeBulkWrite($this->namespace, $bulk);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new MongoDBFormatter;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/NativeMailerHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/NativeMailerHandler.php
@@ -1,0 +1,179 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\Formatter\LineFormatter;
+
+/**
+ * NativeMailerHandler uses the mail() function to send the emails
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ * @author Mark Garrett <mark@moderndeveloperllc.com>
+ */
+class NativeMailerHandler extends MailHandler
+{
+    /**
+     * The email addresses to which the message will be sent
+     * @var string[]
+     */
+    protected array $to;
+
+    /**
+     * The subject of the email
+     */
+    protected string $subject;
+
+    /**
+     * Optional headers for the message
+     * @var string[]
+     */
+    protected array $headers = [];
+
+    /**
+     * Optional parameters for the message
+     * @var string[]
+     */
+    protected array $parameters = [];
+
+    /**
+     * The wordwrap length for the message
+     */
+    protected int $maxColumnWidth;
+
+    /**
+     * The Content-type for the message
+     */
+    protected string|null $contentType = null;
+
+    /**
+     * The encoding for the message
+     */
+    protected string $encoding = 'utf-8';
+
+    /**
+     * @param string|string[] $to             The receiver of the mail
+     * @param string          $subject        The subject of the mail
+     * @param string          $from           The sender of the mail
+     * @param int             $maxColumnWidth The maximum column width that the message lines will have
+     */
+    public function __construct(string|array $to, string $subject, string $from, int|string|Level $level = Level::Error, bool $bubble = true, int $maxColumnWidth = 70)
+    {
+        parent::__construct($level, $bubble);
+        $this->to = (array) $to;
+        $this->subject = $subject;
+        $this->addHeader(sprintf('From: %s', $from));
+        $this->maxColumnWidth = $maxColumnWidth;
+    }
+
+    /**
+     * Add headers to the message
+     *
+     * @param  string|string[] $headers Custom added headers
+     * @return $this
+     */
+    public function addHeader($headers): self
+    {
+        foreach ((array) $headers as $header) {
+            if (strpos($header, "\n") !== false || strpos($header, "\r") !== false) {
+                throw new \InvalidArgumentException('Headers can not contain newline characters for security reasons');
+            }
+            $this->headers[] = $header;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add parameters to the message
+     *
+     * @param  string|string[] $parameters Custom added parameters
+     * @return $this
+     */
+    public function addParameter($parameters): self
+    {
+        $this->parameters = array_merge($this->parameters, (array) $parameters);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function send(string $content, array $records): void
+    {
+        $contentType = $this->getContentType() ?? ($this->isHtmlBody($content) ? 'text/html' : 'text/plain');
+
+        if ($contentType !== 'text/html') {
+            $content = wordwrap($content, $this->maxColumnWidth);
+        }
+
+        $headers = ltrim(implode("\r\n", $this->headers) . "\r\n", "\r\n");
+        $headers .= 'Content-type: ' . $contentType . '; charset=' . $this->getEncoding() . "\r\n";
+        if ($contentType === 'text/html' && false === strpos($headers, 'MIME-Version:')) {
+            $headers .= 'MIME-Version: 1.0' . "\r\n";
+        }
+
+        $subjectFormatter = new LineFormatter($this->subject);
+        $subject = $subjectFormatter->format($this->getHighestRecord($records));
+
+        $parameters = implode(' ', $this->parameters);
+        foreach ($this->to as $to) {
+            $this->mail($to, $subject, $content, $headers, $parameters);
+        }
+    }
+
+    public function getContentType(): ?string
+    {
+        return $this->contentType;
+    }
+
+    public function getEncoding(): string
+    {
+        return $this->encoding;
+    }
+
+    /**
+     * @param  string $contentType The content type of the email - Defaults to text/plain. Use text/html for HTML messages.
+     * @return $this
+     */
+    public function setContentType(string $contentType): self
+    {
+        if (strpos($contentType, "\n") !== false || strpos($contentType, "\r") !== false) {
+            throw new \InvalidArgumentException('The content type can not contain newline characters to prevent email header injection');
+        }
+
+        $this->contentType = $contentType;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setEncoding(string $encoding): self
+    {
+        if (strpos($encoding, "\n") !== false || strpos($encoding, "\r") !== false) {
+            throw new \InvalidArgumentException('The encoding can not contain newline characters to prevent email header injection');
+        }
+
+        $this->encoding = $encoding;
+
+        return $this;
+    }
+
+
+    protected function mail(string $to, string $subject, string $content, string $headers, string $parameters): void
+    {
+        mail($to, $subject, $content, $headers, $parameters);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/NewRelicHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/NewRelicHandler.php
@@ -1,0 +1,180 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\Utils;
+use Monolog\Formatter\NormalizerFormatter;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\LogRecord;
+
+/**
+ * Class to record a log on a NewRelic application.
+ * Enabling New Relic High Security mode may prevent capture of useful information.
+ *
+ * This handler requires a NormalizerFormatter to function and expects an array in $record->formatted
+ *
+ * @see https://docs.newrelic.com/docs/agents/php-agent
+ * @see https://docs.newrelic.com/docs/accounts-partnerships/accounts/security/high-security
+ */
+class NewRelicHandler extends AbstractProcessingHandler
+{
+    /**
+     * @inheritDoc
+     */
+    public function __construct(
+        int|string|Level $level = Level::Error,
+        bool $bubble = true,
+
+        /**
+         * Name of the New Relic application that will receive logs from this handler.
+         */
+        protected string|null $appName = null,
+
+        /**
+         * Some context and extra data is passed into the handler as arrays of values. Do we send them as is
+         * (useful if we are using the API), or explode them for display on the NewRelic RPM website?
+         */
+        protected bool $explodeArrays = false,
+
+        /**
+         * Name of the current transaction
+         */
+        protected string|null $transactionName = null
+    ) {
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        if (!$this->isNewRelicEnabled()) {
+            throw new MissingExtensionException('The newrelic PHP extension is required to use the NewRelicHandler');
+        }
+
+        if (null !== ($appName = $this->getAppName($record->context))) {
+            $this->setNewRelicAppName($appName);
+        }
+
+        if (null !== ($transactionName = $this->getTransactionName($record->context))) {
+            $this->setNewRelicTransactionName($transactionName);
+            unset($record->formatted['context']['transaction_name']);
+        }
+
+        if (isset($record->context['exception']) && $record->context['exception'] instanceof \Throwable) {
+            newrelic_notice_error($record->message, $record->context['exception']);
+            unset($record->formatted['context']['exception']);
+        } else {
+            newrelic_notice_error($record->message);
+        }
+
+        if (isset($record->formatted['context']) && \is_array($record->formatted['context'])) {
+            foreach ($record->formatted['context'] as $key => $parameter) {
+                if (\is_array($parameter) && $this->explodeArrays) {
+                    foreach ($parameter as $paramKey => $paramValue) {
+                        $this->setNewRelicParameter('context_' . $key . '_' . $paramKey, $paramValue);
+                    }
+                } else {
+                    $this->setNewRelicParameter('context_' . $key, $parameter);
+                }
+            }
+        }
+
+        if (isset($record->formatted['extra']) && \is_array($record->formatted['extra'])) {
+            foreach ($record->formatted['extra'] as $key => $parameter) {
+                if (\is_array($parameter) && $this->explodeArrays) {
+                    foreach ($parameter as $paramKey => $paramValue) {
+                        $this->setNewRelicParameter('extra_' . $key . '_' . $paramKey, $paramValue);
+                    }
+                } else {
+                    $this->setNewRelicParameter('extra_' . $key, $parameter);
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks whether the NewRelic extension is enabled in the system.
+     */
+    protected function isNewRelicEnabled(): bool
+    {
+        return \extension_loaded('newrelic');
+    }
+
+    /**
+     * Returns the appname where this log should be sent. Each log can override the default appname, set in this
+     * handler's constructor, by providing the appname in it's context.
+     *
+     * @param mixed[] $context
+     */
+    protected function getAppName(array $context): ?string
+    {
+        if (isset($context['appname'])) {
+            return $context['appname'];
+        }
+
+        return $this->appName;
+    }
+
+    /**
+     * Returns the name of the current transaction. Each log can override the default transaction name, set in this
+     * handler's constructor, by providing the transaction_name in it's context
+     *
+     * @param mixed[] $context
+     */
+    protected function getTransactionName(array $context): ?string
+    {
+        if (isset($context['transaction_name'])) {
+            return $context['transaction_name'];
+        }
+
+        return $this->transactionName;
+    }
+
+    /**
+     * Sets the NewRelic application that should receive this log.
+     */
+    protected function setNewRelicAppName(string $appName): void
+    {
+        newrelic_set_appname($appName);
+    }
+
+    /**
+     * Overwrites the name of the current transaction
+     */
+    protected function setNewRelicTransactionName(string $transactionName): void
+    {
+        newrelic_name_transaction($transactionName);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    protected function setNewRelicParameter(string $key, $value): void
+    {
+        if (null === $value || \is_scalar($value)) {
+            newrelic_add_custom_parameter($key, $value);
+        } else {
+            newrelic_add_custom_parameter($key, Utils::jsonEncode($value, null, true));
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new NormalizerFormatter();
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/NoopHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/NoopHandler.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\LogRecord;
+
+/**
+ * No-op
+ *
+ * This handler handles anything, but does nothing, and does not stop bubbling to the rest of the stack.
+ * This can be used for testing, or to disable a handler when overriding a configuration without
+ * influencing the rest of the stack.
+ *
+ * @author Roel Harbers <roelharbers@gmail.com>
+ */
+class NoopHandler extends Handler
+{
+    /**
+     * @inheritDoc
+     */
+    public function isHandling(LogRecord $record): bool
+    {
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handle(LogRecord $record): bool
+    {
+        return false;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/NullHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/NullHandler.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Psr\Log\LogLevel;
+use Monolog\Logger;
+use Monolog\LogRecord;
+
+/**
+ * Blackhole
+ *
+ * Any record it can handle will be thrown away. This can be used
+ * to put on top of an existing stack to override it temporarily.
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class NullHandler extends Handler
+{
+    private Level $level;
+
+    /**
+     * @param string|int|Level $level The minimum logging level at which this handler will be triggered
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $level
+     */
+    public function __construct(string|int|Level $level = Level::Debug)
+    {
+        $this->level = Logger::toMonologLevel($level);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isHandling(LogRecord $record): bool
+    {
+        return $record->level->value >= $this->level->value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handle(LogRecord $record): bool
+    {
+        return $record->level->value >= $this->level->value;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/OverflowHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/OverflowHandler.php
@@ -1,0 +1,139 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\LogRecord;
+
+/**
+ * Handler to only pass log messages when a certain threshold of number of messages is reached.
+ *
+ * This can be useful in cases of processing a batch of data, but you're for example only interested
+ * in case it fails catastrophically instead of a warning for 1 or 2 events. Worse things can happen, right?
+ *
+ * Usage example:
+ *
+ * ```
+ *   $log = new Logger('application');
+ *   $handler = new SomeHandler(...)
+ *
+ *   // Pass all warnings to the handler when more than 10 & all error messages when more then 5
+ *   $overflow = new OverflowHandler($handler, [Level::Warning->value => 10, Level::Error->value => 5]);
+ *
+ *   $log->pushHandler($overflow);
+ *```
+ *
+ * @author Kris Buist <krisbuist@gmail.com>
+ */
+class OverflowHandler extends AbstractHandler implements FormattableHandlerInterface
+{
+    private HandlerInterface $handler;
+
+    /** @var array<int, int> */
+    private array $thresholdMap = [];
+
+    /**
+     * Buffer of all messages passed to the handler before the threshold was reached
+     *
+     * @var mixed[][]
+     */
+    private array $buffer = [];
+
+    /**
+     * @param array<int, int> $thresholdMap Dictionary of log level value => threshold
+     */
+    public function __construct(
+        HandlerInterface $handler,
+        array $thresholdMap = [],
+        $level = Level::Debug,
+        bool $bubble = true
+    ) {
+        $this->handler = $handler;
+        foreach ($thresholdMap as $thresholdLevel => $threshold) {
+            $this->thresholdMap[$thresholdLevel] = $threshold;
+        }
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * Handles a record.
+     *
+     * All records may be passed to this method, and the handler should discard
+     * those that it does not want to handle.
+     *
+     * The return value of this function controls the bubbling process of the handler stack.
+     * Unless the bubbling is interrupted (by returning true), the Logger class will keep on
+     * calling further handlers in the stack with a given log record.
+     *
+     * @inheritDoc
+     */
+    public function handle(LogRecord $record): bool
+    {
+        if ($record->level->isLowerThan($this->level)) {
+            return false;
+        }
+
+        $level = $record->level->value;
+
+        if (!isset($this->thresholdMap[$level])) {
+            $this->thresholdMap[$level] = 0;
+        }
+
+        if ($this->thresholdMap[$level] > 0) {
+            // The overflow threshold is not yet reached, so we're buffering the record and lowering the threshold by 1
+            $this->thresholdMap[$level]--;
+            $this->buffer[$level][] = $record;
+
+            return false === $this->bubble;
+        }
+
+        if ($this->thresholdMap[$level] === 0) {
+            // This current message is breaking the threshold. Flush the buffer and continue handling the current record
+            foreach ($this->buffer[$level] ?? [] as $buffered) {
+                $this->handler->handle($buffered);
+            }
+            $this->thresholdMap[$level]--;
+            unset($this->buffer[$level]);
+        }
+
+        $this->handler->handle($record);
+
+        return false === $this->bubble;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface
+    {
+        if ($this->handler instanceof FormattableHandlerInterface) {
+            $this->handler->setFormatter($formatter);
+
+            return $this;
+        }
+
+        throw new \UnexpectedValueException('The nested handler of type '.\get_class($this->handler).' does not support formatters.');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFormatter(): FormatterInterface
+    {
+        if ($this->handler instanceof FormattableHandlerInterface) {
+            return $this->handler->getFormatter();
+        }
+
+        throw new \UnexpectedValueException('The nested handler of type '.\get_class($this->handler).' does not support formatters.');
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/PHPConsoleHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/PHPConsoleHandler.php
@@ -1,0 +1,303 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\LineFormatter;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Level;
+use Monolog\Utils;
+use PhpConsole\Connector;
+use PhpConsole\Handler as VendorPhpConsoleHandler;
+use PhpConsole\Helper;
+use Monolog\LogRecord;
+use PhpConsole\Storage;
+
+/**
+ * Monolog handler for Google Chrome extension "PHP Console"
+ *
+ * Display PHP error/debug log messages in Google Chrome console and notification popups, executes PHP code remotely
+ *
+ * Usage:
+ * 1. Install Google Chrome extension [now dead and removed from the chrome store]
+ * 2. See overview https://github.com/barbushin/php-console#overview
+ * 3. Install PHP Console library https://github.com/barbushin/php-console#installation
+ * 4. Example (result will looks like http://i.hizliresim.com/vg3Pz4.png)
+ *
+ *      $logger = new \Monolog\Logger('all', array(new \Monolog\Handler\PHPConsoleHandler()));
+ *      \Monolog\ErrorHandler::register($logger);
+ *      echo $undefinedVar;
+ *      $logger->debug('SELECT * FROM users', array('db', 'time' => 0.012));
+ *      PC::debug($_SERVER); // PHP Console debugger for any type of vars
+ *
+ * @author Sergey Barbushin https://www.linkedin.com/in/barbushin
+ * @phpstan-type Options array{
+ *     enabled: bool,
+ *     classesPartialsTraceIgnore: string[],
+ *     debugTagsKeysInContext: array<int|string>,
+ *     useOwnErrorsHandler: bool,
+ *     useOwnExceptionsHandler: bool,
+ *     sourcesBasePath: string|null,
+ *     registerHelper: bool,
+ *     serverEncoding: string|null,
+ *     headersLimit: int|null,
+ *     password: string|null,
+ *     enableSslOnlyMode: bool,
+ *     ipMasks: string[],
+ *     enableEvalListener: bool,
+ *     dumperDetectCallbacks: bool,
+ *     dumperLevelLimit: int,
+ *     dumperItemsCountLimit: int,
+ *     dumperItemSizeLimit: int,
+ *     dumperDumpSizeLimit: int,
+ *     detectDumpTraceAndSource: bool,
+ *     dataStorage: Storage|null
+ * }
+ * @phpstan-type InputOptions array{
+ *     enabled?: bool,
+ *     classesPartialsTraceIgnore?: string[],
+ *     debugTagsKeysInContext?: array<int|string>,
+ *     useOwnErrorsHandler?: bool,
+ *     useOwnExceptionsHandler?: bool,
+ *     sourcesBasePath?: string|null,
+ *     registerHelper?: bool,
+ *     serverEncoding?: string|null,
+ *     headersLimit?: int|null,
+ *     password?: string|null,
+ *     enableSslOnlyMode?: bool,
+ *     ipMasks?: string[],
+ *     enableEvalListener?: bool,
+ *     dumperDetectCallbacks?: bool,
+ *     dumperLevelLimit?: int,
+ *     dumperItemsCountLimit?: int,
+ *     dumperItemSizeLimit?: int,
+ *     dumperDumpSizeLimit?: int,
+ *     detectDumpTraceAndSource?: bool,
+ *     dataStorage?: Storage|null
+ * }
+ *
+ * @deprecated Since 2.8.0 and 3.2.0, PHPConsole is abandoned and thus we will drop this handler in Monolog 4
+ */
+class PHPConsoleHandler extends AbstractProcessingHandler
+{
+    /**
+     * @phpstan-var Options
+     */
+    private array $options = [
+        'enabled' => true, // bool Is PHP Console server enabled
+        'classesPartialsTraceIgnore' => ['Monolog\\'], // array Hide calls of classes started with...
+        'debugTagsKeysInContext' => [0, 'tag'], // bool Is PHP Console server enabled
+        'useOwnErrorsHandler' => false, // bool Enable errors handling
+        'useOwnExceptionsHandler' => false, // bool Enable exceptions handling
+        'sourcesBasePath' => null, // string Base path of all project sources to strip in errors source paths
+        'registerHelper' => true, // bool Register PhpConsole\Helper that allows short debug calls like PC::debug($var, 'ta.g.s')
+        'serverEncoding' => null, // string|null Server internal encoding
+        'headersLimit' => null, // int|null Set headers size limit for your web-server
+        'password' => null, // string|null Protect PHP Console connection by password
+        'enableSslOnlyMode' => false, // bool Force connection by SSL for clients with PHP Console installed
+        'ipMasks' => [], // array Set IP masks of clients that will be allowed to connect to PHP Console: array('192.168.*.*', '127.0.0.1')
+        'enableEvalListener' => false, // bool Enable eval request to be handled by eval dispatcher(if enabled, 'password' option is also required)
+        'dumperDetectCallbacks' => false, // bool Convert callback items in dumper vars to (callback SomeClass::someMethod) strings
+        'dumperLevelLimit' => 5, // int Maximum dumped vars array or object nested dump level
+        'dumperItemsCountLimit' => 100, // int Maximum dumped var same level array items or object properties number
+        'dumperItemSizeLimit' => 5000, // int Maximum length of any string or dumped array item
+        'dumperDumpSizeLimit' => 500000, // int Maximum approximate size of dumped vars result formatted in JSON
+        'detectDumpTraceAndSource' => false, // bool Autodetect and append trace data to debug
+        'dataStorage' => null, // \PhpConsole\Storage|null Fixes problem with custom $_SESSION handler (see https://github.com/barbushin/php-console#troubleshooting-with-_session-handler-overridden-in-some-frameworks)
+    ];
+
+    private Connector $connector;
+
+    /**
+     * @param  array<string, mixed> $options   See \Monolog\Handler\PHPConsoleHandler::$options for more details
+     * @param  Connector|null       $connector Instance of \PhpConsole\Connector class (optional)
+     * @throws \RuntimeException
+     * @phpstan-param InputOptions $options
+     */
+    public function __construct(array $options = [], ?Connector $connector = null, int|string|Level $level = Level::Debug, bool $bubble = true)
+    {
+        if (!class_exists('PhpConsole\Connector')) {
+            throw new \RuntimeException('PHP Console library not found. See https://github.com/barbushin/php-console#installation');
+        }
+        parent::__construct($level, $bubble);
+        $this->options = $this->initOptions($options);
+        $this->connector = $this->initConnector($connector);
+    }
+
+    /**
+     * @param  array<string, mixed> $options
+     * @return array<string, mixed>
+     *
+     * @phpstan-param InputOptions $options
+     * @phpstan-return Options
+     */
+    private function initOptions(array $options): array
+    {
+        $wrongOptions = array_diff(array_keys($options), array_keys($this->options));
+        if (\count($wrongOptions) > 0) {
+            throw new \RuntimeException('Unknown options: ' . implode(', ', $wrongOptions));
+        }
+
+        return array_replace($this->options, $options);
+    }
+
+    private function initConnector(?Connector $connector = null): Connector
+    {
+        if (null === $connector) {
+            if ($this->options['dataStorage'] instanceof Storage) {
+                Connector::setPostponeStorage($this->options['dataStorage']);
+            }
+            $connector = Connector::getInstance();
+        }
+
+        if ($this->options['registerHelper'] && !Helper::isRegistered()) {
+            Helper::register();
+        }
+
+        if ($this->options['enabled'] && $connector->isActiveClient()) {
+            if ($this->options['useOwnErrorsHandler'] || $this->options['useOwnExceptionsHandler']) {
+                $handler = VendorPhpConsoleHandler::getInstance();
+                $handler->setHandleErrors($this->options['useOwnErrorsHandler']);
+                $handler->setHandleExceptions($this->options['useOwnExceptionsHandler']);
+                $handler->start();
+            }
+            if (null !== $this->options['sourcesBasePath']) {
+                $connector->setSourcesBasePath($this->options['sourcesBasePath']);
+            }
+            if (null !== $this->options['serverEncoding']) {
+                $connector->setServerEncoding($this->options['serverEncoding']);
+            }
+            if (null !== $this->options['password']) {
+                $connector->setPassword($this->options['password']);
+            }
+            if ($this->options['enableSslOnlyMode']) {
+                $connector->enableSslOnlyMode();
+            }
+            if (\count($this->options['ipMasks']) > 0) {
+                $connector->setAllowedIpMasks($this->options['ipMasks']);
+            }
+            if (null !== $this->options['headersLimit'] && $this->options['headersLimit'] > 0) {
+                $connector->setHeadersLimit($this->options['headersLimit']);
+            }
+            if ($this->options['detectDumpTraceAndSource']) {
+                $connector->getDebugDispatcher()->detectTraceAndSource = true;
+            }
+            $dumper = $connector->getDumper();
+            $dumper->levelLimit = $this->options['dumperLevelLimit'];
+            $dumper->itemsCountLimit = $this->options['dumperItemsCountLimit'];
+            $dumper->itemSizeLimit = $this->options['dumperItemSizeLimit'];
+            $dumper->dumpSizeLimit = $this->options['dumperDumpSizeLimit'];
+            $dumper->detectCallbacks = $this->options['dumperDetectCallbacks'];
+            if ($this->options['enableEvalListener']) {
+                $connector->startEvalRequestsListener();
+            }
+        }
+
+        return $connector;
+    }
+
+    public function getConnector(): Connector
+    {
+        return $this->connector;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    public function handle(LogRecord $record): bool
+    {
+        if ($this->options['enabled'] && $this->connector->isActiveClient()) {
+            return parent::handle($record);
+        }
+
+        return !$this->bubble;
+    }
+
+    /**
+     * Writes the record down to the log of the implementing handler
+     */
+    protected function write(LogRecord $record): void
+    {
+        if ($record->level->isLowerThan(Level::Notice)) {
+            $this->handleDebugRecord($record);
+        } elseif (isset($record->context['exception']) && $record->context['exception'] instanceof \Throwable) {
+            $this->handleExceptionRecord($record);
+        } else {
+            $this->handleErrorRecord($record);
+        }
+    }
+
+    private function handleDebugRecord(LogRecord $record): void
+    {
+        [$tags, $filteredContext] = $this->getRecordTags($record);
+        $message = $record->message;
+        if (\count($filteredContext) > 0) {
+            $message .= ' ' . Utils::jsonEncode($this->connector->getDumper()->dump(array_filter($filteredContext)), null, true);
+        }
+        $this->connector->getDebugDispatcher()->dispatchDebug($message, $tags, $this->options['classesPartialsTraceIgnore']);
+    }
+
+    private function handleExceptionRecord(LogRecord $record): void
+    {
+        $this->connector->getErrorsDispatcher()->dispatchException($record->context['exception']);
+    }
+
+    private function handleErrorRecord(LogRecord $record): void
+    {
+        $context = $record->context;
+
+        $this->connector->getErrorsDispatcher()->dispatchError(
+            $context['code'] ?? null,
+            $context['message'] ?? $record->message,
+            $context['file'] ?? null,
+            $context['line'] ?? null,
+            $this->options['classesPartialsTraceIgnore']
+        );
+    }
+
+    /**
+     * @return array{string, mixed[]}
+     */
+    private function getRecordTags(LogRecord $record): array
+    {
+        $tags = null;
+        $filteredContext = [];
+        if ($record->context !== []) {
+            $filteredContext = $record->context;
+            foreach ($this->options['debugTagsKeysInContext'] as $key) {
+                if (isset($filteredContext[$key])) {
+                    $tags = $filteredContext[$key];
+                    if ($key === 0) {
+                        array_shift($filteredContext);
+                    } else {
+                        unset($filteredContext[$key]);
+                    }
+                    break;
+                }
+            }
+        }
+
+        return [$tags ?? $record->level->toPsrLogLevel(), $filteredContext];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new LineFormatter('%message%');
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/ProcessHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/ProcessHandler.php
@@ -1,0 +1,191 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\LogRecord;
+
+/**
+ * Stores to STDIN of any process, specified by a command.
+ *
+ * Usage example:
+ * <pre>
+ * $log = new Logger('myLogger');
+ * $log->pushHandler(new ProcessHandler('/usr/bin/php /var/www/monolog/someScript.php'));
+ * </pre>
+ *
+ * @author Kolja Zuelsdorf <koljaz@web.de>
+ */
+class ProcessHandler extends AbstractProcessingHandler
+{
+    /**
+     * Holds the process to receive data on its STDIN.
+     *
+     * @var resource|bool|null
+     */
+    private $process;
+
+    private string $command;
+
+    private ?string $cwd;
+
+    /**
+     * @var resource[]
+     */
+    private array $pipes = [];
+
+    private float $timeout;
+
+    /**
+     * @var array<int, list<string>>
+     */
+    protected const DESCRIPTOR_SPEC = [
+        0 => ['pipe', 'r'],  // STDIN is a pipe that the child will read from
+        1 => ['pipe', 'w'],  // STDOUT is a pipe that the child will write to
+        2 => ['pipe', 'w'],  // STDERR is a pipe to catch the any errors
+    ];
+
+    /**
+     * @param  string                    $command Command for the process to start. Absolute paths are recommended,
+     *                                            especially if you do not use the $cwd parameter.
+     * @param  string|null               $cwd     "Current working directory" (CWD) for the process to be executed in.
+     * @param  float                     $timeout The maximum timeout (in seconds) for the stream_select() function.
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(string $command, int|string|Level $level = Level::Debug, bool $bubble = true, ?string $cwd = null, float $timeout = 1.0)
+    {
+        if ($command === '') {
+            throw new \InvalidArgumentException('The command argument must be a non-empty string.');
+        }
+        if ($cwd === '') {
+            throw new \InvalidArgumentException('The optional CWD argument must be a non-empty string or null.');
+        }
+
+        parent::__construct($level, $bubble);
+
+        $this->command = $command;
+        $this->cwd = $cwd;
+        $this->timeout = $timeout;
+    }
+
+    /**
+     * Writes the record down to the log of the implementing handler
+     *
+     * @throws \UnexpectedValueException
+     */
+    protected function write(LogRecord $record): void
+    {
+        $this->ensureProcessIsStarted();
+
+        $this->writeProcessInput($record->formatted);
+
+        $errors = $this->readProcessErrors();
+        if ($errors !== '') {
+            throw new \UnexpectedValueException(sprintf('Errors while writing to process: %s', $errors));
+        }
+    }
+
+    /**
+     * Makes sure that the process is actually started, and if not, starts it,
+     * assigns the stream pipes, and handles startup errors, if any.
+     */
+    private function ensureProcessIsStarted(): void
+    {
+        if (\is_resource($this->process) === false) {
+            $this->startProcess();
+
+            $this->handleStartupErrors();
+        }
+    }
+
+    /**
+     * Starts the actual process and sets all streams to non-blocking.
+     */
+    private function startProcess(): void
+    {
+        $this->process = proc_open($this->command, static::DESCRIPTOR_SPEC, $this->pipes, $this->cwd);
+
+        foreach ($this->pipes as $pipe) {
+            stream_set_blocking($pipe, false);
+        }
+    }
+
+    /**
+     * Selects the STDERR stream, handles upcoming startup errors, and throws an exception, if any.
+     *
+     * @throws \UnexpectedValueException
+     */
+    private function handleStartupErrors(): void
+    {
+        $selected = $this->selectErrorStream();
+        if (false === $selected) {
+            throw new \UnexpectedValueException('Something went wrong while selecting a stream.');
+        }
+
+        $errors = $this->readProcessErrors();
+
+        if (\is_resource($this->process) === false || $errors !== '') {
+            throw new \UnexpectedValueException(
+                sprintf('The process "%s" could not be opened: ' . $errors, $this->command)
+            );
+        }
+    }
+
+    /**
+     * Selects the STDERR stream.
+     *
+     * @return int|bool
+     */
+    protected function selectErrorStream()
+    {
+        $empty = [];
+        $errorPipes = [$this->pipes[2]];
+
+        $seconds = (int) $this->timeout;
+        return stream_select($errorPipes, $empty, $empty, $seconds, (int) (($this->timeout - $seconds) * 1000000));
+    }
+
+    /**
+     * Reads the errors of the process, if there are any.
+     *
+     * @codeCoverageIgnore
+     * @return string Empty string if there are no errors.
+     */
+    protected function readProcessErrors(): string
+    {
+        return (string) stream_get_contents($this->pipes[2]);
+    }
+
+    /**
+     * Writes to the input stream of the opened process.
+     *
+     * @codeCoverageIgnore
+     */
+    protected function writeProcessInput(string $string): void
+    {
+        fwrite($this->pipes[0], $string);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function close(): void
+    {
+        if (\is_resource($this->process)) {
+            foreach ($this->pipes as $pipe) {
+                fclose($pipe);
+            }
+            proc_close($this->process);
+            $this->process = null;
+        }
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/ProcessableHandlerInterface.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/ProcessableHandlerInterface.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Processor\ProcessorInterface;
+use Monolog\LogRecord;
+
+/**
+ * Interface to describe loggers that have processors
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+interface ProcessableHandlerInterface
+{
+    /**
+     * Adds a processor in the stack.
+     *
+     * @phpstan-param ProcessorInterface|(callable(LogRecord): LogRecord) $callback
+     *
+     * @param  ProcessorInterface|callable $callback
+     * @return HandlerInterface            self
+     */
+    public function pushProcessor(callable $callback): HandlerInterface;
+
+    /**
+     * Removes the processor on top of the stack and returns it.
+     *
+     * @phpstan-return ProcessorInterface|(callable(LogRecord): LogRecord) $callback
+     *
+     * @throws \LogicException             In case the processor stack is empty
+     * @return callable|ProcessorInterface
+     */
+    public function popProcessor(): callable;
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/ProcessableHandlerTrait.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/ProcessableHandlerTrait.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\ResettableInterface;
+use Monolog\Processor\ProcessorInterface;
+use Monolog\LogRecord;
+
+/**
+ * Helper trait for implementing ProcessableInterface
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+trait ProcessableHandlerTrait
+{
+    /**
+     * @var callable[]
+     * @phpstan-var array<(callable(LogRecord): LogRecord)|ProcessorInterface>
+     */
+    protected array $processors = [];
+
+    /**
+     * @inheritDoc
+     */
+    public function pushProcessor(callable $callback): HandlerInterface
+    {
+        array_unshift($this->processors, $callback);
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function popProcessor(): callable
+    {
+        if (\count($this->processors) === 0) {
+            throw new \LogicException('You tried to pop from an empty processor stack.');
+        }
+
+        return array_shift($this->processors);
+    }
+
+    protected function processRecord(LogRecord $record): LogRecord
+    {
+        foreach ($this->processors as $processor) {
+            $record = $processor($record);
+        }
+
+        return $record;
+    }
+
+    protected function resetProcessors(): void
+    {
+        foreach ($this->processors as $processor) {
+            if ($processor instanceof ResettableInterface) {
+                $processor->reset();
+            }
+        }
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/PsrHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/PsrHandler.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Psr\Log\LoggerInterface;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\LogRecord;
+
+/**
+ * Proxies log messages to an existing PSR-3 compliant logger.
+ *
+ * If a formatter is configured, the formatter's output MUST be a string and the
+ * formatted message will be fed to the wrapped PSR logger instead of the original
+ * log record's message.
+ *
+ * @author Michael Moussa <michael.moussa@gmail.com>
+ */
+class PsrHandler extends AbstractHandler implements FormattableHandlerInterface
+{
+    /**
+     * PSR-3 compliant logger
+     */
+    protected LoggerInterface $logger;
+
+    protected FormatterInterface|null $formatter = null;
+    private bool $includeExtra;
+
+    /**
+     * @param LoggerInterface $logger The underlying PSR-3 compliant logger to which messages will be proxied
+     */
+    public function __construct(LoggerInterface $logger, int|string|Level $level = Level::Debug, bool $bubble = true, bool $includeExtra = false)
+    {
+        parent::__construct($level, $bubble);
+
+        $this->logger = $logger;
+        $this->includeExtra = $includeExtra;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handle(LogRecord $record): bool
+    {
+        if (!$this->isHandling($record)) {
+            return false;
+        }
+
+        $message = $this->formatter !== null
+            ? (string) $this->formatter->format($record)
+            : $record->message;
+
+        $context = $this->includeExtra
+            ? [...$record->extra, ...$record->context]
+            : $record->context;
+
+        $this->logger->log($record->level->toPsrLogLevel(), $message, $context);
+
+        return false === $this->bubble;
+    }
+
+    /**
+     * Sets the formatter.
+     */
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface
+    {
+        $this->formatter = $formatter;
+
+        return $this;
+    }
+
+    /**
+     * Gets the formatter.
+     */
+    public function getFormatter(): FormatterInterface
+    {
+        if ($this->formatter === null) {
+            throw new \LogicException('No formatter has been set and this handler does not have a default formatter');
+        }
+
+        return $this->formatter;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/PushoverHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/PushoverHandler.php
@@ -1,0 +1,246 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\Logger;
+use Monolog\Utils;
+use Psr\Log\LogLevel;
+use Monolog\LogRecord;
+
+/**
+ * Sends notifications through the pushover api to mobile phones
+ *
+ * @author Sebastian Göttschkes <sebastian.goettschkes@googlemail.com>
+ * @see    https://www.pushover.net/api
+ */
+class PushoverHandler extends SocketHandler
+{
+    private string $token;
+
+    /** @var array<int|string> */
+    private array $users;
+
+    private string $title;
+
+    private string|int|null $user = null;
+
+    private int $retry;
+
+    private int $expire;
+
+    private Level $highPriorityLevel;
+
+    private Level $emergencyLevel;
+
+    private bool $useFormattedMessage = false;
+
+    /**
+     * All parameters that can be sent to Pushover
+     * @see https://pushover.net/api
+     * @var array<string, bool>
+     */
+    private array $parameterNames = [
+        'token' => true,
+        'user' => true,
+        'message' => true,
+        'device' => true,
+        'title' => true,
+        'url' => true,
+        'url_title' => true,
+        'priority' => true,
+        'timestamp' => true,
+        'sound' => true,
+        'retry' => true,
+        'expire' => true,
+        'callback' => true,
+    ];
+
+    /**
+     * Sounds the api supports by default
+     * @see https://pushover.net/api#sounds
+     * @var string[]
+     */
+    private array $sounds = [
+        'pushover', 'bike', 'bugle', 'cashregister', 'classical', 'cosmic', 'falling', 'gamelan', 'incoming',
+        'intermission', 'magic', 'mechanical', 'pianobar', 'siren', 'spacealarm', 'tugboat', 'alien', 'climb',
+        'persistent', 'echo', 'updown', 'none',
+    ];
+
+    /**
+     * @param string       $token  Pushover api token
+     * @param string|array $users  Pushover user id or array of ids the message will be sent to
+     * @param string|null  $title  Title sent to the Pushover API
+     * @param bool         $useSSL Whether to connect via SSL. Required when pushing messages to users that are not
+     *                             the pushover.net app owner. OpenSSL is required for this option.
+     * @param int          $retry  The retry parameter specifies how often (in seconds) the Pushover servers will
+     *                             send the same notification to the user.
+     * @param int          $expire The expire parameter specifies how many seconds your notification will continue
+     *                             to be retried for (every retry seconds).
+     *
+     * @param int|string|Level|LogLevel::* $highPriorityLevel The minimum logging level at which this handler will start
+     *                                                        sending "high priority" requests to the Pushover API
+     * @param int|string|Level|LogLevel::* $emergencyLevel    The minimum logging level at which this handler will start
+     *                                                        sending "emergency" requests to the Pushover API
+     *
+     *
+     * @phpstan-param string|array<int|string>    $users
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $highPriorityLevel
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $emergencyLevel
+     */
+    public function __construct(
+        string $token,
+        $users,
+        ?string $title = null,
+        int|string|Level $level = Level::Critical,
+        bool $bubble = true,
+        bool $useSSL = true,
+        int|string|Level $highPriorityLevel = Level::Critical,
+        int|string|Level $emergencyLevel = Level::Emergency,
+        int $retry = 30,
+        int $expire = 25200,
+        bool $persistent = false,
+        float $timeout = 0.0,
+        float $writingTimeout = 10.0,
+        ?float $connectionTimeout = null,
+        ?int $chunkSize = null
+    ) {
+        $connectionString = $useSSL ? 'ssl://api.pushover.net:443' : 'api.pushover.net:80';
+        parent::__construct(
+            $connectionString,
+            $level,
+            $bubble,
+            $persistent,
+            $timeout,
+            $writingTimeout,
+            $connectionTimeout,
+            $chunkSize
+        );
+
+        $this->token = $token;
+        $this->users = (array) $users;
+        $this->title = $title ?? (string) gethostname();
+        $this->highPriorityLevel = Logger::toMonologLevel($highPriorityLevel);
+        $this->emergencyLevel = Logger::toMonologLevel($emergencyLevel);
+        $this->retry = $retry;
+        $this->expire = $expire;
+    }
+
+    protected function generateDataStream(LogRecord $record): string
+    {
+        $content = $this->buildContent($record);
+
+        return $this->buildHeader($content) . $content;
+    }
+
+    private function buildContent(LogRecord $record): string
+    {
+        // Pushover has a limit of 512 characters on title and message combined.
+        $maxMessageLength = 512 - \strlen($this->title);
+
+        $message = ($this->useFormattedMessage) ? $record->formatted : $record->message;
+        $message = Utils::substr($message, 0, $maxMessageLength);
+
+        $timestamp = $record->datetime->getTimestamp();
+
+        $dataArray = [
+            'token' => $this->token,
+            'user' => $this->user,
+            'message' => $message,
+            'title' => $this->title,
+            'timestamp' => $timestamp,
+        ];
+
+        if ($record->level->value >= $this->emergencyLevel->value) {
+            $dataArray['priority'] = 2;
+            $dataArray['retry'] = $this->retry;
+            $dataArray['expire'] = $this->expire;
+        } elseif ($record->level->value >= $this->highPriorityLevel->value) {
+            $dataArray['priority'] = 1;
+        }
+
+        // First determine the available parameters
+        $context = array_intersect_key($record->context, $this->parameterNames);
+        $extra = array_intersect_key($record->extra, $this->parameterNames);
+
+        // Least important info should be merged with subsequent info
+        $dataArray = array_merge($extra, $context, $dataArray);
+
+        // Only pass sounds that are supported by the API
+        if (isset($dataArray['sound']) && !\in_array($dataArray['sound'], $this->sounds, true)) {
+            unset($dataArray['sound']);
+        }
+
+        return http_build_query($dataArray);
+    }
+
+    private function buildHeader(string $content): string
+    {
+        $header = "POST /1/messages.json HTTP/1.1\r\n";
+        $header .= "Host: api.pushover.net\r\n";
+        $header .= "Content-Type: application/x-www-form-urlencoded\r\n";
+        $header .= "Content-Length: " . \strlen($content) . "\r\n";
+        $header .= "\r\n";
+
+        return $header;
+    }
+
+    protected function write(LogRecord $record): void
+    {
+        foreach ($this->users as $user) {
+            $this->user = $user;
+
+            parent::write($record);
+            $this->closeSocket();
+        }
+
+        $this->user = null;
+    }
+
+    /**
+     * @param  int|string|Level|LogLevel::* $level
+     * @return $this
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $level
+     */
+    public function setHighPriorityLevel(int|string|Level $level): self
+    {
+        $this->highPriorityLevel = Logger::toMonologLevel($level);
+
+        return $this;
+    }
+
+    /**
+     * @param  int|string|Level|LogLevel::* $level
+     * @return $this
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $level
+     */
+    public function setEmergencyLevel(int|string|Level $level): self
+    {
+        $this->emergencyLevel = Logger::toMonologLevel($level);
+
+        return $this;
+    }
+
+    /**
+     * Use the formatted message?
+     *
+     * @return $this
+     */
+    public function useFormattedMessage(bool $useFormattedMessage): self
+    {
+        $this->useFormattedMessage = $useFormattedMessage;
+
+        return $this;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/RedisHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/RedisHandler.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\LineFormatter;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Predis\Client as Predis;
+use Redis;
+
+/**
+ * Logs to a Redis key using rpush
+ *
+ * usage example:
+ *
+ *   $log = new Logger('application');
+ *   $redis = new RedisHandler(new Predis\Client("tcp://localhost:6379"), "logs");
+ *   $log->pushHandler($redis);
+ *
+ * @author Thomas Tourlourat <thomas@tourlourat.com>
+ */
+class RedisHandler extends AbstractProcessingHandler
+{
+    /** @var Predis<Predis>|Redis */
+    private Predis|Redis $redisClient;
+    private string $redisKey;
+    protected int $capSize;
+
+    /**
+     * @param Predis<Predis>|Redis $redis   The redis instance
+     * @param string               $key     The key name to push records to
+     * @param int                  $capSize Number of entries to limit list size to, 0 = unlimited
+     */
+    public function __construct(Predis|Redis $redis, string $key, int|string|Level $level = Level::Debug, bool $bubble = true, int $capSize = 0)
+    {
+        $this->redisClient = $redis;
+        $this->redisKey = $key;
+        $this->capSize = $capSize;
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        if ($this->capSize > 0) {
+            $this->writeCapped($record);
+        } else {
+            $this->redisClient->rpush($this->redisKey, $record->formatted);
+        }
+    }
+
+    /**
+     * Write and cap the collection
+     * Writes the record to the redis list and caps its
+     */
+    protected function writeCapped(LogRecord $record): void
+    {
+        if ($this->redisClient instanceof Redis) {
+            $mode = \defined('Redis::MULTI') ? Redis::MULTI : 1;
+            $this->redisClient->multi($mode)
+                ->rPush($this->redisKey, $record->formatted)
+                ->ltrim($this->redisKey, -$this->capSize, -1)
+                ->exec();
+        } else {
+            $redisKey = $this->redisKey;
+            $capSize = $this->capSize;
+            $this->redisClient->transaction(function ($tx) use ($record, $redisKey, $capSize) {
+                $tx->rpush($redisKey, $record->formatted);
+                $tx->ltrim($redisKey, -$capSize, -1);
+            });
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new LineFormatter();
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/RedisPubSubHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/RedisPubSubHandler.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\LineFormatter;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Predis\Client as Predis;
+use Redis;
+
+/**
+ * Sends the message to a Redis Pub/Sub channel using PUBLISH
+ *
+ * usage example:
+ *
+ *   $log = new Logger('application');
+ *   $redis = new RedisPubSubHandler(new Predis\Client("tcp://localhost:6379"), "logs", Level::Warning);
+ *   $log->pushHandler($redis);
+ *
+ * @author Gaëtan Faugère <gaetan@fauge.re>
+ */
+class RedisPubSubHandler extends AbstractProcessingHandler
+{
+    /** @var Predis<Predis>|Redis */
+    private Predis|Redis $redisClient;
+    private string $channelKey;
+
+    /**
+     * @param Predis<Predis>|Redis $redis The redis instance
+     * @param string               $key   The channel key to publish records to
+     */
+    public function __construct(Predis|Redis $redis, string $key, int|string|Level $level = Level::Debug, bool $bubble = true)
+    {
+        $this->redisClient = $redis;
+        $this->channelKey = $key;
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        $this->redisClient->publish($this->channelKey, $record->formatted);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultFormatter(): FormatterInterface
+    {
+        return new LineFormatter();
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/RollbarHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/RollbarHandler.php
@@ -1,0 +1,132 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Rollbar\RollbarLogger;
+use Throwable;
+use Monolog\LogRecord;
+
+/**
+ * Sends errors to Rollbar
+ *
+ * If the context data contains a `payload` key, that is used as an array
+ * of payload options to RollbarLogger's log method.
+ *
+ * Rollbar's context info will contain the context + extra keys from the log record
+ * merged, and then on top of that a few keys:
+ *
+ *  - level (rollbar level name)
+ *  - monolog_level (monolog level name, raw level, as rollbar only has 5 but monolog 8)
+ *  - channel
+ *  - datetime (unix timestamp)
+ *
+ * @author Paul Statezny <paulstatezny@gmail.com>
+ */
+class RollbarHandler extends AbstractProcessingHandler
+{
+    protected RollbarLogger $rollbarLogger;
+
+    /**
+     * Records whether any log records have been added since the last flush of the rollbar notifier
+     */
+    private bool $hasRecords = false;
+
+    protected bool $initialized = false;
+
+    /**
+     * @param RollbarLogger $rollbarLogger RollbarLogger object constructed with valid token
+     */
+    public function __construct(RollbarLogger $rollbarLogger, int|string|Level $level = Level::Error, bool $bubble = true)
+    {
+        $this->rollbarLogger = $rollbarLogger;
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * Translates Monolog log levels to Rollbar levels.
+     *
+     * @return 'debug'|'info'|'warning'|'error'|'critical'
+     */
+    protected function toRollbarLevel(Level $level): string
+    {
+        return match ($level) {
+            Level::Debug     => 'debug',
+            Level::Info      => 'info',
+            Level::Notice    => 'info',
+            Level::Warning   => 'warning',
+            Level::Error     => 'error',
+            Level::Critical  => 'critical',
+            Level::Alert     => 'critical',
+            Level::Emergency => 'critical',
+        };
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        if (!$this->initialized) {
+            // __destructor() doesn't get called on Fatal errors
+            register_shutdown_function([$this, 'close']);
+            $this->initialized = true;
+        }
+
+        $context = $record->context;
+        $context = array_merge($context, $record->extra, [
+            'level' => $this->toRollbarLevel($record->level),
+            'monolog_level' => $record->level->getName(),
+            'channel' => $record->channel,
+            'datetime' => $record->datetime->format('U'),
+        ]);
+
+        if (isset($context['exception']) && $context['exception'] instanceof Throwable) {
+            $exception = $context['exception'];
+            unset($context['exception']);
+            $toLog = $exception;
+        } else {
+            $toLog = $record->message;
+        }
+
+        $this->rollbarLogger->log($context['level'], $toLog, $context);
+
+        $this->hasRecords = true;
+    }
+
+    public function flush(): void
+    {
+        if ($this->hasRecords) {
+            $this->rollbarLogger->flush();
+            $this->hasRecords = false;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function close(): void
+    {
+        $this->flush();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function reset(): void
+    {
+        $this->flush();
+
+        parent::reset();
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/RotatingFileHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/RotatingFileHandler.php
@@ -1,0 +1,234 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use DateTimeZone;
+use InvalidArgumentException;
+use Monolog\Level;
+use Monolog\Utils;
+use Monolog\LogRecord;
+
+/**
+ * Stores logs to files that are rotated every day and a limited number of files are kept.
+ *
+ * This rotation is only intended to be used as a workaround. Using logrotate to
+ * handle the rotation is strongly encouraged when you can use it.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class RotatingFileHandler extends StreamHandler
+{
+    public const FILE_PER_DAY = 'Y-m-d';
+    public const FILE_PER_MONTH = 'Y-m';
+    public const FILE_PER_YEAR = 'Y';
+
+    protected string $filename;
+    protected int $maxFiles;
+    protected bool|null $mustRotate = null;
+    protected \DateTimeImmutable $nextRotation;
+    protected string $filenameFormat;
+    protected string $dateFormat;
+    protected DateTimeZone|null $timezone = null;
+
+    /**
+     * @param int      $maxFiles       The maximal amount of files to keep (0 means unlimited)
+     * @param int|null $filePermission Optional file permissions (default (0644) are only for owner read/write)
+     * @param bool     $useLocking     Try to lock log file before doing any writes
+     */
+    public function __construct(string $filename, int $maxFiles = 0, int|string|Level $level = Level::Debug, bool $bubble = true, ?int $filePermission = null, bool $useLocking = false, string $dateFormat = self::FILE_PER_DAY, string $filenameFormat  = '{filename}-{date}', DateTimeZone|null $timezone = null)
+    {
+        $this->filename = Utils::canonicalizePath($filename);
+        $this->maxFiles = $maxFiles;
+        $this->setFilenameFormat($filenameFormat, $dateFormat);
+        $this->nextRotation = $this->getNextRotation();
+        $this->timezone = $timezone;
+
+        parent::__construct($this->getTimedFilename(), $level, $bubble, $filePermission, $useLocking);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function close(): void
+    {
+        parent::close();
+
+        if (true === $this->mustRotate) {
+            $this->rotate();
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function reset(): void
+    {
+        parent::reset();
+    }
+
+    /**
+     * @return $this
+     */
+    public function setFilenameFormat(string $filenameFormat, string $dateFormat): self
+    {
+        $this->setDateFormat($dateFormat);
+        if (substr_count($filenameFormat, '{date}') === 0) {
+            throw new InvalidArgumentException(
+                'Invalid filename format - format must contain at least `{date}`, because otherwise rotating is impossible.'
+            );
+        }
+        $this->filenameFormat = $filenameFormat;
+        $this->url = $this->getTimedFilename();
+        $this->close();
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        // on the first record written, if the log is new, we rotate (once per day) after the log has been written so that the new file exists
+        if (null === $this->mustRotate) {
+            $this->mustRotate = null === $this->url || !file_exists($this->url);
+        }
+
+        // if the next rotation is expired, then we rotate immediately
+        if ($this->nextRotation <= $record->datetime) {
+            $this->mustRotate = true;
+            $this->close(); // triggers rotation
+        }
+
+        parent::write($record);
+
+        if (true === $this->mustRotate) {
+            $this->close(); // triggers rotation
+        }
+    }
+
+    /**
+     * Rotates the files.
+     */
+    protected function rotate(): void
+    {
+        // update filename
+        $this->url = $this->getTimedFilename();
+        $this->nextRotation = $this->getNextRotation();
+
+        $this->mustRotate = false;
+
+        // skip GC of old logs if files are unlimited
+        if (0 === $this->maxFiles) {
+            return;
+        }
+
+        $logFiles = glob($this->getGlobPattern());
+        if (false === $logFiles) {
+            // failed to glob
+            return;
+        }
+
+        if ($this->maxFiles >= \count($logFiles)) {
+            // no files to remove
+            return;
+        }
+
+        // Sorting the files by name to remove the older ones
+        usort($logFiles, function ($a, $b) {
+            return strcmp($b, $a);
+        });
+
+        $basePath = dirname($this->filename);
+
+        foreach (\array_slice($logFiles, $this->maxFiles) as $file) {
+            if (is_writable($file)) {
+                // suppress errors here as unlink() might fail if two processes
+                // are cleaning up/rotating at the same time
+                set_error_handler(function (int $errno, string $errstr, string $errfile, int $errline): bool {
+                    return true;
+                });
+                unlink($file);
+
+                $dir = dirname($file);
+                while ($dir !== $basePath) {
+                    $entries = scandir($dir);
+                    if ($entries === false || \count(array_diff($entries, ['.', '..'])) > 0) {
+                        break;
+                    }
+
+                    rmdir($dir);
+                    $dir = dirname($dir);
+                }
+                restore_error_handler();
+            }
+        }
+    }
+
+    protected function getTimedFilename(): string
+    {
+        $fileInfo = pathinfo($this->filename);
+        $timedFilename = str_replace(
+            ['{filename}', '{date}'],
+            [$fileInfo['filename'], (new \DateTimeImmutable(timezone: $this->timezone))->format($this->dateFormat)],
+            ($fileInfo['dirname'] ?? '') . '/' . $this->filenameFormat
+        );
+
+        if (isset($fileInfo['extension'])) {
+            $timedFilename .= '.'.$fileInfo['extension'];
+        }
+
+        return $timedFilename;
+    }
+
+    protected function getGlobPattern(): string
+    {
+        $fileInfo = pathinfo($this->filename);
+        $glob = str_replace(
+            ['{filename}', '{date}'],
+            [$fileInfo['filename'], str_replace(
+                ['Y', 'y', 'm', 'd'],
+                ['[0-9][0-9][0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]', '[0-9][0-9]'],
+                $this->dateFormat
+            )],
+            ($fileInfo['dirname'] ?? '') . '/' . $this->filenameFormat
+        );
+        if (isset($fileInfo['extension'])) {
+            $glob .= '.'.$fileInfo['extension'];
+        }
+
+        return $glob;
+    }
+
+    protected function setDateFormat(string $dateFormat): void
+    {
+        if (0 === preg_match('{^[Yy](([/_.-]?m)([/_.-]?d)?)?$}', $dateFormat)) {
+            throw new InvalidArgumentException(
+                'Invalid date format - format must be one of '.
+                'RotatingFileHandler::FILE_PER_DAY ("Y-m-d"), RotatingFileHandler::FILE_PER_MONTH ("Y-m") '.
+                'or RotatingFileHandler::FILE_PER_YEAR ("Y"), or you can set one of the '.
+                'date formats using slashes, underscores and/or dots instead of dashes.'
+            );
+        }
+        $this->dateFormat = $dateFormat;
+    }
+
+    protected function getNextRotation(): \DateTimeImmutable
+    {
+        return match (str_replace(['/','_','.'], '-', $this->dateFormat)) {
+            self::FILE_PER_MONTH => (new \DateTimeImmutable('first day of next month'))->setTime(0, 0, 0),
+            self::FILE_PER_YEAR => (new \DateTimeImmutable('first day of January next year'))->setTime(0, 0, 0),
+            default => (new \DateTimeImmutable('tomorrow'))->setTime(0, 0, 0),
+        };
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/SamplingHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/SamplingHandler.php
@@ -1,0 +1,121 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Closure;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\LogRecord;
+
+/**
+ * Sampling handler
+ *
+ * A sampled event stream can be useful for logging high frequency events in
+ * a production environment where you only need an idea of what is happening
+ * and are not concerned with capturing every occurrence. Since the decision to
+ * handle or not handle a particular event is determined randomly, the
+ * resulting sampled log is not guaranteed to contain 1/N of the events that
+ * occurred in the application, but based on the Law of large numbers, it will
+ * tend to be close to this ratio with a large number of attempts.
+ *
+ * @author Bryan Davis <bd808@wikimedia.org>
+ * @author Kunal Mehta <legoktm@gmail.com>
+ */
+class SamplingHandler extends AbstractHandler implements ProcessableHandlerInterface, FormattableHandlerInterface
+{
+    use ProcessableHandlerTrait;
+
+    /**
+     * Handler or factory Closure($record, $this)
+     *
+     * @phpstan-var (Closure(LogRecord|null, HandlerInterface): HandlerInterface)|HandlerInterface
+     */
+    protected Closure|HandlerInterface $handler;
+
+    protected int $factor;
+
+    /**
+     * @phpstan-param (Closure(LogRecord|null, HandlerInterface): HandlerInterface)|HandlerInterface $handler
+     *
+     * @param Closure|HandlerInterface $handler Handler or factory Closure($record|null, $samplingHandler).
+     * @param int                      $factor  Sample factor (e.g. 10 means every ~10th record is sampled)
+     */
+    public function __construct(Closure|HandlerInterface $handler, int $factor)
+    {
+        parent::__construct();
+        $this->handler = $handler;
+        $this->factor = $factor;
+    }
+
+    public function isHandling(LogRecord $record): bool
+    {
+        return $this->getHandler($record)->isHandling($record);
+    }
+
+    public function handle(LogRecord $record): bool
+    {
+        if ($this->isHandling($record) && mt_rand(1, $this->factor) === 1) {
+            if (\count($this->processors) > 0) {
+                $record = $this->processRecord($record);
+            }
+
+            $this->getHandler($record)->handle($record);
+        }
+
+        return false === $this->bubble;
+    }
+
+    /**
+     * Return the nested handler
+     *
+     * If the handler was provided as a factory, this will trigger the handler's instantiation.
+     */
+    public function getHandler(LogRecord|null $record = null): HandlerInterface
+    {
+        if (!$this->handler instanceof HandlerInterface) {
+            $handler = ($this->handler)($record, $this);
+            if (!$handler instanceof HandlerInterface) {
+                throw new \RuntimeException("The factory Closure should return a HandlerInterface");
+            }
+            $this->handler = $handler;
+        }
+
+        return $this->handler;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface
+    {
+        $handler = $this->getHandler();
+        if ($handler instanceof FormattableHandlerInterface) {
+            $handler->setFormatter($formatter);
+
+            return $this;
+        }
+
+        throw new \UnexpectedValueException('The nested handler of type '.\get_class($handler).' does not support formatters.');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getFormatter(): FormatterInterface
+    {
+        $handler = $this->getHandler();
+        if ($handler instanceof FormattableHandlerInterface) {
+            return $handler->getFormatter();
+        }
+
+        throw new \UnexpectedValueException('The nested handler of type '.\get_class($handler).' does not support formatters.');
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/SendGridHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/SendGridHandler.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\Utils;
+
+/**
+ * SendGridHandler uses the SendGrid API v3 function to send Log emails, more information in https://www.twilio.com/docs/sendgrid/for-developers/sending-email/api-getting-started
+ *
+ * @author Ricardo Fontanelli <ricardo.fontanelli@hotmail.com>
+ */
+class SendGridHandler extends MailHandler
+{
+    /**
+     * The SendGrid API User
+     * @deprecated this is not used anymore as of SendGrid API v3
+     */
+    protected string $apiUser;
+    /**
+     * The email addresses to which the message will be sent
+     * @var string[]
+     */
+    protected array $to;
+
+    /**
+     * @param string|null $apiUser Unused user as of SendGrid API v3, you can pass null or any string
+     * @param list<string>|string $to
+     * @param non-empty-string $apiHost Allows you to use another endpoint (e.g. api.eu.sendgrid.com)
+     * @throws MissingExtensionException If the curl extension is missing
+     */
+    public function __construct(
+        string|null $apiUser,
+        protected string $apiKey,
+        protected string $from,
+        array|string $to,
+        protected string $subject,
+        int|string|Level $level = Level::Error,
+        bool $bubble = true,
+        /** @var non-empty-string */
+        private readonly string $apiHost = 'api.sendgrid.com',
+    ) {
+        if (!\extension_loaded('curl')) {
+            throw new MissingExtensionException('The curl extension is needed to use the SendGridHandler');
+        }
+
+        $this->to = (array) $to;
+        // @phpstan-ignore property.deprecated
+        $this->apiUser = $apiUser ?? '';
+        parent::__construct($level, $bubble);
+    }
+
+    protected function send(string $content, array $records): void
+    {
+        $body = [];
+        $body['personalizations'] = [];
+        $body['from']['email'] = $this->from;
+        foreach ($this->to as $recipient) {
+            $body['personalizations'][]['to'][]['email'] = $recipient;
+        }
+        $body['subject'] = $this->subject;
+
+        if ($this->isHtmlBody($content)) {
+            $body['content'][] = [
+                'type' => 'text/html',
+                'value' => $content,
+            ];
+        } else {
+            $body['content'][] = [
+                'type' => 'text/plain',
+                'value' => $content,
+            ];
+        }
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/json',
+            'Authorization: Bearer '.$this->apiKey,
+        ]);
+        curl_setopt($ch, CURLOPT_URL, 'https://'.$this->apiHost.'/v3/mail/send');
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, Utils::jsonEncode($body));
+
+        Curl\Util::execute($ch, 2);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/Slack/SlackRecord.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/Slack/SlackRecord.php
@@ -1,0 +1,381 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler\Slack;
+
+use Monolog\Level;
+use Monolog\Utils;
+use Monolog\Formatter\NormalizerFormatter;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\LogRecord;
+
+/**
+ * Slack record utility helping to log to Slack webhooks or API.
+ *
+ * @author Greg Kedzierski <greg@gregkedzierski.com>
+ * @author Haralan Dobrev <hkdobrev@gmail.com>
+ * @see    https://api.slack.com/incoming-webhooks
+ * @see    https://api.slack.com/docs/message-attachments
+ */
+class SlackRecord
+{
+    public const COLOR_DANGER = 'danger';
+
+    public const COLOR_WARNING = 'warning';
+
+    public const COLOR_GOOD = 'good';
+
+    public const COLOR_DEFAULT = '#e3e4e6';
+
+    /**
+     * Slack channel (encoded ID or name)
+     */
+    private string|null $channel;
+
+    /**
+     * Name of a bot
+     */
+    private string|null $username;
+
+    /**
+     * User icon e.g. 'ghost', 'http://example.com/user.png'
+     */
+    private string|null $userIcon;
+
+    /**
+     * Whether the message should be added to Slack as attachment (plain text otherwise)
+     */
+    private bool $useAttachment;
+
+    /**
+     * Whether the the context/extra messages added to Slack as attachments are in a short style
+     */
+    private bool $useShortAttachment;
+
+    /**
+     * Whether the attachment should include context and extra data
+     */
+    private bool $includeContextAndExtra;
+
+    /**
+     * Dot separated list of fields to exclude from slack message. E.g. ['context.field1', 'extra.field2']
+     * @var string[]
+     */
+    private array $excludeFields;
+
+    private FormatterInterface|null $formatter;
+
+    private NormalizerFormatter $normalizerFormatter;
+
+    /**
+     * @param string[] $excludeFields
+     */
+    public function __construct(
+        ?string $channel = null,
+        ?string $username = null,
+        bool $useAttachment = true,
+        ?string $userIcon = null,
+        bool $useShortAttachment = false,
+        bool $includeContextAndExtra = false,
+        array $excludeFields = [],
+        FormatterInterface|null $formatter = null
+    ) {
+        $this
+            ->setChannel($channel)
+            ->setUsername($username)
+            ->useAttachment($useAttachment)
+            ->setUserIcon($userIcon)
+            ->useShortAttachment($useShortAttachment)
+            ->includeContextAndExtra($includeContextAndExtra)
+            ->excludeFields($excludeFields)
+            ->setFormatter($formatter);
+
+        if ($this->includeContextAndExtra) {
+            $this->normalizerFormatter = new NormalizerFormatter();
+        }
+    }
+
+    /**
+     * Returns required data in format that Slack
+     * is expecting.
+     *
+     * @phpstan-return mixed[]
+     */
+    public function getSlackData(LogRecord $record): array
+    {
+        $dataArray = [];
+
+        if ($this->username !== null) {
+            $dataArray['username'] = $this->username;
+        }
+
+        if ($this->channel !== null) {
+            $dataArray['channel'] = $this->channel;
+        }
+
+        if ($this->formatter !== null && !$this->useAttachment) {
+            $message = $this->formatter->format($record);
+        } else {
+            $message = $record->message;
+        }
+
+        $recordData = $this->removeExcludedFields($record);
+
+        if ($this->useAttachment) {
+            $attachment = [
+                'fallback'  => $message,
+                'text'      => $message,
+                'color'     => $this->getAttachmentColor($record->level),
+                'fields'    => [],
+                'mrkdwn_in' => ['fields'],
+                'ts'        => $recordData['datetime']->getTimestamp(),
+                'footer'      => $this->username,
+                'footer_icon' => $this->userIcon,
+            ];
+
+            if ($this->useShortAttachment) {
+                $attachment['title'] = $recordData['level_name'];
+            } else {
+                $attachment['title'] = 'Message';
+                $attachment['fields'][] = $this->generateAttachmentField('Level', $recordData['level_name']);
+            }
+
+            if ($this->includeContextAndExtra) {
+                foreach (['extra', 'context'] as $key) {
+                    if (!isset($recordData[$key]) || \count($recordData[$key]) === 0) {
+                        continue;
+                    }
+
+                    if ($this->useShortAttachment) {
+                        $attachment['fields'][] = $this->generateAttachmentField(
+                            $key,
+                            $recordData[$key]
+                        );
+                    } else {
+                        // Add all extra fields as individual fields in attachment
+                        $attachment['fields'] = array_merge(
+                            $attachment['fields'],
+                            $this->generateAttachmentFields($recordData[$key])
+                        );
+                    }
+                }
+            }
+
+            $dataArray['attachments'] = [$attachment];
+        } else {
+            $dataArray['text'] = $message;
+        }
+
+        if ($this->userIcon !== null) {
+            if (false !== ($iconUrl = filter_var($this->userIcon, FILTER_VALIDATE_URL))) {
+                $dataArray['icon_url'] = $iconUrl;
+            } else {
+                $dataArray['icon_emoji'] = ":{$this->userIcon}:";
+            }
+        }
+
+        return $dataArray;
+    }
+
+    /**
+     * Returns a Slack message attachment color associated with
+     * provided level.
+     */
+    public function getAttachmentColor(Level $level): string
+    {
+        return match ($level) {
+            Level::Error, Level::Critical, Level::Alert, Level::Emergency => static::COLOR_DANGER,
+            Level::Warning => static::COLOR_WARNING,
+            Level::Info, Level::Notice => static::COLOR_GOOD,
+            Level::Debug => static::COLOR_DEFAULT
+        };
+    }
+
+    /**
+     * Stringifies an array of key/value pairs to be used in attachment fields
+     *
+     * @param mixed[] $fields
+     */
+    public function stringify(array $fields): string
+    {
+        /** @var array<array<mixed>|bool|float|int|string|null> $normalized */
+        $normalized = $this->normalizerFormatter->normalizeValue($fields);
+
+        $hasSecondDimension = \count(array_filter($normalized, 'is_array')) > 0;
+        $hasOnlyNonNumericKeys = \count(array_filter(array_keys($normalized), 'is_numeric')) === 0;
+
+        return $hasSecondDimension || $hasOnlyNonNumericKeys
+            ? Utils::jsonEncode($normalized, JSON_PRETTY_PRINT|Utils::DEFAULT_JSON_FLAGS)
+            : Utils::jsonEncode($normalized, Utils::DEFAULT_JSON_FLAGS);
+    }
+
+    /**
+     * Channel used by the bot when posting
+     *
+     * @param  ?string $channel
+     * @return $this
+     */
+    public function setChannel(?string $channel = null): self
+    {
+        $this->channel = $channel;
+
+        return $this;
+    }
+
+    /**
+     * Username used by the bot when posting
+     *
+     * @param  ?string $username
+     * @return $this
+     */
+    public function setUsername(?string $username = null): self
+    {
+        $this->username = $username;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function useAttachment(bool $useAttachment = true): self
+    {
+        $this->useAttachment = $useAttachment;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setUserIcon(?string $userIcon = null): self
+    {
+        $this->userIcon = $userIcon;
+
+        if (\is_string($userIcon)) {
+            $this->userIcon = trim($userIcon, ':');
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function useShortAttachment(bool $useShortAttachment = false): self
+    {
+        $this->useShortAttachment = $useShortAttachment;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function includeContextAndExtra(bool $includeContextAndExtra = false): self
+    {
+        $this->includeContextAndExtra = $includeContextAndExtra;
+
+        if ($this->includeContextAndExtra) {
+            $this->normalizerFormatter = new NormalizerFormatter();
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param  string[] $excludeFields
+     * @return $this
+     */
+    public function excludeFields(array $excludeFields = []): self
+    {
+        $this->excludeFields = $excludeFields;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setFormatter(?FormatterInterface $formatter = null): self
+    {
+        $this->formatter = $formatter;
+
+        return $this;
+    }
+
+    /**
+     * Generates attachment field
+     *
+     * @param string|mixed[] $value
+     *
+     * @return array{title: string, value: string, short: false}
+     */
+    private function generateAttachmentField(string $title, $value): array
+    {
+        $value = \is_array($value)
+            ? sprintf('```%s```', substr($this->stringify($value), 0, 1990))
+            : $value;
+
+        return [
+            'title' => ucfirst($title),
+            'value' => $value,
+            'short' => false,
+        ];
+    }
+
+    /**
+     * Generates a collection of attachment fields from array
+     *
+     * @param mixed[] $data
+     *
+     * @return array<array{title: string, value: string, short: false}>
+     */
+    private function generateAttachmentFields(array $data): array
+    {
+        /** @var array<array<mixed>|string> $normalized */
+        $normalized = $this->normalizerFormatter->normalizeValue($data);
+
+        $fields = [];
+        foreach ($normalized as $key => $value) {
+            $fields[] = $this->generateAttachmentField((string) $key, $value);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Get a copy of record with fields excluded according to $this->excludeFields
+     *
+     * @return mixed[]
+     */
+    private function removeExcludedFields(LogRecord $record): array
+    {
+        $recordData = $record->toArray();
+        foreach ($this->excludeFields as $field) {
+            $keys = explode('.', $field);
+            $node = &$recordData;
+            $lastKey = end($keys);
+            foreach ($keys as $key) {
+                if (!isset($node[$key])) {
+                    break;
+                }
+                if ($lastKey === $key) {
+                    unset($node[$key]);
+                    break;
+                }
+                $node = &$node[$key];
+            }
+        }
+
+        return $recordData;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/SlackHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/SlackHandler.php
@@ -1,0 +1,267 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Level;
+use Monolog\Utils;
+use Monolog\Handler\Slack\SlackRecord;
+use Monolog\LogRecord;
+
+/**
+ * Sends notifications through Slack API
+ *
+ * @author Greg Kedzierski <greg@gregkedzierski.com>
+ * @see    https://api.slack.com/
+ */
+class SlackHandler extends SocketHandler
+{
+    /**
+     * Slack API token
+     */
+    private string $token;
+
+    /**
+     * Instance of the SlackRecord util class preparing data for Slack API.
+     */
+    private SlackRecord $slackRecord;
+
+    /**
+     * @param  string                    $token                  Slack API token
+     * @param  string                    $channel                Slack channel (encoded ID or name)
+     * @param  string|null               $username               Name of a bot
+     * @param  bool                      $useAttachment          Whether the message should be added to Slack as attachment (plain text otherwise)
+     * @param  string|null               $iconEmoji              The emoji name to use (or null)
+     * @param  bool                      $useShortAttachment     Whether the context/extra messages added to Slack as attachments are in a short style
+     * @param  bool                      $includeContextAndExtra Whether the attachment should include context and extra data
+     * @param  string[]                  $excludeFields          Dot separated list of fields to exclude from slack message. E.g. ['context.field1', 'extra.field2']
+     * @throws MissingExtensionException If no OpenSSL PHP extension configured
+     */
+    public function __construct(
+        string $token,
+        string $channel,
+        ?string $username = null,
+        bool $useAttachment = true,
+        ?string $iconEmoji = null,
+        $level = Level::Critical,
+        bool $bubble = true,
+        bool $useShortAttachment = false,
+        bool $includeContextAndExtra = false,
+        array $excludeFields = [],
+        bool $persistent = false,
+        float $timeout = 0.0,
+        float $writingTimeout = 10.0,
+        ?float $connectionTimeout = null,
+        ?int $chunkSize = null
+    ) {
+        if (!\extension_loaded('openssl')) {
+            throw new MissingExtensionException('The OpenSSL PHP extension is required to use the SlackHandler');
+        }
+
+        parent::__construct(
+            'ssl://slack.com:443',
+            $level,
+            $bubble,
+            $persistent,
+            $timeout,
+            $writingTimeout,
+            $connectionTimeout,
+            $chunkSize
+        );
+
+        $this->slackRecord = new SlackRecord(
+            $channel,
+            $username,
+            $useAttachment,
+            $iconEmoji,
+            $useShortAttachment,
+            $includeContextAndExtra,
+            $excludeFields
+        );
+
+        $this->token = $token;
+    }
+
+    public function getSlackRecord(): SlackRecord
+    {
+        return $this->slackRecord;
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function generateDataStream(LogRecord $record): string
+    {
+        $content = $this->buildContent($record);
+
+        return $this->buildHeader($content) . $content;
+    }
+
+    /**
+     * Builds the body of API call
+     */
+    private function buildContent(LogRecord $record): string
+    {
+        $dataArray = $this->prepareContentData($record);
+
+        return http_build_query($dataArray);
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function prepareContentData(LogRecord $record): array
+    {
+        $dataArray = $this->slackRecord->getSlackData($record);
+        $dataArray['token'] = $this->token;
+
+        if (isset($dataArray['attachments']) && \is_array($dataArray['attachments']) && \count($dataArray['attachments']) > 0) {
+            $dataArray['attachments'] = Utils::jsonEncode($dataArray['attachments']);
+        }
+
+        return $dataArray;
+    }
+
+    /**
+     * Builds the header of the API Call
+     */
+    private function buildHeader(string $content): string
+    {
+        $header = "POST /api/chat.postMessage HTTP/1.1\r\n";
+        $header .= "Host: slack.com\r\n";
+        $header .= "Content-Type: application/x-www-form-urlencoded\r\n";
+        $header .= "Content-Length: " . \strlen($content) . "\r\n";
+        $header .= "\r\n";
+
+        return $header;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        parent::write($record);
+        $this->finalizeWrite();
+    }
+
+    /**
+     * Finalizes the request by reading some bytes and then closing the socket
+     *
+     * If we do not read some but close the socket too early, slack sometimes
+     * drops the request entirely.
+     */
+    protected function finalizeWrite(): void
+    {
+        $res = $this->getResource();
+        if (\is_resource($res)) {
+            @fread($res, 2048);
+        }
+        $this->closeSocket();
+    }
+
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface
+    {
+        parent::setFormatter($formatter);
+        $this->slackRecord->setFormatter($formatter);
+
+        return $this;
+    }
+
+    public function getFormatter(): FormatterInterface
+    {
+        $formatter = parent::getFormatter();
+        $this->slackRecord->setFormatter($formatter);
+
+        return $formatter;
+    }
+
+    /**
+     * Channel used by the bot when posting
+     *
+     * @return $this
+     */
+    public function setChannel(string $channel): self
+    {
+        $this->slackRecord->setChannel($channel);
+
+        return $this;
+    }
+
+    /**
+     * Username used by the bot when posting
+     *
+     * @return $this
+     */
+    public function setUsername(string $username): self
+    {
+        $this->slackRecord->setUsername($username);
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function useAttachment(bool $useAttachment): self
+    {
+        $this->slackRecord->useAttachment($useAttachment);
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setIconEmoji(string $iconEmoji): self
+    {
+        $this->slackRecord->setUserIcon($iconEmoji);
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function useShortAttachment(bool $useShortAttachment): self
+    {
+        $this->slackRecord->useShortAttachment($useShortAttachment);
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function includeContextAndExtra(bool $includeContextAndExtra): self
+    {
+        $this->slackRecord->includeContextAndExtra($includeContextAndExtra);
+
+        return $this;
+    }
+
+    /**
+     * @param  string[] $excludeFields
+     * @return $this
+     */
+    public function excludeFields(array $excludeFields): self
+    {
+        $this->slackRecord->excludeFields($excludeFields);
+
+        return $this;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/SlackWebhookHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/SlackWebhookHandler.php
@@ -1,0 +1,130 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Level;
+use Monolog\Utils;
+use Monolog\Handler\Slack\SlackRecord;
+use Monolog\LogRecord;
+
+/**
+ * Sends notifications through Slack Webhooks
+ *
+ * @author Haralan Dobrev <hkdobrev@gmail.com>
+ * @see    https://api.slack.com/incoming-webhooks
+ */
+class SlackWebhookHandler extends AbstractProcessingHandler
+{
+    /**
+     * Slack Webhook token
+     *
+     * @var non-empty-string
+     */
+    private string $webhookUrl;
+
+    /**
+     * Instance of the SlackRecord util class preparing data for Slack API.
+     */
+    private SlackRecord $slackRecord;
+
+    /**
+     * @param non-empty-string $webhookUrl             Slack Webhook URL
+     * @param string|null $channel                Slack channel (encoded ID or name)
+     * @param string|null $username               Name of a bot
+     * @param bool        $useAttachment          Whether the message should be added to Slack as attachment (plain text otherwise)
+     * @param string|null $iconEmoji              The emoji name to use (or null)
+     * @param bool        $useShortAttachment     Whether the the context/extra messages added to Slack as attachments are in a short style
+     * @param bool        $includeContextAndExtra Whether the attachment should include context and extra data
+     * @param string[]    $excludeFields          Dot separated list of fields to exclude from slack message. E.g. ['context.field1', 'extra.field2']
+     *
+     * @throws MissingExtensionException If the curl extension is missing
+     */
+    public function __construct(
+        string $webhookUrl,
+        ?string $channel = null,
+        ?string $username = null,
+        bool $useAttachment = true,
+        ?string $iconEmoji = null,
+        bool $useShortAttachment = false,
+        bool $includeContextAndExtra = false,
+        $level = Level::Critical,
+        bool $bubble = true,
+        array $excludeFields = []
+    ) {
+        if (!\extension_loaded('curl')) {
+            throw new MissingExtensionException('The curl extension is needed to use the SlackWebhookHandler');
+        }
+
+        parent::__construct($level, $bubble);
+
+        $this->webhookUrl = $webhookUrl;
+
+        $this->slackRecord = new SlackRecord(
+            $channel,
+            $username,
+            $useAttachment,
+            $iconEmoji,
+            $useShortAttachment,
+            $includeContextAndExtra,
+            $excludeFields
+        );
+    }
+
+    public function getSlackRecord(): SlackRecord
+    {
+        return $this->slackRecord;
+    }
+
+    public function getWebhookUrl(): string
+    {
+        return $this->webhookUrl;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        $postData = $this->slackRecord->getSlackData($record);
+        $postString = Utils::jsonEncode($postData);
+
+        $ch = curl_init();
+        $options = [
+            CURLOPT_URL => $this->webhookUrl,
+            CURLOPT_POST => true,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HTTPHEADER => ['Content-type: application/json'],
+            CURLOPT_POSTFIELDS => $postString,
+        ];
+
+        curl_setopt_array($ch, $options);
+
+        Curl\Util::execute($ch);
+    }
+
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface
+    {
+        parent::setFormatter($formatter);
+        $this->slackRecord->setFormatter($formatter);
+
+        return $this;
+    }
+
+    public function getFormatter(): FormatterInterface
+    {
+        $formatter = parent::getFormatter();
+        $this->slackRecord->setFormatter($formatter);
+
+        return $formatter;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/SocketHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/SocketHandler.php
@@ -1,0 +1,436 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\LogRecord;
+
+/**
+ * Stores to any socket - uses fsockopen() or pfsockopen().
+ *
+ * @author Pablo de Leon Belloc <pablolb@gmail.com>
+ * @see    http://php.net/manual/en/function.fsockopen.php
+ */
+class SocketHandler extends AbstractProcessingHandler
+{
+    private string $connectionString;
+    private float $connectionTimeout;
+    /** @var resource|null */
+    private $resource;
+    private float $timeout;
+    private float $writingTimeout;
+    private int|null $lastSentBytes = null;
+    private int|null $chunkSize;
+    private bool $persistent;
+    private int|null $errno = null;
+    private string|null $errstr = null;
+    private float|null $lastWritingAt = null;
+
+    /**
+     * @param string     $connectionString  Socket connection string
+     * @param bool       $persistent        Flag to enable/disable persistent connections
+     * @param float      $timeout           Socket timeout to wait until the request is being aborted
+     * @param float      $writingTimeout    Socket timeout to wait until the request should've been sent/written
+     * @param float|null $connectionTimeout Socket connect timeout to wait until the connection should've been
+     *                                      established
+     * @param int|null   $chunkSize         Sets the chunk size. Only has effect during connection in the writing cycle
+     *
+     * @throws \InvalidArgumentException If an invalid timeout value (less than 0) is passed.
+     */
+    public function __construct(
+        string $connectionString,
+        $level = Level::Debug,
+        bool $bubble = true,
+        bool $persistent = false,
+        float $timeout = 0.0,
+        float $writingTimeout = 10.0,
+        ?float $connectionTimeout = null,
+        ?int $chunkSize = null
+    ) {
+        parent::__construct($level, $bubble);
+        $this->connectionString = $connectionString;
+
+        if ($connectionTimeout !== null) {
+            $this->validateTimeout($connectionTimeout);
+        }
+
+        $this->connectionTimeout = $connectionTimeout ?? (float) \ini_get('default_socket_timeout');
+        $this->persistent = $persistent;
+        $this->validateTimeout($timeout);
+        $this->timeout = $timeout;
+        $this->validateTimeout($writingTimeout);
+        $this->writingTimeout = $writingTimeout;
+        $this->chunkSize = $chunkSize;
+    }
+
+    /**
+     * Connect (if necessary) and write to the socket
+     *
+     * @inheritDoc
+     *
+     * @throws \UnexpectedValueException
+     * @throws \RuntimeException
+     */
+    protected function write(LogRecord $record): void
+    {
+        $this->connectIfNotConnected();
+        $data = $this->generateDataStream($record);
+        $this->writeToSocket($data);
+    }
+
+    /**
+     * We will not close a PersistentSocket instance so it can be reused in other requests.
+     */
+    public function close(): void
+    {
+        if (!$this->isPersistent()) {
+            $this->closeSocket();
+        }
+    }
+
+    /**
+     * Close socket, if open
+     */
+    public function closeSocket(): void
+    {
+        if (\is_resource($this->resource)) {
+            fclose($this->resource);
+            $this->resource = null;
+        }
+    }
+
+    /**
+     * Set socket connection to be persistent. It only has effect before the connection is initiated.
+     *
+     * @return $this
+     */
+    public function setPersistent(bool $persistent): self
+    {
+        $this->persistent = $persistent;
+
+        return $this;
+    }
+
+    /**
+     * Set connection timeout.  Only has effect before we connect.
+     *
+     * @see http://php.net/manual/en/function.fsockopen.php
+     * @return $this
+     */
+    public function setConnectionTimeout(float $seconds): self
+    {
+        $this->validateTimeout($seconds);
+        $this->connectionTimeout = $seconds;
+
+        return $this;
+    }
+
+    /**
+     * Set write timeout. Only has effect before we connect.
+     *
+     * @see http://php.net/manual/en/function.stream-set-timeout.php
+     * @return $this
+     */
+    public function setTimeout(float $seconds): self
+    {
+        $this->validateTimeout($seconds);
+        $this->timeout = $seconds;
+
+        return $this;
+    }
+
+    /**
+     * Set writing timeout. Only has effect during connection in the writing cycle.
+     *
+     * @param  float $seconds 0 for no timeout
+     * @return $this
+     */
+    public function setWritingTimeout(float $seconds): self
+    {
+        $this->validateTimeout($seconds);
+        $this->writingTimeout = $seconds;
+
+        return $this;
+    }
+
+    /**
+     * Set chunk size. Only has effect during connection in the writing cycle.
+     *
+     * @return $this
+     */
+    public function setChunkSize(int $bytes): self
+    {
+        $this->chunkSize = $bytes;
+
+        return $this;
+    }
+
+    /**
+     * Get current connection string
+     */
+    public function getConnectionString(): string
+    {
+        return $this->connectionString;
+    }
+
+    /**
+     * Get persistent setting
+     */
+    public function isPersistent(): bool
+    {
+        return $this->persistent;
+    }
+
+    /**
+     * Get current connection timeout setting
+     */
+    public function getConnectionTimeout(): float
+    {
+        return $this->connectionTimeout;
+    }
+
+    /**
+     * Get current in-transfer timeout
+     */
+    public function getTimeout(): float
+    {
+        return $this->timeout;
+    }
+
+    /**
+     * Get current local writing timeout
+     */
+    public function getWritingTimeout(): float
+    {
+        return $this->writingTimeout;
+    }
+
+    /**
+     * Get current chunk size
+     */
+    public function getChunkSize(): ?int
+    {
+        return $this->chunkSize;
+    }
+
+    /**
+     * Check to see if the socket is currently available.
+     *
+     * UDP might appear to be connected but might fail when writing.  See http://php.net/fsockopen for details.
+     */
+    public function isConnected(): bool
+    {
+        return \is_resource($this->resource)
+            && !feof($this->resource);  // on TCP - other party can close connection.
+    }
+
+    /**
+     * Wrapper to allow mocking
+     *
+     * @return resource|false
+     */
+    protected function pfsockopen()
+    {
+        return @pfsockopen($this->connectionString, -1, $this->errno, $this->errstr, $this->connectionTimeout);
+    }
+
+    /**
+     * Wrapper to allow mocking
+     *
+     * @return resource|false
+     */
+    protected function fsockopen()
+    {
+        return @fsockopen($this->connectionString, -1, $this->errno, $this->errstr, $this->connectionTimeout);
+    }
+
+    /**
+     * Wrapper to allow mocking
+     *
+     * @see http://php.net/manual/en/function.stream-set-timeout.php
+     */
+    protected function streamSetTimeout(): bool
+    {
+        $seconds = floor($this->timeout);
+        $microseconds = round(($this->timeout - $seconds) * 1e6);
+
+        if (!\is_resource($this->resource)) {
+            throw new \LogicException('streamSetTimeout called but $this->resource is not a resource');
+        }
+
+        return stream_set_timeout($this->resource, (int) $seconds, (int) $microseconds);
+    }
+
+    /**
+     * Wrapper to allow mocking
+     *
+     * @see http://php.net/manual/en/function.stream-set-chunk-size.php
+     *
+     * @return int|false
+     */
+    protected function streamSetChunkSize(): int|bool
+    {
+        if (!\is_resource($this->resource)) {
+            throw new \LogicException('streamSetChunkSize called but $this->resource is not a resource');
+        }
+
+        if (null === $this->chunkSize) {
+            throw new \LogicException('streamSetChunkSize called but $this->chunkSize is not set');
+        }
+
+        return stream_set_chunk_size($this->resource, $this->chunkSize);
+    }
+
+    /**
+     * Wrapper to allow mocking
+     *
+     * @return int|false
+     */
+    protected function fwrite(string $data): int|bool
+    {
+        if (!\is_resource($this->resource)) {
+            throw new \LogicException('fwrite called but $this->resource is not a resource');
+        }
+
+        return @fwrite($this->resource, $data);
+    }
+
+    /**
+     * Wrapper to allow mocking
+     *
+     * @return mixed[]|bool
+     */
+    protected function streamGetMetadata(): array|bool
+    {
+        if (!\is_resource($this->resource)) {
+            throw new \LogicException('streamGetMetadata called but $this->resource is not a resource');
+        }
+
+        return stream_get_meta_data($this->resource);
+    }
+
+    private function validateTimeout(float $value): void
+    {
+        if ($value < 0) {
+            throw new \InvalidArgumentException("Timeout must be 0 or a positive float (got $value)");
+        }
+    }
+
+    private function connectIfNotConnected(): void
+    {
+        if ($this->isConnected()) {
+            return;
+        }
+        $this->connect();
+    }
+
+    protected function generateDataStream(LogRecord $record): string
+    {
+        return (string) $record->formatted;
+    }
+
+    /**
+     * @return resource|null
+     */
+    protected function getResource()
+    {
+        return $this->resource;
+    }
+
+    private function connect(): void
+    {
+        $this->createSocketResource();
+        $this->setSocketTimeout();
+        $this->setStreamChunkSize();
+    }
+
+    private function createSocketResource(): void
+    {
+        if ($this->isPersistent()) {
+            $resource = $this->pfsockopen();
+        } else {
+            $resource = $this->fsockopen();
+        }
+        if (\is_bool($resource)) {
+            throw new \UnexpectedValueException("Failed connecting to $this->connectionString ($this->errno: $this->errstr)");
+        }
+        $this->resource = $resource;
+    }
+
+    private function setSocketTimeout(): void
+    {
+        if (!$this->streamSetTimeout()) {
+            throw new \UnexpectedValueException("Failed setting timeout with stream_set_timeout()");
+        }
+    }
+
+    private function setStreamChunkSize(): void
+    {
+        if (null !== $this->chunkSize && false === $this->streamSetChunkSize()) {
+            throw new \UnexpectedValueException("Failed setting chunk size with stream_set_chunk_size()");
+        }
+    }
+
+    private function writeToSocket(string $data): void
+    {
+        $length = \strlen($data);
+        $sent = 0;
+        $this->lastSentBytes = $sent;
+        while ($this->isConnected() && $sent < $length) {
+            if (0 === $sent) {
+                $chunk = $this->fwrite($data);
+            } else {
+                $chunk = $this->fwrite(substr($data, $sent));
+            }
+            if ($chunk === false) {
+                throw new \RuntimeException("Could not write to socket");
+            }
+            $sent += $chunk;
+            $socketInfo = $this->streamGetMetadata();
+            if (\is_array($socketInfo) && (bool) $socketInfo['timed_out']) {
+                throw new \RuntimeException("Write timed-out");
+            }
+
+            if ($this->writingIsTimedOut($sent)) {
+                throw new \RuntimeException("Write timed-out, no data sent for `{$this->writingTimeout}` seconds, probably we got disconnected (sent $sent of $length)");
+            }
+        }
+        if (!$this->isConnected() && $sent < $length) {
+            throw new \RuntimeException("End-of-file reached, probably we got disconnected (sent $sent of $length)");
+        }
+    }
+
+    private function writingIsTimedOut(int $sent): bool
+    {
+        // convert to ms
+        if (0.0 === $this->writingTimeout) {
+            return false;
+        }
+
+        if ($sent !== $this->lastSentBytes) {
+            $this->lastWritingAt = microtime(true);
+            $this->lastSentBytes = $sent;
+
+            return false;
+        } else {
+            usleep(100);
+        }
+
+        if ((microtime(true) - (float) $this->lastWritingAt) >= $this->writingTimeout) {
+            $this->closeSocket();
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/SqsHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/SqsHandler.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Aws\Sqs\SqsClient;
+use Monolog\Level;
+use Monolog\Utils;
+use Monolog\LogRecord;
+
+/**
+ * Writes to any sqs queue.
+ *
+ * @author Martijn van Calker <git@amvc.nl>
+ */
+class SqsHandler extends AbstractProcessingHandler
+{
+    /** 256 KB in bytes - maximum message size in SQS */
+    protected const MAX_MESSAGE_SIZE = 262144;
+    /** 100 KB in bytes - head message size for new error log */
+    protected const HEAD_MESSAGE_SIZE = 102400;
+
+    private SqsClient $client;
+    private string $queueUrl;
+
+    public function __construct(SqsClient $sqsClient, string $queueUrl, int|string|Level $level = Level::Debug, bool $bubble = true)
+    {
+        parent::__construct($level, $bubble);
+
+        $this->client = $sqsClient;
+        $this->queueUrl = $queueUrl;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        if (!isset($record->formatted) || 'string' !== \gettype($record->formatted)) {
+            throw new \InvalidArgumentException('SqsHandler accepts only formatted records as a string' . Utils::getRecordMessageForException($record));
+        }
+
+        $messageBody = $record->formatted;
+        if (\strlen($messageBody) >= static::MAX_MESSAGE_SIZE) {
+            $messageBody = Utils::substr($messageBody, 0, static::HEAD_MESSAGE_SIZE);
+        }
+
+        $this->client->sendMessage([
+            'QueueUrl' => $this->queueUrl,
+            'MessageBody' => $messageBody,
+        ]);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/StreamHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/StreamHandler.php
@@ -1,0 +1,280 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\Utils;
+use Monolog\LogRecord;
+
+/**
+ * Stores to any stream resource
+ *
+ * Can be used to store into php://stderr, remote and local files, etc.
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class StreamHandler extends AbstractProcessingHandler
+{
+    protected const MAX_CHUNK_SIZE = 2147483647;
+    /** 10MB */
+    protected const DEFAULT_CHUNK_SIZE = 10 * 1024 * 1024;
+    protected int $streamChunkSize;
+    /** @var resource|null */
+    protected $stream;
+    protected string|null $url = null;
+    private string|null $errorMessage = null;
+    protected int|null $filePermission;
+    protected bool $useLocking;
+    protected string $fileOpenMode;
+    /** @var true|null */
+    private bool|null $dirCreated = null;
+    private bool $retrying = false;
+    private int|null $inodeUrl = null;
+
+    /**
+     * @param resource|string $stream         If a missing path can't be created, an UnexpectedValueException will be thrown on first write
+     * @param int|null        $filePermission Optional file permissions (default (0644) are only for owner read/write)
+     * @param bool            $useLocking     Try to lock log file before doing any writes
+     * @param string          $fileOpenMode   The fopen() mode used when opening a file, if $stream is a file path
+     *
+     * @throws \InvalidArgumentException If stream is not a resource or string
+     */
+    public function __construct($stream, int|string|Level $level = Level::Debug, bool $bubble = true, ?int $filePermission = null, bool $useLocking = false, string $fileOpenMode = 'a')
+    {
+        parent::__construct($level, $bubble);
+
+        if (($phpMemoryLimit = Utils::expandIniShorthandBytes(\ini_get('memory_limit'))) !== false) {
+            if ($phpMemoryLimit > 0) {
+                // use max 10% of allowed memory for the chunk size, and at least 100KB
+                $this->streamChunkSize = min(static::MAX_CHUNK_SIZE, max((int) ($phpMemoryLimit / 10), 100 * 1024));
+            } else {
+                // memory is unlimited, set to the default 10MB
+                $this->streamChunkSize = static::DEFAULT_CHUNK_SIZE;
+            }
+        } else {
+            // no memory limit information, set to the default 10MB
+            $this->streamChunkSize = static::DEFAULT_CHUNK_SIZE;
+        }
+
+        if (\is_resource($stream)) {
+            $this->stream = $stream;
+
+            stream_set_chunk_size($this->stream, $this->streamChunkSize);
+        } elseif (\is_string($stream)) {
+            $this->url = Utils::canonicalizePath($stream);
+        } else {
+            throw new \InvalidArgumentException('A stream must either be a resource or a string.');
+        }
+
+        $this->fileOpenMode = $fileOpenMode;
+        $this->filePermission = $filePermission;
+        $this->useLocking = $useLocking;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function reset(): void
+    {
+        parent::reset();
+
+        // auto-close on reset to make sure we periodically close the file in long running processes
+        // as long as they correctly call reset() between jobs
+        if ($this->url !== null && $this->url !== 'php://memory') {
+            $this->close();
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function close(): void
+    {
+        if (null !== $this->url && \is_resource($this->stream)) {
+            fclose($this->stream);
+        }
+        $this->stream = null;
+        $this->dirCreated = null;
+    }
+
+    /**
+     * Return the currently active stream if it is open
+     *
+     * @return resource|null
+     */
+    public function getStream()
+    {
+        return $this->stream;
+    }
+
+    /**
+     * Return the stream URL if it was configured with a URL and not an active resource
+     */
+    public function getUrl(): ?string
+    {
+        return $this->url;
+    }
+
+    public function getStreamChunkSize(): int
+    {
+        return $this->streamChunkSize;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        if ($this->hasUrlInodeWasChanged()) {
+            $this->close();
+            $this->write($record);
+
+            return;
+        }
+
+        if (!\is_resource($this->stream)) {
+            $url = $this->url;
+            if (null === $url || '' === $url) {
+                throw new \LogicException('Missing stream url, the stream can not be opened. This may be caused by a premature call to close().' . Utils::getRecordMessageForException($record));
+            }
+            $this->createDir($url);
+            $this->errorMessage = null;
+            set_error_handler($this->customErrorHandler(...));
+
+            try {
+                $stream = fopen($url, $this->fileOpenMode);
+                if ($this->filePermission !== null) {
+                    @chmod($url, $this->filePermission);
+                }
+            } finally {
+                restore_error_handler();
+            }
+            if (!\is_resource($stream)) {
+                $this->stream = null;
+
+                throw new \UnexpectedValueException(sprintf('The stream or file "%s" could not be opened in append mode: '.$this->errorMessage, $url) . Utils::getRecordMessageForException($record));
+            }
+            stream_set_chunk_size($stream, $this->streamChunkSize);
+            $this->stream = $stream;
+            $this->inodeUrl = $this->getInodeFromUrl();
+        }
+
+        $stream = $this->stream;
+        if ($this->useLocking) {
+            // ignoring errors here, there's not much we can do about them
+            flock($stream, LOCK_EX);
+        }
+
+        $this->errorMessage = null;
+        set_error_handler($this->customErrorHandler(...));
+        try {
+            $this->streamWrite($stream, $record);
+        } finally {
+            restore_error_handler();
+        }
+        if ($this->errorMessage !== null) {
+            $error = $this->errorMessage;
+            // close the resource if possible to reopen it, and retry the failed write
+            if (!$this->retrying && $this->url !== null && $this->url !== 'php://memory') {
+                $this->retrying = true;
+                $this->close();
+                $this->write($record);
+
+                return;
+            }
+
+            throw new \UnexpectedValueException('Writing to the log file failed: '.$error . Utils::getRecordMessageForException($record));
+        }
+
+        $this->retrying = false;
+        if ($this->useLocking) {
+            flock($stream, LOCK_UN);
+        }
+    }
+
+    /**
+     * Write to stream
+     * @param resource $stream
+     */
+    protected function streamWrite($stream, LogRecord $record): void
+    {
+        fwrite($stream, (string) $record->formatted);
+    }
+
+    /**
+     * @return true
+     */
+    private function customErrorHandler(int $code, string $msg): bool
+    {
+        $this->errorMessage = preg_replace('{^(fopen|mkdir|fwrite)\(.*?\): }', '', $msg);
+
+        return true;
+    }
+
+    private function getDirFromStream(string $stream): ?string
+    {
+        $pos = strpos($stream, '://');
+        if ($pos === false) {
+            return \dirname($stream);
+        }
+
+        if ('file://' === substr($stream, 0, 7)) {
+            return \dirname(substr($stream, 7));
+        }
+
+        return null;
+    }
+
+    private function createDir(string $url): void
+    {
+        // Do not try to create dir if it has already been tried.
+        if (true === $this->dirCreated) {
+            return;
+        }
+
+        $dir = $this->getDirFromStream($url);
+        if (null !== $dir && !is_dir($dir)) {
+            $this->errorMessage = null;
+            set_error_handler(function (...$args) {
+                return $this->customErrorHandler(...$args);
+            });
+            $status = mkdir($dir, 0777, true);
+            restore_error_handler();
+            if (false === $status && !is_dir($dir) && strpos((string) $this->errorMessage, 'File exists') === false) {
+                throw new \UnexpectedValueException(sprintf('There is no existing directory at "%s" and it could not be created: '.$this->errorMessage, $dir));
+            }
+        }
+        $this->dirCreated = true;
+    }
+
+    private function getInodeFromUrl(): ?int
+    {
+        if ($this->url === null || str_starts_with($this->url, 'php://')) {
+            return null;
+        }
+
+        $inode = @fileinode($this->url);
+
+        return $inode === false ? null : $inode;
+    }
+
+    private function hasUrlInodeWasChanged(): bool
+    {
+        if ($this->inodeUrl === null || $this->retrying || $this->inodeUrl === $this->getInodeFromUrl()) {
+            return false;
+        }
+
+        $this->retrying = true;
+
+        return true;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/SymfonyMailerHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/SymfonyMailerHandler.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Closure;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Monolog\Utils;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\LineFormatter;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mime\Email;
+
+/**
+ * SymfonyMailerHandler uses Symfony's Mailer component to send the emails
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class SymfonyMailerHandler extends MailHandler
+{
+    protected MailerInterface|TransportInterface $mailer;
+    /** @var Email|Closure(string, LogRecord[]): Email */
+    private Email|Closure $emailTemplate;
+
+    /**
+     * @phpstan-param Email|Closure(string, LogRecord[]): Email $email
+     *
+     * @param MailerInterface|TransportInterface $mailer The mailer to use
+     * @param Closure|Email                      $email  An email template, the subject/body will be replaced
+     */
+    public function __construct($mailer, Email|Closure $email, int|string|Level $level = Level::Error, bool $bubble = true)
+    {
+        parent::__construct($level, $bubble);
+
+        $this->mailer = $mailer;
+        $this->emailTemplate = $email;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function send(string $content, array $records): void
+    {
+        $this->mailer->send($this->buildMessage($content, $records));
+    }
+
+    /**
+     * Gets the formatter for the Swift_Message subject.
+     *
+     * @param string|null $format The format of the subject
+     */
+    protected function getSubjectFormatter(?string $format): FormatterInterface
+    {
+        return new LineFormatter($format);
+    }
+
+    /**
+     * Creates instance of Email to be sent
+     *
+     * @param string      $content formatted email body to be sent
+     * @param LogRecord[] $records Log records that formed the content
+     */
+    protected function buildMessage(string $content, array $records): Email
+    {
+        $message = null;
+        if ($this->emailTemplate instanceof Email) {
+            $message = clone $this->emailTemplate;
+        } elseif (\is_callable($this->emailTemplate)) {
+            $message = ($this->emailTemplate)($content, $records);
+        }
+
+        if (!$message instanceof Email) {
+            $record = reset($records);
+
+            throw new \InvalidArgumentException('Could not resolve message as instance of Email or a callable returning it' . ($record instanceof LogRecord ? Utils::getRecordMessageForException($record) : ''));
+        }
+
+        if (\count($records) > 0) {
+            $subjectFormatter = $this->getSubjectFormatter($message->getSubject());
+            $message->subject($subjectFormatter->format($this->getHighestRecord($records)));
+        }
+
+        if ($this->isHtmlBody($content)) {
+            if (null !== ($charset = $message->getHtmlCharset())) {
+                $message->html($content, $charset);
+            } else {
+                $message->html($content);
+            }
+        } else {
+            if (null !== ($charset = $message->getTextCharset())) {
+                $message->text($content, $charset);
+            } else {
+                $message->text($content);
+            }
+        }
+
+        return $message->date(new \DateTimeImmutable());
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/SyslogHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/SyslogHandler.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\LogRecord;
+
+/**
+ * Logs to syslog service.
+ *
+ * usage example:
+ *
+ *   $log = new Logger('application');
+ *   $syslog = new SyslogHandler('myfacility', 'local6');
+ *   $formatter = new LineFormatter("%channel%.%level_name%: %message% %extra%");
+ *   $syslog->setFormatter($formatter);
+ *   $log->pushHandler($syslog);
+ *
+ * @author Sven Paulus <sven@karlsruhe.org>
+ */
+class SyslogHandler extends AbstractSyslogHandler
+{
+    protected string $ident;
+    protected int $logopts;
+
+    /**
+     * @param string|int $facility Either one of the names of the keys in $this->facilities, or a LOG_* facility constant
+     * @param int        $logopts  Option flags for the openlog() call, defaults to LOG_PID
+     */
+    public function __construct(string $ident, string|int $facility = LOG_USER, int|string|Level $level = Level::Debug, bool $bubble = true, int $logopts = LOG_PID)
+    {
+        parent::__construct($facility, $level, $bubble);
+
+        $this->ident = $ident;
+        $this->logopts = $logopts;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function close(): void
+    {
+        closelog();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        openlog($this->ident, $this->logopts, $this->facility);
+        syslog($this->toSyslogPriority($record->level), (string) $record->formatted);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/SyslogUdp/UdpSocket.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/SyslogUdp/UdpSocket.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler\SyslogUdp;
+
+use Monolog\Utils;
+use Socket;
+
+class UdpSocket
+{
+    protected const DATAGRAM_MAX_LENGTH = 65023;
+
+    protected string $ip;
+    protected int $port;
+    protected ?Socket $socket = null;
+
+    public function __construct(string $ip, int $port = 514)
+    {
+        $this->ip = $ip;
+        $this->port = $port;
+    }
+
+    public function write(string $line, string $header = ""): void
+    {
+        $this->send($this->assembleMessage($line, $header));
+    }
+
+    public function close(): void
+    {
+        if ($this->socket instanceof Socket) {
+            socket_close($this->socket);
+            $this->socket = null;
+        }
+    }
+
+    protected function getSocket(): Socket
+    {
+        if (null !== $this->socket) {
+            return $this->socket;
+        }
+
+        $domain = AF_INET;
+        $protocol = SOL_UDP;
+        // Check if we are using unix sockets.
+        if ($this->port === 0) {
+            $domain = AF_UNIX;
+            $protocol = IPPROTO_IP;
+        }
+
+        $socket = socket_create($domain, SOCK_DGRAM, $protocol);
+        if ($socket instanceof Socket) {
+            return $this->socket = $socket;
+        }
+
+        throw new \RuntimeException('The UdpSocket to '.$this->ip.':'.$this->port.' could not be opened via socket_create');
+    }
+
+    protected function send(string $chunk): void
+    {
+        socket_sendto($this->getSocket(), $chunk, \strlen($chunk), $flags = 0, $this->ip, $this->port);
+    }
+
+    protected function assembleMessage(string $line, string $header): string
+    {
+        $chunkSize = static::DATAGRAM_MAX_LENGTH - \strlen($header);
+
+        return $header . Utils::substr($line, 0, $chunkSize);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/SyslogUdpHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/SyslogUdpHandler.php
@@ -1,0 +1,154 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use DateTimeInterface;
+use Monolog\Handler\SyslogUdp\UdpSocket;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Monolog\Utils;
+
+/**
+ * A Handler for logging to a remote syslogd server.
+ *
+ * @author Jesper Skovgaard Nielsen <nulpunkt@gmail.com>
+ * @author Dominik Kukacka <dominik.kukacka@gmail.com>
+ */
+class SyslogUdpHandler extends AbstractSyslogHandler
+{
+    const RFC3164 = 0;
+    const RFC5424 = 1;
+    const RFC5424e = 2;
+
+    /** @var array<self::RFC*, string> */
+    private array $dateFormats = [
+        self::RFC3164 => 'M d H:i:s',
+        self::RFC5424 => \DateTime::RFC3339,
+        self::RFC5424e => \DateTime::RFC3339_EXTENDED,
+    ];
+
+    protected UdpSocket $socket;
+    protected string $ident;
+    /** @var self::RFC* */
+    protected int $rfc;
+
+    /**
+     * @param  string                    $host     Either IP/hostname or a path to a unix socket (port must be 0 then)
+     * @param  int                       $port     Port number, or 0 if $host is a unix socket
+     * @param  string|int                $facility Either one of the names of the keys in $this->facilities, or a LOG_* facility constant
+     * @param  bool                      $bubble   Whether the messages that are handled can bubble up the stack or not
+     * @param  string                    $ident    Program name or tag for each log message.
+     * @param  int                       $rfc      RFC to format the message for.
+     * @throws MissingExtensionException when there is no socket extension
+     *
+     * @phpstan-param self::RFC* $rfc
+     */
+    public function __construct(string $host, int $port = 514, string|int $facility = LOG_USER, int|string|Level $level = Level::Debug, bool $bubble = true, string $ident = 'php', int $rfc = self::RFC5424)
+    {
+        if (!\extension_loaded('sockets')) {
+            throw new MissingExtensionException('The sockets extension is required to use the SyslogUdpHandler');
+        }
+
+        parent::__construct($facility, $level, $bubble);
+
+        $this->ident = $ident;
+        $this->rfc = $rfc;
+
+        $this->socket = new UdpSocket($host, $port);
+    }
+
+    protected function write(LogRecord $record): void
+    {
+        $lines = $this->splitMessageIntoLines($record->formatted);
+
+        $header = $this->makeCommonSyslogHeader($this->toSyslogPriority($record->level), $record->datetime);
+
+        foreach ($lines as $line) {
+            $this->socket->write($line, $header);
+        }
+    }
+
+    public function close(): void
+    {
+        $this->socket->close();
+    }
+
+    /**
+     * @param  string|string[] $message
+     * @return string[]
+     */
+    private function splitMessageIntoLines($message): array
+    {
+        if (\is_array($message)) {
+            $message = implode("\n", $message);
+        }
+
+        $lines = preg_split('/$\R?^/m', (string) $message, -1, PREG_SPLIT_NO_EMPTY);
+        if (false === $lines) {
+            $pcreErrorCode = preg_last_error();
+
+            throw new \RuntimeException('Could not preg_split: ' . $pcreErrorCode . ' / ' . preg_last_error_msg());
+        }
+
+        return $lines;
+    }
+
+    /**
+     * Make common syslog header (see rfc5424 or rfc3164)
+     */
+    protected function makeCommonSyslogHeader(int $severity, DateTimeInterface $datetime): string
+    {
+        $priority = $severity + $this->facility;
+
+        $pid = getmypid();
+        if (false === $pid) {
+            $pid = '-';
+        }
+
+        $hostname = gethostname();
+        if (false === $hostname) {
+            $hostname = '-';
+        }
+
+        if ($this->rfc === self::RFC3164) {
+            // see https://github.com/phpstan/phpstan/issues/5348
+            // @phpstan-ignore-next-line
+            $dateNew = $datetime->setTimezone(new \DateTimeZone('UTC'));
+            $date = $dateNew->format($this->dateFormats[$this->rfc]);
+
+            return "<$priority>" .
+                $date . " " .
+                $hostname . " " .
+                $this->ident . "[" . $pid . "]: ";
+        }
+
+        $date = $datetime->format($this->dateFormats[$this->rfc]);
+
+        return "<$priority>1 " .
+            $date . " " .
+            $hostname . " " .
+            $this->ident . " " .
+            $pid . " - - ";
+    }
+
+    /**
+     * Inject your own socket, mainly used for testing
+     *
+     * @return $this
+     */
+    public function setSocket(UdpSocket $socket): self
+    {
+        $this->socket = $socket;
+
+        return $this;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/TelegramBotHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/TelegramBotHandler.php
@@ -1,0 +1,301 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use RuntimeException;
+use Monolog\Level;
+use Monolog\Utils;
+use Monolog\LogRecord;
+
+/**
+ * Handler sends logs to Telegram using Telegram Bot API.
+ *
+ * How to use:
+ *  1) Create a Telegram bot with https://telegram.me/BotFather;
+ *  2) Create a Telegram channel or a group where logs will be recorded;
+ *  3) Add the created bot from step 1 to the created channel/group from step 2.
+ *
+ * In order to create an instance of TelegramBotHandler use
+ *  1. The Telegram bot API key from step 1
+ *  2. The channel name with the `@` prefix if you created a public channel (e.g. `@my_public_channel`),
+ *     or the channel ID with the `-100` prefix if you created a private channel (e.g. `-1001234567890`),
+ *     or the group ID from step 2 (e.g. `-1234567890`).
+ *
+ * @link https://core.telegram.org/bots/api
+ *
+ * @author Mazur Alexandr <alexandrmazur96@gmail.com>
+ */
+class TelegramBotHandler extends AbstractProcessingHandler
+{
+    private const BOT_API = 'https://api.telegram.org/bot';
+
+    /**
+     * The available values of parseMode according to the Telegram api documentation
+     */
+    private const AVAILABLE_PARSE_MODES = [
+        'HTML',
+        'MarkdownV2',
+        'Markdown', // legacy mode without underline and strikethrough, use MarkdownV2 instead
+    ];
+
+    /**
+     * The maximum number of characters allowed in a message according to the Telegram api documentation
+     */
+    private const MAX_MESSAGE_LENGTH = 4096;
+
+    /**
+     * Telegram bot access token provided by BotFather.
+     * Create telegram bot with https://telegram.me/BotFather and use access token from it.
+     */
+    private string $apiKey;
+
+    /**
+     * Telegram channel name.
+     * Since to start with '@' symbol as prefix.
+     */
+    private string $channel;
+
+    /**
+     * The kind of formatting that is used for the message.
+     * See available options at https://core.telegram.org/bots/api#formatting-options
+     * or in AVAILABLE_PARSE_MODES
+     */
+    private string|null $parseMode;
+
+    /**
+     * Disables link previews for links in the message.
+     */
+    private bool|null $disableWebPagePreview;
+
+    /**
+     * Sends the message silently. Users will receive a notification with no sound.
+     */
+    private bool|null $disableNotification;
+
+    /**
+     * True - split a message longer than MAX_MESSAGE_LENGTH into parts and send in multiple messages.
+     * False - truncates a message that is too long.
+     */
+    private bool $splitLongMessages;
+
+    /**
+     * Adds 1-second delay between sending a split message (according to Telegram API to avoid 429 Too Many Requests).
+     */
+    private bool $delayBetweenMessages;
+
+    /**
+     * Telegram message thread id, unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+     * See how to get the `message_thread_id` https://stackoverflow.com/a/75178418
+     */
+    private int|null $topic;
+
+    /**
+     * @param  string                    $apiKey               Telegram bot access token provided by BotFather
+     * @param  string                    $channel              Telegram channel name
+     * @param  bool                      $splitLongMessages    Split a message longer than MAX_MESSAGE_LENGTH into parts and send in multiple messages
+     * @param  bool                      $delayBetweenMessages Adds delay between sending a split message according to Telegram API
+     * @param  int                       $topic                Telegram message thread id, unique identifier for the target message thread (topic) of the forum
+     * @throws MissingExtensionException If the curl extension is missing
+     */
+    public function __construct(
+        string $apiKey,
+        string $channel,
+        $level = Level::Debug,
+        bool   $bubble = true,
+        ?string $parseMode = null,
+        ?bool   $disableWebPagePreview = null,
+        ?bool   $disableNotification = null,
+        bool   $splitLongMessages = false,
+        bool   $delayBetweenMessages = false,
+        ?int   $topic = null
+    ) {
+        if (!\extension_loaded('curl')) {
+            throw new MissingExtensionException('The curl extension is needed to use the TelegramBotHandler');
+        }
+
+        parent::__construct($level, $bubble);
+
+        $this->apiKey = $apiKey;
+        $this->channel = $channel;
+        $this->setParseMode($parseMode);
+        $this->disableWebPagePreview($disableWebPagePreview);
+        $this->disableNotification($disableNotification);
+        $this->splitLongMessages($splitLongMessages);
+        $this->delayBetweenMessages($delayBetweenMessages);
+        $this->setTopic($topic);
+    }
+
+    /**
+     * @return $this
+     */
+    public function setParseMode(string|null $parseMode = null): self
+    {
+        if ($parseMode !== null && !\in_array($parseMode, self::AVAILABLE_PARSE_MODES, true)) {
+            throw new \InvalidArgumentException('Unknown parseMode, use one of these: ' . implode(', ', self::AVAILABLE_PARSE_MODES) . '.');
+        }
+
+        $this->parseMode = $parseMode;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function disableWebPagePreview(bool|null $disableWebPagePreview = null): self
+    {
+        $this->disableWebPagePreview = $disableWebPagePreview;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function disableNotification(bool|null $disableNotification = null): self
+    {
+        $this->disableNotification = $disableNotification;
+
+        return $this;
+    }
+
+    /**
+     * True - split a message longer than MAX_MESSAGE_LENGTH into parts and send in multiple messages.
+     * False - truncates a message that is too long.
+     *
+     * @return $this
+     */
+    public function splitLongMessages(bool $splitLongMessages = false): self
+    {
+        $this->splitLongMessages = $splitLongMessages;
+
+        return $this;
+    }
+
+    /**
+     * Adds 1-second delay between sending a split message (according to Telegram API to avoid 429 Too Many Requests).
+     *
+     * @return $this
+     */
+    public function delayBetweenMessages(bool $delayBetweenMessages = false): self
+    {
+        $this->delayBetweenMessages = $delayBetweenMessages;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setTopic(?int $topic = null): self
+    {
+        $this->topic = $topic;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handleBatch(array $records): void
+    {
+        $messages = [];
+
+        foreach ($records as $record) {
+            if (!$this->isHandling($record)) {
+                continue;
+            }
+
+            if (\count($this->processors) > 0) {
+                $record = $this->processRecord($record);
+            }
+
+            $messages[] = $record;
+        }
+
+        if (\count($messages) > 0) {
+            $this->send((string) $this->getFormatter()->formatBatch($messages));
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        $this->send($record->formatted);
+    }
+
+    /**
+     * Send request to @link https://api.telegram.org/bot on SendMessage action.
+     */
+    protected function send(string $message): void
+    {
+        $messages = $this->handleMessageLength($message);
+
+        foreach ($messages as $key => $msg) {
+            if ($this->delayBetweenMessages && $key > 0) {
+                sleep(1);
+            }
+
+            $this->sendCurl($msg);
+        }
+    }
+
+    protected function sendCurl(string $message): void
+    {
+        if ('' === trim($message)) {
+            return;
+        }
+        
+        $ch = curl_init();
+        $url = self::BOT_API . $this->apiKey . '/SendMessage';
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        $params = [
+            'text' => $message,
+            'chat_id' => $this->channel,
+            'parse_mode' => $this->parseMode,
+            'disable_web_page_preview' => $this->disableWebPagePreview,
+            'disable_notification' => $this->disableNotification,
+        ];
+        if ($this->topic !== null) {
+            $params['message_thread_id'] = $this->topic;
+        }
+        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($params));
+
+        $result = Curl\Util::execute($ch);
+        if (!\is_string($result)) {
+            throw new RuntimeException('Telegram API error. Description: No response');
+        }
+        $result = json_decode($result, true);
+
+        if ($result['ok'] === false) {
+            throw new RuntimeException('Telegram API error. Description: ' . $result['description']);
+        }
+    }
+
+    /**
+     * Handle a message that is too long: truncates or splits into several
+     * @return string[]
+     */
+    private function handleMessageLength(string $message): array
+    {
+        $truncatedMarker = ' (…truncated)';
+        if (!$this->splitLongMessages && \strlen($message) > self::MAX_MESSAGE_LENGTH) {
+            return [Utils::substr($message, 0, self::MAX_MESSAGE_LENGTH - \strlen($truncatedMarker)) . $truncatedMarker];
+        }
+
+        return str_split($message, self::MAX_MESSAGE_LENGTH);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/TestHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/TestHandler.php
@@ -1,0 +1,203 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Level;
+use Monolog\Logger;
+use Psr\Log\LogLevel;
+use Monolog\LogRecord;
+use NoDiscard;
+
+/**
+ * Used for testing purposes.
+ *
+ * It records all records and gives you access to them for verification.
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @method bool hasEmergency(array{message: string, context?: mixed[]}|string $recordAssertions)
+ * @method bool hasAlert(array{message: string, context?: mixed[]}|string $recordAssertions)
+ * @method bool hasCritical(array{message: string, context?: mixed[]}|string $recordAssertions)
+ * @method bool hasError(array{message: string, context?: mixed[]}|string $recordAssertions)
+ * @method bool hasWarning(array{message: string, context?: mixed[]}|string $recordAssertions)
+ * @method bool hasNotice(array{message: string, context?: mixed[]}|string $recordAssertions)
+ * @method bool hasInfo(array{message: string, context?: mixed[]}|string $recordAssertions)
+ * @method bool hasDebug(array{message: string, context?: mixed[]}|string $recordAssertions)
+ *
+ * @method bool hasEmergencyRecords()
+ * @method bool hasAlertRecords()
+ * @method bool hasCriticalRecords()
+ * @method bool hasErrorRecords()
+ * @method bool hasWarningRecords()
+ * @method bool hasNoticeRecords()
+ * @method bool hasInfoRecords()
+ * @method bool hasDebugRecords()
+ *
+ * @method bool hasEmergencyThatContains(string $message)
+ * @method bool hasAlertThatContains(string $message)
+ * @method bool hasCriticalThatContains(string $message)
+ * @method bool hasErrorThatContains(string $message)
+ * @method bool hasWarningThatContains(string $message)
+ * @method bool hasNoticeThatContains(string $message)
+ * @method bool hasInfoThatContains(string $message)
+ * @method bool hasDebugThatContains(string $message)
+ *
+ * @method bool hasEmergencyThatMatches(string $regex)
+ * @method bool hasAlertThatMatches(string $regex)
+ * @method bool hasCriticalThatMatches(string $regex)
+ * @method bool hasErrorThatMatches(string $regex)
+ * @method bool hasWarningThatMatches(string $regex)
+ * @method bool hasNoticeThatMatches(string $regex)
+ * @method bool hasInfoThatMatches(string $regex)
+ * @method bool hasDebugThatMatches(string $regex)
+ *
+ * @method bool hasEmergencyThatPasses(callable $predicate)
+ * @method bool hasAlertThatPasses(callable $predicate)
+ * @method bool hasCriticalThatPasses(callable $predicate)
+ * @method bool hasErrorThatPasses(callable $predicate)
+ * @method bool hasWarningThatPasses(callable $predicate)
+ * @method bool hasNoticeThatPasses(callable $predicate)
+ * @method bool hasInfoThatPasses(callable $predicate)
+ * @method bool hasDebugThatPasses(callable $predicate)
+ */
+class TestHandler extends AbstractProcessingHandler
+{
+    /** @var LogRecord[] */
+    protected array $records = [];
+    /** @phpstan-var array<value-of<Level::VALUES>, LogRecord[]> */
+    protected array $recordsByLevel = [];
+    private bool $skipReset = false;
+
+    /**
+     * @return array<LogRecord>
+     */
+    #[NoDiscard]
+    public function getRecords(): array
+    {
+        return $this->records;
+    }
+
+    public function clear(): void
+    {
+        $this->records = [];
+        $this->recordsByLevel = [];
+    }
+
+    public function reset(): void
+    {
+        if (!$this->skipReset) {
+            $this->clear();
+        }
+    }
+
+    public function setSkipReset(bool $skipReset): void
+    {
+        $this->skipReset = $skipReset;
+    }
+
+    /**
+     * @param int|string|Level|LogLevel::* $level Logging level value or name
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $level
+     */
+    #[NoDiscard]
+    public function hasRecords(int|string|Level $level): bool
+    {
+        return isset($this->recordsByLevel[Logger::toMonologLevel($level)->value]);
+    }
+
+    /**
+     * @param string|array $recordAssertions Either a message string or an array containing message and optionally context keys that will be checked against all records
+     *
+     * @phpstan-param array{message: string, context?: mixed[]}|string $recordAssertions
+     */
+    #[NoDiscard]
+    public function hasRecord(string|array $recordAssertions, Level $level): bool
+    {
+        if (\is_string($recordAssertions)) {
+            $recordAssertions = ['message' => $recordAssertions];
+        }
+
+        return $this->hasRecordThatPasses(function (LogRecord $rec) use ($recordAssertions) {
+            if ($rec->message !== $recordAssertions['message']) {
+                return false;
+            }
+            if (isset($recordAssertions['context']) && $rec->context !== $recordAssertions['context']) {
+                return false;
+            }
+
+            return true;
+        }, $level);
+    }
+
+    #[NoDiscard]
+    public function hasRecordThatContains(string $message, Level $level): bool
+    {
+        return $this->hasRecordThatPasses(fn (LogRecord $rec) => str_contains($rec->message, $message), $level);
+    }
+
+    #[NoDiscard]
+    public function hasRecordThatMatches(string $regex, Level $level): bool
+    {
+        return $this->hasRecordThatPasses(fn (LogRecord $rec) => preg_match($regex, $rec->message) > 0, $level);
+    }
+
+    /**
+     * @phpstan-param callable(LogRecord, int): mixed $predicate
+     */
+    #[NoDiscard]
+    public function hasRecordThatPasses(callable $predicate, Level $level): bool
+    {
+        $level = Logger::toMonologLevel($level);
+
+        if (!isset($this->recordsByLevel[$level->value])) {
+            return false;
+        }
+
+        foreach ($this->recordsByLevel[$level->value] as $i => $rec) {
+            if ((bool) $predicate($rec, $i)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        $this->recordsByLevel[$record->level->value][] = $record;
+        $this->records[] = $record;
+    }
+
+    /**
+     * @param mixed[] $args
+     */
+    #[NoDiscard]
+    public function __call(string $method, array $args): bool
+    {
+        if ((bool) preg_match('/(.*)(Debug|Info|Notice|Warning|Error|Critical|Alert|Emergency)(.*)/', $method, $matches)) {
+            $genericMethod = $matches[1] . ('Records' !== $matches[3] ? 'Record' : '') . $matches[3];
+            $level = \constant(Level::class.'::' . $matches[2]);
+            $callback = [$this, $genericMethod];
+            if (\is_callable($callback)) {
+                $args[] = $level;
+
+                return \call_user_func_array($callback, $args);
+            }
+        }
+
+        throw new \BadMethodCallException('Call to undefined method ' . \get_class($this) . '::' . $method . '()');
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/WebRequestRecognizerTrait.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/WebRequestRecognizerTrait.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+trait WebRequestRecognizerTrait
+{
+    /**
+     * Checks if PHP's serving a web request
+     */
+    protected function isWebRequest(): bool
+    {
+        return 'cli' !== \PHP_SAPI && 'phpdbg' !== \PHP_SAPI;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/WhatFailureGroupHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/WhatFailureGroupHandler.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\LogRecord;
+use Throwable;
+
+/**
+ * Forwards records to multiple handlers suppressing failures of each handler
+ * and continuing through to give every handler a chance to succeed.
+ *
+ * @author Craig D'Amelio <craig@damelio.ca>
+ */
+class WhatFailureGroupHandler extends GroupHandler
+{
+    /**
+     * @inheritDoc
+     */
+    public function handle(LogRecord $record): bool
+    {
+        if (\count($this->processors) > 0) {
+            $record = $this->processRecord($record);
+        }
+
+        foreach ($this->handlers as $handler) {
+            try {
+                $handler->handle(clone $record);
+            } catch (Throwable) {
+                // What failure?
+            }
+        }
+
+        return false === $this->bubble;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function handleBatch(array $records): void
+    {
+        if (\count($this->processors) > 0) {
+            $processed = [];
+            foreach ($records as $record) {
+                $processed[] = $this->processRecord($record);
+            }
+            $records = $processed;
+        }
+
+        foreach ($this->handlers as $handler) {
+            try {
+                $handler->handleBatch(array_map(fn ($record) => clone $record, $records));
+            } catch (Throwable) {
+                // What failure?
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function close(): void
+    {
+        foreach ($this->handlers as $handler) {
+            try {
+                $handler->close();
+            } catch (\Throwable $e) {
+                // What failure?
+            }
+        }
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Handler/ZendMonitorHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/Handler/ZendMonitorHandler.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Handler;
+
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Formatter\NormalizerFormatter;
+use Monolog\Level;
+use Monolog\LogRecord;
+
+/**
+ * Handler sending logs to Zend Monitor
+ *
+ * @author  Christian Bergau <cbergau86@gmail.com>
+ * @author  Jason Davis <happydude@jasondavis.net>
+ */
+class ZendMonitorHandler extends AbstractProcessingHandler
+{
+    /**
+     * @throws MissingExtensionException
+     */
+    public function __construct(int|string|Level $level = Level::Debug, bool $bubble = true)
+    {
+        if (!\function_exists('zend_monitor_custom_event')) {
+            throw new MissingExtensionException(
+                'You must have Zend Server installed with Zend Monitor enabled in order to use this handler'
+            );
+        }
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * Translates Monolog log levels to ZendMonitor levels.
+     */
+    protected function toZendMonitorLevel(Level $level): int
+    {
+        return match ($level) {
+            Level::Debug     => \ZEND_MONITOR_EVENT_SEVERITY_INFO,
+            Level::Info      => \ZEND_MONITOR_EVENT_SEVERITY_INFO,
+            Level::Notice    => \ZEND_MONITOR_EVENT_SEVERITY_INFO,
+            Level::Warning   => \ZEND_MONITOR_EVENT_SEVERITY_WARNING,
+            Level::Error     => \ZEND_MONITOR_EVENT_SEVERITY_ERROR,
+            Level::Critical  => \ZEND_MONITOR_EVENT_SEVERITY_ERROR,
+            Level::Alert     => \ZEND_MONITOR_EVENT_SEVERITY_ERROR,
+            Level::Emergency => \ZEND_MONITOR_EVENT_SEVERITY_ERROR,
+        };
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function write(LogRecord $record): void
+    {
+        $this->writeZendMonitorCustomEvent(
+            $record->level->getName(),
+            $record->message,
+            $record->formatted,
+            $this->toZendMonitorLevel($record->level)
+        );
+    }
+
+    /**
+     * Write to Zend Monitor Events
+     * @param string       $type      Text displayed in "Class Name (custom)" field
+     * @param string       $message   Text displayed in "Error String"
+     * @param array<mixed> $formatted Displayed in Custom Variables tab
+     * @param int          $severity  Set the event severity level (-1,0,1)
+     */
+    protected function writeZendMonitorCustomEvent(string $type, string $message, array $formatted, int $severity): void
+    {
+        zend_monitor_custom_event($type, $message, $formatted, $severity);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDefaultFormatter(): FormatterInterface
+    {
+        return new NormalizerFormatter();
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/JsonSerializableDateTimeImmutable.php
+++ b/vendor/monolog/monolog/src/Monolog/JsonSerializableDateTimeImmutable.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog;
+
+use DateTimeZone;
+
+/**
+ * Overrides default json encoding of date time objects
+ *
+ * @author Menno Holtkamp
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class JsonSerializableDateTimeImmutable extends \DateTimeImmutable implements \JsonSerializable
+{
+    private bool $useMicroseconds;
+
+    public function __construct(bool $useMicroseconds, ?DateTimeZone $timezone = null)
+    {
+        $this->useMicroseconds = $useMicroseconds;
+
+        // if you like to use a custom time to pass to Logger::addRecord directly,
+        // call modify() or setTimestamp() on this instance to change the date after creating it
+        parent::__construct('now', $timezone);
+    }
+
+    public function jsonSerialize(): string
+    {
+        if ($this->useMicroseconds) {
+            return $this->format('Y-m-d\TH:i:s.uP');
+        }
+
+        return $this->format('Y-m-d\TH:i:sP');
+    }
+
+    public function __toString(): string
+    {
+        return $this->jsonSerialize();
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Level.php
+++ b/vendor/monolog/monolog/src/Monolog/Level.php
@@ -1,0 +1,209 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog;
+
+use Psr\Log\LogLevel;
+
+/**
+ * Represents the log levels
+ *
+ * Monolog supports the logging levels described by RFC 5424 {@see https://datatracker.ietf.org/doc/html/rfc5424}
+ * but due to BC the severity values used internally are not 0-7.
+ *
+ * To get the level name/value out of a Level there are several options:
+ *
+ * - Use ->getName() to get the standard Monolog name which is full uppercased (e.g. "DEBUG")
+ * - Use ->toPsrLogLevel() to get the standard PSR-3 name which is full lowercased (e.g. "debug")
+ * - Use ->toRFC5424Level() to get the standard RFC 5424 value (e.g. 7 for debug, 0 for emergency)
+ * - Use ->name to get the enum case's name which is capitalized (e.g. "Debug")
+ *
+ * To get the internal value for filtering, if the includes/isLowerThan/isHigherThan methods are
+ * not enough, you can use ->value to get the enum case's integer value.
+ */
+enum Level: int
+{
+    /**
+     * Detailed debug information
+     */
+    case Debug = 100;
+
+    /**
+     * Interesting events
+     *
+     * Examples: User logs in, SQL logs.
+     */
+    case Info = 200;
+
+    /**
+     * Uncommon events
+     */
+    case Notice = 250;
+
+    /**
+     * Exceptional occurrences that are not errors
+     *
+     * Examples: Use of deprecated APIs, poor use of an API,
+     * undesirable things that are not necessarily wrong.
+     */
+    case Warning = 300;
+
+    /**
+     * Runtime errors
+     */
+    case Error = 400;
+
+    /**
+     * Critical conditions
+     *
+     * Example: Application component unavailable, unexpected exception.
+     */
+    case Critical = 500;
+
+    /**
+     * Action must be taken immediately
+     *
+     * Example: Entire website down, database unavailable, etc.
+     * This should trigger the SMS alerts and wake you up.
+     */
+    case Alert = 550;
+
+    /**
+     * Urgent alert.
+     */
+    case Emergency = 600;
+
+    /**
+     * @param  value-of<self::NAMES>|LogLevel::*|'Debug'|'Info'|'Notice'|'Warning'|'Error'|'Critical'|'Alert'|'Emergency' $name
+     * @return static
+     */
+    public static function fromName(string $name): self
+    {
+        return match (strtolower($name)) {
+            'debug' => self::Debug,
+            'info' => self::Info,
+            'notice' => self::Notice,
+            'warning' => self::Warning,
+            'error' => self::Error,
+            'critical' => self::Critical,
+            'alert' => self::Alert,
+            'emergency' => self::Emergency,
+        };
+    }
+
+    /**
+     * @param  value-of<self::VALUES> $value
+     * @return static
+     */
+    public static function fromValue(int $value): self
+    {
+        return self::from($value);
+    }
+
+    /**
+     * Returns true if the passed $level is higher or equal to $this
+     */
+    public function includes(Level $level): bool
+    {
+        return $this->value <= $level->value;
+    }
+
+    public function isHigherThan(Level $level): bool
+    {
+        return $this->value > $level->value;
+    }
+
+    public function isLowerThan(Level $level): bool
+    {
+        return $this->value < $level->value;
+    }
+
+    /**
+     * Returns the monolog standardized all-capitals name of the level
+     *
+     * Use this instead of $level->name which returns the enum case name (e.g. Debug vs DEBUG if you use getName())
+     *
+     * @return value-of<self::NAMES>
+     */
+    public function getName(): string
+    {
+        return match ($this) {
+            self::Debug => 'DEBUG',
+            self::Info => 'INFO',
+            self::Notice => 'NOTICE',
+            self::Warning => 'WARNING',
+            self::Error => 'ERROR',
+            self::Critical => 'CRITICAL',
+            self::Alert => 'ALERT',
+            self::Emergency => 'EMERGENCY',
+        };
+    }
+
+    /**
+     * Returns the PSR-3 level matching this instance
+     *
+     * @phpstan-return \Psr\Log\LogLevel::*
+     */
+    public function toPsrLogLevel(): string
+    {
+        return match ($this) {
+            self::Debug => LogLevel::DEBUG,
+            self::Info => LogLevel::INFO,
+            self::Notice => LogLevel::NOTICE,
+            self::Warning => LogLevel::WARNING,
+            self::Error => LogLevel::ERROR,
+            self::Critical => LogLevel::CRITICAL,
+            self::Alert => LogLevel::ALERT,
+            self::Emergency => LogLevel::EMERGENCY,
+        };
+    }
+
+    /**
+     * Returns the RFC 5424 level matching this instance
+     *
+     * @phpstan-return int<0, 7>
+     */
+    public function toRFC5424Level(): int
+    {
+        return match ($this) {
+            self::Debug => 7,
+            self::Info => 6,
+            self::Notice => 5,
+            self::Warning => 4,
+            self::Error => 3,
+            self::Critical => 2,
+            self::Alert => 1,
+            self::Emergency => 0,
+        };
+    }
+
+    public const VALUES = [
+        100,
+        200,
+        250,
+        300,
+        400,
+        500,
+        550,
+        600,
+    ];
+
+    public const NAMES = [
+        'DEBUG',
+        'INFO',
+        'NOTICE',
+        'WARNING',
+        'ERROR',
+        'CRITICAL',
+        'ALERT',
+        'EMERGENCY',
+    ];
+}

--- a/vendor/monolog/monolog/src/Monolog/LogRecord.php
+++ b/vendor/monolog/monolog/src/Monolog/LogRecord.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog;
+
+use ArrayAccess;
+
+/**
+ * Monolog log record
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ * @template-implements ArrayAccess<'message'|'level'|'context'|'level_name'|'channel'|'datetime'|'extra'|'formatted', int|string|\DateTimeImmutable|array<mixed>>
+ */
+class LogRecord implements ArrayAccess
+{
+    private const MODIFIABLE_FIELDS = [
+        'extra' => true,
+        'formatted' => true,
+    ];
+
+    public function __construct(
+        public readonly \DateTimeImmutable $datetime,
+        public readonly string $channel,
+        public readonly Level $level,
+        public readonly string $message,
+        /** @var array<mixed> */
+        public readonly array $context = [],
+        /** @var array<mixed> */
+        public array $extra = [],
+        public mixed $formatted = null,
+    ) {
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        if ($offset === 'extra') {
+            if (!\is_array($value)) {
+                throw new \InvalidArgumentException('extra must be an array');
+            }
+
+            $this->extra = $value;
+
+            return;
+        }
+
+        if ($offset === 'formatted') {
+            $this->formatted = $value;
+
+            return;
+        }
+
+        throw new \LogicException('Unsupported operation: setting '.$offset);
+    }
+
+    public function offsetExists(mixed $offset): bool
+    {
+        if ($offset === 'level_name') {
+            return true;
+        }
+
+        return isset($this->{$offset});
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        throw new \LogicException('Unsupported operation');
+    }
+
+    public function &offsetGet(mixed $offset): mixed
+    {
+        // handle special cases for the level enum
+        if ($offset === 'level_name') {
+            // avoid returning readonly props by ref as this is illegal
+            $copy = $this->level->getName();
+
+            return $copy;
+        }
+        if ($offset === 'level') {
+            // avoid returning readonly props by ref as this is illegal
+            $copy = $this->level->value;
+
+            return $copy;
+        }
+
+        if (isset(self::MODIFIABLE_FIELDS[$offset])) {
+            return $this->{$offset};
+        }
+
+        // avoid returning readonly props by ref as this is illegal
+        $copy = $this->{$offset};
+
+        return $copy;
+    }
+
+    /**
+     * @phpstan-return array{message: string, context: mixed[], level: value-of<Level::VALUES>, level_name: value-of<Level::NAMES>, channel: string, datetime: \DateTimeImmutable, extra: mixed[]}
+     */
+    public function toArray(): array
+    {
+        return [
+            'message' => $this->message,
+            'context' => $this->context,
+            'level' => $this->level->value,
+            'level_name' => $this->level->getName(),
+            'channel' => $this->channel,
+            'datetime' => $this->datetime,
+            'extra' => $this->extra,
+        ];
+    }
+
+    public function with(mixed ...$args): self
+    {
+        foreach (['message', 'context', 'level', 'channel', 'datetime', 'extra'] as $prop) {
+            $args[$prop] ??= $this->{$prop};
+        }
+
+        return new self(...$args);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Logger.php
+++ b/vendor/monolog/monolog/src/Monolog/Logger.php
@@ -1,0 +1,751 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog;
+
+use Closure;
+use DateTimeZone;
+use Fiber;
+use Monolog\Handler\HandlerInterface;
+use Monolog\Processor\ProcessorInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\InvalidArgumentException;
+use Psr\Log\LogLevel;
+use Throwable;
+use Stringable;
+use WeakMap;
+
+/**
+ * Monolog log channel
+ *
+ * It contains a stack of Handlers and a stack of Processors,
+ * and uses them to store records that are added to it.
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ * @final
+ */
+class Logger implements LoggerInterface, ResettableInterface
+{
+    /**
+     * Detailed debug information
+     *
+     * @deprecated Use \Monolog\Level::Debug
+     */
+    public const DEBUG = 100;
+
+    /**
+     * Interesting events
+     *
+     * Examples: User logs in, SQL logs.
+     *
+     * @deprecated Use \Monolog\Level::Info
+     */
+    public const INFO = 200;
+
+    /**
+     * Uncommon events
+     *
+     * @deprecated Use \Monolog\Level::Notice
+     */
+    public const NOTICE = 250;
+
+    /**
+     * Exceptional occurrences that are not errors
+     *
+     * Examples: Use of deprecated APIs, poor use of an API,
+     * undesirable things that are not necessarily wrong.
+     *
+     * @deprecated Use \Monolog\Level::Warning
+     */
+    public const WARNING = 300;
+
+    /**
+     * Runtime errors
+     *
+     * @deprecated Use \Monolog\Level::Error
+     */
+    public const ERROR = 400;
+
+    /**
+     * Critical conditions
+     *
+     * Example: Application component unavailable, unexpected exception.
+     *
+     * @deprecated Use \Monolog\Level::Critical
+     */
+    public const CRITICAL = 500;
+
+    /**
+     * Action must be taken immediately
+     *
+     * Example: Entire website down, database unavailable, etc.
+     * This should trigger the SMS alerts and wake you up.
+     *
+     * @deprecated Use \Monolog\Level::Alert
+     */
+    public const ALERT = 550;
+
+    /**
+     * Urgent alert.
+     *
+     * @deprecated Use \Monolog\Level::Emergency
+     */
+    public const EMERGENCY = 600;
+
+    /**
+     * Monolog API version
+     *
+     * This is only bumped when API breaks are done and should
+     * follow the major version of the library
+     */
+    public const API = 3;
+
+    /**
+     * Mapping between levels numbers defined in RFC 5424 and Monolog ones
+     *
+     * @phpstan-var array<int, Level> $rfc_5424_levels
+     */
+    private const RFC_5424_LEVELS = [
+        7 => Level::Debug,
+        6 => Level::Info,
+        5 => Level::Notice,
+        4 => Level::Warning,
+        3 => Level::Error,
+        2 => Level::Critical,
+        1 => Level::Alert,
+        0 => Level::Emergency,
+    ];
+
+    protected string $name;
+
+    /**
+     * The handler stack
+     *
+     * @var list<HandlerInterface>
+     */
+    protected array $handlers;
+
+    /**
+     * Processors that will process all log records
+     *
+     * To process records of a single handler instead, add the processor on that specific handler
+     *
+     * @var array<(callable(LogRecord): LogRecord)|ProcessorInterface>
+     */
+    protected array $processors;
+
+    protected bool $microsecondTimestamps = true;
+
+    protected DateTimeZone $timezone;
+
+    protected Closure|null $exceptionHandler = null;
+
+    /**
+     * Keeps track of depth to prevent infinite logging loops
+     */
+    private int $logDepth = 0;
+
+    /**
+     * @var WeakMap<Fiber<mixed, mixed, mixed, mixed>, int> Keeps track of depth inside fibers to prevent infinite logging loops
+     */
+    private WeakMap $fiberLogDepth;
+
+    /**
+     * Whether to detect infinite logging loops
+     * This can be disabled via {@see useLoggingLoopDetection} if you have async handlers that do not play well with this
+     */
+    private bool $detectCycles = true;
+
+    /**
+     * @param string             $name       The logging channel, a simple descriptive name that is attached to all log records
+     * @param list<HandlerInterface> $handlers   Optional stack of handlers, the first one in the array is called first, etc.
+     * @param callable[]         $processors Optional array of processors
+     * @param DateTimeZone|null  $timezone   Optional timezone, if not provided date_default_timezone_get() will be used
+     *
+     * @phpstan-param array<(callable(LogRecord): LogRecord)|ProcessorInterface> $processors
+     */
+    public function __construct(string $name, array $handlers = [], array $processors = [], DateTimeZone|null $timezone = null)
+    {
+        $this->name = $name;
+        $this->setHandlers($handlers);
+        $this->processors = $processors;
+        $this->timezone = $timezone ?? new DateTimeZone(date_default_timezone_get());
+        $this->fiberLogDepth = new \WeakMap();
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Return a new cloned instance with the name changed
+     *
+     * @return static
+     */
+    public function withName(string $name): self
+    {
+        $new = clone $this;
+        $new->name = $name;
+
+        return $new;
+    }
+
+    /**
+     * Pushes a handler on to the stack.
+     *
+     * @return $this
+     */
+    public function pushHandler(HandlerInterface $handler): self
+    {
+        array_unshift($this->handlers, $handler);
+
+        return $this;
+    }
+
+    /**
+     * Pops a handler from the stack
+     *
+     * @throws \LogicException If empty handler stack
+     */
+    public function popHandler(): HandlerInterface
+    {
+        if (0 === \count($this->handlers)) {
+            throw new \LogicException('You tried to pop from an empty handler stack.');
+        }
+
+        return array_shift($this->handlers);
+    }
+
+    /**
+     * Set handlers, replacing all existing ones.
+     *
+     * If a map is passed, keys will be ignored.
+     *
+     * @param  list<HandlerInterface> $handlers
+     * @return $this
+     */
+    public function setHandlers(array $handlers): self
+    {
+        $this->handlers = [];
+        foreach (array_reverse($handlers) as $handler) {
+            $this->pushHandler($handler);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return list<HandlerInterface>
+     */
+    public function getHandlers(): array
+    {
+        return $this->handlers;
+    }
+
+    /**
+     * Adds a processor on to the stack.
+     *
+     * @phpstan-param ProcessorInterface|(callable(LogRecord): LogRecord) $callback
+     * @return $this
+     */
+    public function pushProcessor(ProcessorInterface|callable $callback): self
+    {
+        array_unshift($this->processors, $callback);
+
+        return $this;
+    }
+
+    /**
+     * Removes the processor on top of the stack and returns it.
+     *
+     * @phpstan-return ProcessorInterface|(callable(LogRecord): LogRecord)
+     * @throws \LogicException If empty processor stack
+     */
+    public function popProcessor(): callable
+    {
+        if (0 === \count($this->processors)) {
+            throw new \LogicException('You tried to pop from an empty processor stack.');
+        }
+
+        return array_shift($this->processors);
+    }
+
+    /**
+     * @return callable[]
+     * @phpstan-return array<ProcessorInterface|(callable(LogRecord): LogRecord)>
+     */
+    public function getProcessors(): array
+    {
+        return $this->processors;
+    }
+
+    /**
+     * Control the use of microsecond resolution timestamps in the 'datetime'
+     * member of new records.
+     *
+     * As of PHP7.1 microseconds are always included by the engine, so
+     * there is no performance penalty and Monolog 2 enabled microseconds
+     * by default. This function lets you disable them though in case you want
+     * to suppress microseconds from the output.
+     *
+     * @param  bool  $micro True to use microtime() to create timestamps
+     * @return $this
+     */
+    public function useMicrosecondTimestamps(bool $micro): self
+    {
+        $this->microsecondTimestamps = $micro;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function useLoggingLoopDetection(bool $detectCycles): self
+    {
+        $this->detectCycles = $detectCycles;
+
+        return $this;
+    }
+
+    /**
+     * Adds a log record.
+     *
+     * @param  int                    $level    The logging level (a Monolog or RFC 5424 level)
+     * @param  string                 $message  The log message
+     * @param  mixed[]                $context  The log context
+     * @param  JsonSerializableDateTimeImmutable|null $datetime Optional log date to log into the past or future
+     *
+     * @return bool                   Whether the record has been processed
+     *
+     * @phpstan-param value-of<Level::VALUES>|Level $level
+     */
+    public function addRecord(int|Level $level, string $message, array $context = [], JsonSerializableDateTimeImmutable|null $datetime = null): bool
+    {
+        if (\is_int($level) && isset(self::RFC_5424_LEVELS[$level])) {
+            $level = self::RFC_5424_LEVELS[$level];
+        }
+
+        if ($this->detectCycles) {
+            if (null !== ($fiber = Fiber::getCurrent())) {
+                $logDepth = $this->fiberLogDepth[$fiber] = ($this->fiberLogDepth[$fiber] ?? 0) + 1;
+            } else {
+                $logDepth = ++$this->logDepth;
+            }
+        } else {
+            $logDepth = 0;
+        }
+
+        if ($logDepth === 3) {
+            $this->warning('A possible infinite logging loop was detected and aborted. It appears some of your handler code is triggering logging, see the previous log record for a hint as to what may be the cause.');
+
+            return false;
+        } elseif ($logDepth >= 5) { // log depth 4 is let through, so we can log the warning above
+            return false;
+        }
+
+        try {
+            $recordInitialized = \count($this->processors) === 0;
+
+            $record = new LogRecord(
+                datetime: $datetime ?? new JsonSerializableDateTimeImmutable($this->microsecondTimestamps, $this->timezone),
+                channel: $this->name,
+                level: self::toMonologLevel($level),
+                message: $message,
+                context: $context,
+                extra: [],
+            );
+            $handled = false;
+
+            foreach ($this->handlers as $handler) {
+                if (false === $recordInitialized) {
+                    // skip initializing the record as long as no handler is going to handle it
+                    if (!$handler->isHandling($record)) {
+                        continue;
+                    }
+
+                    try {
+                        foreach ($this->processors as $processor) {
+                            $record = $processor($record);
+                        }
+                        $recordInitialized = true;
+                    } catch (Throwable $e) {
+                        $this->handleException($e, $record);
+
+                        return true;
+                    }
+                }
+
+                // once the record is initialized, send it to all handlers as long as the bubbling chain is not interrupted
+                try {
+                    $handled = true;
+                    if (true === $handler->handle(clone $record)) {
+                        break;
+                    }
+                } catch (Throwable $e) {
+                    $this->handleException($e, $record);
+
+                    return true;
+                }
+            }
+
+            return $handled;
+        } finally {
+            if ($this->detectCycles) {
+                if (isset($fiber)) {
+                    $this->fiberLogDepth[$fiber]--;
+                } else {
+                    $this->logDepth--;
+                }
+            }
+        }
+    }
+
+    /**
+     * Ends a log cycle and frees all resources used by handlers.
+     *
+     * Closing a Handler means flushing all buffers and freeing any open resources/handles.
+     * Handlers that have been closed should be able to accept log records again and re-open
+     * themselves on demand, but this may not always be possible depending on implementation.
+     *
+     * This is useful at the end of a request and will be called automatically on every handler
+     * when they get destructed.
+     */
+    public function close(): void
+    {
+        foreach ($this->handlers as $handler) {
+            $handler->close();
+        }
+    }
+
+    /**
+     * Ends a log cycle and resets all handlers and processors to their initial state.
+     *
+     * Resetting a Handler or a Processor means flushing/cleaning all buffers, resetting internal
+     * state, and getting it back to a state in which it can receive log records again.
+     *
+     * This is useful in case you want to avoid logs leaking between two requests or jobs when you
+     * have a long running process like a worker or an application server serving multiple requests
+     * in one process.
+     */
+    public function reset(): void
+    {
+        foreach ($this->handlers as $handler) {
+            if ($handler instanceof ResettableInterface) {
+                $handler->reset();
+            }
+        }
+
+        foreach ($this->processors as $processor) {
+            if ($processor instanceof ResettableInterface) {
+                $processor->reset();
+            }
+        }
+    }
+
+    /**
+     * Gets the name of the logging level as a string.
+     *
+     * This still returns a string instead of a Level for BC, but new code should not rely on this method.
+     *
+     * @throws \Psr\Log\InvalidArgumentException If level is not defined
+     *
+     * @phpstan-param  value-of<Level::VALUES>|Level $level
+     * @phpstan-return value-of<Level::NAMES>
+     *
+     * @deprecated Since 3.0, use {@see toMonologLevel} or {@see \Monolog\Level->getName()} instead
+     */
+    public static function getLevelName(int|Level $level): string
+    {
+        return self::toMonologLevel($level)->getName();
+    }
+
+    /**
+     * Converts PSR-3 levels to Monolog ones if necessary
+     *
+     * @param  int|string|Level|LogLevel::*      $level Level number (monolog) or name (PSR-3)
+     * @throws \Psr\Log\InvalidArgumentException If level is not defined
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $level
+     */
+    public static function toMonologLevel(string|int|Level $level): Level
+    {
+        if ($level instanceof Level) {
+            return $level;
+        }
+
+        if (\is_string($level)) {
+            if (is_numeric($level)) {
+                $levelEnum = Level::tryFrom((int) $level);
+                if ($levelEnum === null) {
+                    throw new InvalidArgumentException('Level "'.$level.'" is not defined, use one of: '.implode(', ', Level::NAMES + Level::VALUES));
+                }
+
+                return $levelEnum;
+            }
+
+            // Contains first char of all log levels and avoids using strtoupper() which may have
+            // strange results depending on locale (for example, "i" will become "İ" in Turkish locale)
+            $upper = strtr(substr($level, 0, 1), 'dinweca', 'DINWECA') . strtolower(substr($level, 1));
+            if (\defined(Level::class.'::'.$upper)) {
+                return \constant(Level::class . '::' . $upper);
+            }
+
+            throw new InvalidArgumentException('Level "'.$level.'" is not defined, use one of: '.implode(', ', Level::NAMES + Level::VALUES));
+        }
+
+        $levelEnum = Level::tryFrom($level);
+        if ($levelEnum === null) {
+            throw new InvalidArgumentException('Level "'.var_export($level, true).'" is not defined, use one of: '.implode(', ', Level::NAMES + Level::VALUES));
+        }
+
+        return $levelEnum;
+    }
+
+    /**
+     * Checks whether the Logger has a handler that listens on the given level
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $level
+     */
+    public function isHandling(int|string|Level $level): bool
+    {
+        $record = new LogRecord(
+            datetime: new JsonSerializableDateTimeImmutable($this->microsecondTimestamps, $this->timezone),
+            channel: $this->name,
+            message: '',
+            level: self::toMonologLevel($level),
+        );
+
+        foreach ($this->handlers as $handler) {
+            if ($handler->isHandling($record)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Set a custom exception handler that will be called if adding a new record fails
+     *
+     * The Closure will receive an exception object and the record that failed to be logged
+     *
+     * @return $this
+     */
+    public function setExceptionHandler(Closure|null $callback): self
+    {
+        $this->exceptionHandler = $callback;
+
+        return $this;
+    }
+
+    public function getExceptionHandler(): Closure|null
+    {
+        return $this->exceptionHandler;
+    }
+
+    /**
+     * Adds a log record at an arbitrary level.
+     *
+     * This method allows for compatibility with common interfaces.
+     *
+     * @param mixed             $level   The log level (a Monolog, PSR-3 or RFC 5424 level)
+     * @param string|Stringable $message The log message
+     * @param mixed[]           $context The log context
+     *
+     * @phpstan-param Level|LogLevel::* $level
+     */
+    public function log($level, string|\Stringable $message, array $context = []): void
+    {
+        if (!$level instanceof Level) {
+            if (!\is_string($level) && !\is_int($level)) {
+                throw new \InvalidArgumentException('$level is expected to be a string, int or '.Level::class.' instance');
+            }
+
+            if (isset(self::RFC_5424_LEVELS[$level])) {
+                $level = self::RFC_5424_LEVELS[$level];
+            }
+
+            $level = static::toMonologLevel($level);
+        }
+
+        $this->addRecord($level, (string) $message, $context);
+    }
+
+    /**
+     * Adds a log record at the DEBUG level.
+     *
+     * This method allows for compatibility with common interfaces.
+     *
+     * @param string|Stringable $message The log message
+     * @param mixed[]           $context The log context
+     */
+    public function debug(string|\Stringable $message, array $context = []): void
+    {
+        $this->addRecord(Level::Debug, (string) $message, $context);
+    }
+
+    /**
+     * Adds a log record at the INFO level.
+     *
+     * This method allows for compatibility with common interfaces.
+     *
+     * @param string|Stringable $message The log message
+     * @param mixed[]           $context The log context
+     */
+    public function info(string|\Stringable $message, array $context = []): void
+    {
+        $this->addRecord(Level::Info, (string) $message, $context);
+    }
+
+    /**
+     * Adds a log record at the NOTICE level.
+     *
+     * This method allows for compatibility with common interfaces.
+     *
+     * @param string|Stringable $message The log message
+     * @param mixed[]           $context The log context
+     */
+    public function notice(string|\Stringable $message, array $context = []): void
+    {
+        $this->addRecord(Level::Notice, (string) $message, $context);
+    }
+
+    /**
+     * Adds a log record at the WARNING level.
+     *
+     * This method allows for compatibility with common interfaces.
+     *
+     * @param string|Stringable $message The log message
+     * @param mixed[]           $context The log context
+     */
+    public function warning(string|\Stringable $message, array $context = []): void
+    {
+        $this->addRecord(Level::Warning, (string) $message, $context);
+    }
+
+    /**
+     * Adds a log record at the ERROR level.
+     *
+     * This method allows for compatibility with common interfaces.
+     *
+     * @param string|Stringable $message The log message
+     * @param mixed[]           $context The log context
+     */
+    public function error(string|\Stringable $message, array $context = []): void
+    {
+        $this->addRecord(Level::Error, (string) $message, $context);
+    }
+
+    /**
+     * Adds a log record at the CRITICAL level.
+     *
+     * This method allows for compatibility with common interfaces.
+     *
+     * @param string|Stringable $message The log message
+     * @param mixed[]           $context The log context
+     */
+    public function critical(string|\Stringable $message, array $context = []): void
+    {
+        $this->addRecord(Level::Critical, (string) $message, $context);
+    }
+
+    /**
+     * Adds a log record at the ALERT level.
+     *
+     * This method allows for compatibility with common interfaces.
+     *
+     * @param string|Stringable $message The log message
+     * @param mixed[]           $context The log context
+     */
+    public function alert(string|\Stringable $message, array $context = []): void
+    {
+        $this->addRecord(Level::Alert, (string) $message, $context);
+    }
+
+    /**
+     * Adds a log record at the EMERGENCY level.
+     *
+     * This method allows for compatibility with common interfaces.
+     *
+     * @param string|Stringable $message The log message
+     * @param mixed[]           $context The log context
+     */
+    public function emergency(string|\Stringable $message, array $context = []): void
+    {
+        $this->addRecord(Level::Emergency, (string) $message, $context);
+    }
+
+    /**
+     * Sets the timezone to be used for the timestamp of log records.
+     *
+     * @return $this
+     */
+    public function setTimezone(DateTimeZone $tz): self
+    {
+        $this->timezone = $tz;
+
+        return $this;
+    }
+
+    /**
+     * Returns the timezone to be used for the timestamp of log records.
+     */
+    public function getTimezone(): DateTimeZone
+    {
+        return $this->timezone;
+    }
+
+    /**
+     * Delegates exception management to the custom exception handler,
+     * or throws the exception if no custom handler is set.
+     */
+    protected function handleException(Throwable $e, LogRecord $record): void
+    {
+        if (null === $this->exceptionHandler) {
+            throw $e;
+        }
+
+        ($this->exceptionHandler)($e, $record);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __serialize(): array
+    {
+        return [
+            'name' => $this->name,
+            'handlers' => $this->handlers,
+            'processors' => $this->processors,
+            'microsecondTimestamps' => $this->microsecondTimestamps,
+            'timezone' => $this->timezone,
+            'exceptionHandler' => $this->exceptionHandler,
+            'logDepth' => $this->logDepth,
+            'detectCycles' => $this->detectCycles,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __unserialize(array $data): void
+    {
+        foreach (['name', 'handlers', 'processors', 'microsecondTimestamps', 'timezone', 'exceptionHandler', 'logDepth', 'detectCycles'] as $property) {
+            if (isset($data[$property])) {
+                $this->$property = $data[$property];
+            }
+        }
+
+        $this->fiberLogDepth = new \WeakMap();
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Processor/ClosureContextProcessor.php
+++ b/vendor/monolog/monolog/src/Monolog/Processor/ClosureContextProcessor.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+use Monolog\LogRecord;
+
+/**
+ * Generates a context from a Closure if the Closure is the only value
+ * in the context
+ *
+ * It helps reduce the performance impact of debug logs if they do
+ * need to create lots of context information. If this processor is added
+ * on the correct handler the context data will only be generated
+ * when the logs are actually logged to that handler, which is useful when
+ * using FingersCrossedHandler or other filtering handlers to conditionally
+ * log records.
+ */
+class ClosureContextProcessor implements ProcessorInterface
+{
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        $context = $record->context;
+        if (isset($context[0]) && 1 === \count($context) && $context[0] instanceof \Closure) {
+            try {
+                $context = $context[0]();
+            } catch (\Throwable $e) {
+                $context = [
+                    'error_on_context_generation' => $e->getMessage(),
+                    'exception' => $e,
+                ];
+            }
+
+            if (!\is_array($context)) {
+                $context = [$context];
+            }
+
+            $record = $record->with(context: $context);
+        }
+
+        return $record;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Processor/GitProcessor.php
+++ b/vendor/monolog/monolog/src/Monolog/Processor/GitProcessor.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+use Monolog\Level;
+use Monolog\Logger;
+use Psr\Log\LogLevel;
+use Monolog\LogRecord;
+
+/**
+ * Injects Git branch and Git commit SHA in all records
+ *
+ * @author Nick Otter
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class GitProcessor implements ProcessorInterface
+{
+    private Level $level;
+    /** @var array{branch: string, commit: string}|array<never>|null */
+    private static $cache = null;
+
+    /**
+     * @param int|string|Level|LogLevel::* $level The minimum logging level at which this Processor will be triggered
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $level
+     */
+    public function __construct(int|string|Level $level = Level::Debug)
+    {
+        $this->level = Logger::toMonologLevel($level);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        // return if the level is not high enough
+        if ($record->level->isLowerThan($this->level)) {
+            return $record;
+        }
+
+        $record->extra['git'] = self::getGitInfo();
+
+        return $record;
+    }
+
+    /**
+     * @return array{branch: string, commit: string}|array<never>
+     */
+    private static function getGitInfo(): array
+    {
+        if (self::$cache !== null) {
+            return self::$cache;
+        }
+
+        $branches = shell_exec('git branch -v --no-abbrev');
+        if (\is_string($branches) && 1 === preg_match('{^\* (.+?)\s+([a-f0-9]{40})(?:\s|$)}m', $branches, $matches)) {
+            return self::$cache = [
+                'branch' => $matches[1],
+                'commit' => $matches[2],
+            ];
+        }
+
+        return self::$cache = [];
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Processor/HostnameProcessor.php
+++ b/vendor/monolog/monolog/src/Monolog/Processor/HostnameProcessor.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+use Monolog\LogRecord;
+
+/**
+ * Injects value of gethostname in all records
+ */
+class HostnameProcessor implements ProcessorInterface
+{
+    private static string $host;
+
+    public function __construct()
+    {
+        self::$host = (string) gethostname();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        $record->extra['hostname'] = self::$host;
+
+        return $record;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Processor/IntrospectionProcessor.php
+++ b/vendor/monolog/monolog/src/Monolog/Processor/IntrospectionProcessor.php
@@ -1,0 +1,126 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+use Monolog\Level;
+use Monolog\Logger;
+use Psr\Log\LogLevel;
+use Monolog\LogRecord;
+
+/**
+ * Injects line/file:class/function where the log message came from
+ *
+ * Warning: This only works if the handler processes the logs directly.
+ * If you put the processor on a handler that is behind a FingersCrossedHandler
+ * for example, the processor will only be called once the trigger level is reached,
+ * and all the log records will have the same file/line/.. data from the call that
+ * triggered the FingersCrossedHandler.
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class IntrospectionProcessor implements ProcessorInterface
+{
+    protected Level $level;
+
+    /** @var string[] */
+    protected array $skipClassesPartials;
+
+    protected int $skipStackFramesCount;
+
+    protected const SKIP_FUNCTIONS = [
+        'call_user_func',
+        'call_user_func_array',
+    ];
+
+    protected const SKIP_CLASSES = [
+        'Monolog\\',
+    ];
+
+    /**
+     * @param string|int|Level $level               The minimum logging level at which this Processor will be triggered
+     * @param string[]         $skipClassesPartials
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $level
+     */
+    public function __construct(int|string|Level $level = Level::Debug, array $skipClassesPartials = [], int $skipStackFramesCount = 0)
+    {
+        $this->level = Logger::toMonologLevel($level);
+        $this->skipClassesPartials = array_merge(static::SKIP_CLASSES, $skipClassesPartials);
+        $this->skipStackFramesCount = $skipStackFramesCount;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        // return if the level is not high enough
+        if ($record->level->isLowerThan($this->level)) {
+            return $record;
+        }
+
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+
+        // skip first since it's always the current method
+        array_shift($trace);
+        // the call_user_func call is also skipped
+        array_shift($trace);
+
+        $i = 0;
+
+        while ($this->isTraceClassOrSkippedFunction($trace, $i)) {
+            if (isset($trace[$i]['class'])) {
+                foreach ($this->skipClassesPartials as $part) {
+                    if (strpos($trace[$i]['class'], $part) !== false) {
+                        $i++;
+
+                        continue 2;
+                    }
+                }
+            } elseif (\in_array($trace[$i]['function'], self::SKIP_FUNCTIONS, true)) {
+                $i++;
+
+                continue;
+            }
+
+            break;
+        }
+
+        $i += $this->skipStackFramesCount;
+
+        // we should have the call source now
+        $record->extra = array_merge(
+            $record->extra,
+            [
+                'file'      => $trace[$i - 1]['file'] ?? null,
+                'line'      => $trace[$i - 1]['line'] ?? null,
+                'class'     => $trace[$i]['class'] ?? null,
+                'callType'  => $trace[$i]['type'] ?? null,
+                'function'  => $trace[$i]['function'] ?? null,
+            ]
+        );
+
+        return $record;
+    }
+
+    /**
+     * @param array<mixed> $trace
+     */
+    private function isTraceClassOrSkippedFunction(array $trace, int $index): bool
+    {
+        if (!isset($trace[$index])) {
+            return false;
+        }
+
+        return isset($trace[$index]['class']) || \in_array($trace[$index]['function'], self::SKIP_FUNCTIONS, true);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Processor/LoadAverageProcessor.php
+++ b/vendor/monolog/monolog/src/Monolog/Processor/LoadAverageProcessor.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+use Monolog\LogRecord;
+
+/**
+ * Injects sys_getloadavg in all records @see https://www.php.net/manual/en/function.sys-getloadavg.php
+ *
+ * @author Johan Vlaar <johan.vlaar.1994@gmail.com>
+ */
+class LoadAverageProcessor implements ProcessorInterface
+{
+    public const LOAD_1_MINUTE = 0;
+    public const LOAD_5_MINUTE = 1;
+    public const LOAD_15_MINUTE = 2;
+
+    private const AVAILABLE_LOAD = [
+        self::LOAD_1_MINUTE,
+        self::LOAD_5_MINUTE,
+        self::LOAD_15_MINUTE,
+    ];
+
+    /**
+     * @var int
+     */
+    protected $avgSystemLoad;
+
+    /**
+     * @param self::LOAD_* $avgSystemLoad
+     */
+    public function __construct(int $avgSystemLoad = self::LOAD_1_MINUTE)
+    {
+        if (!\in_array($avgSystemLoad, self::AVAILABLE_LOAD, true)) {
+            throw new \InvalidArgumentException(sprintf('Invalid average system load: `%s`', $avgSystemLoad));
+        }
+        $this->avgSystemLoad = $avgSystemLoad;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        if (!\function_exists('sys_getloadavg')) {
+            return $record;
+        }
+        $usage = sys_getloadavg();
+        if (false === $usage) {
+            return $record;
+        }
+
+        $record->extra['load_average'] = $usage[$this->avgSystemLoad];
+
+        return $record;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Processor/MemoryPeakUsageProcessor.php
+++ b/vendor/monolog/monolog/src/Monolog/Processor/MemoryPeakUsageProcessor.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+use Monolog\LogRecord;
+
+/**
+ * Injects memory_get_peak_usage in all records
+ *
+ * @see Monolog\Processor\MemoryProcessor::__construct() for options
+ * @author Rob Jensen
+ */
+class MemoryPeakUsageProcessor extends MemoryProcessor
+{
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        $usage = memory_get_peak_usage($this->realUsage);
+
+        if ($this->useFormatting) {
+            $usage = $this->formatBytes($usage);
+        }
+
+        $record->extra['memory_peak_usage'] = $usage;
+
+        return $record;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Processor/MemoryProcessor.php
+++ b/vendor/monolog/monolog/src/Monolog/Processor/MemoryProcessor.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+/**
+ * Some methods that are common for all memory processors
+ *
+ * @author Rob Jensen
+ */
+abstract class MemoryProcessor implements ProcessorInterface
+{
+    /**
+     * @var bool If true, get the real size of memory allocated from system. Else, only the memory used by emalloc() is reported.
+     */
+    protected bool $realUsage;
+
+    /**
+     * @var bool If true, then format memory size to human readable string (MB, KB, B depending on size)
+     */
+    protected bool $useFormatting;
+
+    /**
+     * @param bool $realUsage     Set this to true to get the real size of memory allocated from system.
+     * @param bool $useFormatting If true, then format memory size to human readable string (MB, KB, B depending on size)
+     */
+    public function __construct(bool $realUsage = true, bool $useFormatting = true)
+    {
+        $this->realUsage = $realUsage;
+        $this->useFormatting = $useFormatting;
+    }
+
+    /**
+     * Formats bytes into a human readable string if $this->useFormatting is true, otherwise return $bytes as is
+     *
+     * @return string|int Formatted string if $this->useFormatting is true, otherwise return $bytes as int
+     */
+    protected function formatBytes(int $bytes)
+    {
+        if (!$this->useFormatting) {
+            return $bytes;
+        }
+
+        if ($bytes > 1024 * 1024) {
+            return round($bytes / 1024 / 1024, 2).' MB';
+        } elseif ($bytes > 1024) {
+            return round($bytes / 1024, 2).' KB';
+        }
+
+        return $bytes . ' B';
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Processor/MemoryUsageProcessor.php
+++ b/vendor/monolog/monolog/src/Monolog/Processor/MemoryUsageProcessor.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+use Monolog\LogRecord;
+
+/**
+ * Injects memory_get_usage in all records
+ *
+ * @see Monolog\Processor\MemoryProcessor::__construct() for options
+ * @author Rob Jensen
+ */
+class MemoryUsageProcessor extends MemoryProcessor
+{
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        $usage = memory_get_usage($this->realUsage);
+
+        if ($this->useFormatting) {
+            $usage = $this->formatBytes($usage);
+        }
+
+        $record->extra['memory_usage'] = $usage;
+
+        return $record;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Processor/MercurialProcessor.php
+++ b/vendor/monolog/monolog/src/Monolog/Processor/MercurialProcessor.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+use Monolog\Level;
+use Monolog\Logger;
+use Psr\Log\LogLevel;
+use Monolog\LogRecord;
+
+/**
+ * Injects Hg branch and Hg revision number in all records
+ *
+ * @author Jonathan A. Schweder <jonathanschweder@gmail.com>
+ */
+class MercurialProcessor implements ProcessorInterface
+{
+    private Level $level;
+    /** @var array{branch: string, revision: string}|array<never>|null */
+    private static $cache = null;
+
+    /**
+     * @param int|string|Level $level The minimum logging level at which this Processor will be triggered
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $level
+     */
+    public function __construct(int|string|Level $level = Level::Debug)
+    {
+        $this->level = Logger::toMonologLevel($level);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        // return if the level is not high enough
+        if ($record->level->isLowerThan($this->level)) {
+            return $record;
+        }
+
+        $record->extra['hg'] = self::getMercurialInfo();
+
+        return $record;
+    }
+
+    /**
+     * @return array{branch: string, revision: string}|array<never>
+     */
+    private static function getMercurialInfo(): array
+    {
+        if (self::$cache !== null) {
+            return self::$cache;
+        }
+
+        $result = explode(' ', trim((string) shell_exec('hg id -nb')));
+        if (\count($result) >= 3) {
+            return self::$cache = [
+                'branch' => $result[1],
+                'revision' => $result[2],
+            ];
+        }
+        if (\count($result) === 2) {
+            return self::$cache = [
+                'branch' => $result[1],
+                'revision' => $result[0],
+            ];
+        }
+
+        return self::$cache = [];
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Processor/ProcessIdProcessor.php
+++ b/vendor/monolog/monolog/src/Monolog/Processor/ProcessIdProcessor.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+use Monolog\LogRecord;
+
+/**
+ * Adds value of getmypid into records
+ *
+ * @author Andreas Hörnicke
+ */
+class ProcessIdProcessor implements ProcessorInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        $record->extra['process_id'] = getmypid();
+
+        return $record;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Processor/ProcessorInterface.php
+++ b/vendor/monolog/monolog/src/Monolog/Processor/ProcessorInterface.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+use Monolog\LogRecord;
+
+/**
+ * An optional interface to allow labelling Monolog processors.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+interface ProcessorInterface
+{
+    /**
+     * @return LogRecord The processed record
+     */
+    public function __invoke(LogRecord $record);
+}

--- a/vendor/monolog/monolog/src/Monolog/Processor/PsrLogMessageProcessor.php
+++ b/vendor/monolog/monolog/src/Monolog/Processor/PsrLogMessageProcessor.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+use Monolog\Utils;
+use Monolog\LogRecord;
+
+/**
+ * Processes a record's message according to PSR-3 rules
+ *
+ * It replaces {foo} with the value from $context['foo']
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class PsrLogMessageProcessor implements ProcessorInterface
+{
+    public const SIMPLE_DATE = "Y-m-d\TH:i:s.uP";
+
+    private ?string $dateFormat;
+
+    private bool $removeUsedContextFields;
+
+    /**
+     * @param string|null $dateFormat              The format of the timestamp: one supported by DateTime::format
+     * @param bool        $removeUsedContextFields If set to true the fields interpolated into message gets unset
+     */
+    public function __construct(?string $dateFormat = null, bool $removeUsedContextFields = false)
+    {
+        $this->dateFormat = $dateFormat;
+        $this->removeUsedContextFields = $removeUsedContextFields;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        if (false === strpos($record->message, '{')) {
+            return $record;
+        }
+
+        $replacements = [];
+        $context = $record->context;
+
+        foreach ($context as $key => $val) {
+            $placeholder = '{' . $key . '}';
+            if (strpos($record->message, $placeholder) === false) {
+                continue;
+            }
+
+            if (null === $val || \is_scalar($val) || (\is_object($val) && method_exists($val, "__toString"))) {
+                $replacements[$placeholder] = $val;
+            } elseif ($val instanceof \DateTimeInterface) {
+                if (null === $this->dateFormat && $val instanceof \Monolog\JsonSerializableDateTimeImmutable) {
+                    // handle monolog dates using __toString if no specific dateFormat was asked for
+                    // so that it follows the useMicroseconds flag
+                    $replacements[$placeholder] = (string) $val;
+                } else {
+                    $replacements[$placeholder] = $val->format($this->dateFormat ?? static::SIMPLE_DATE);
+                }
+            } elseif ($val instanceof \UnitEnum) {
+                $replacements[$placeholder] = $val instanceof \BackedEnum ? $val->value : $val->name;
+            } elseif (\is_object($val)) {
+                $replacements[$placeholder] = '[object '.Utils::getClass($val).']';
+            } elseif (\is_array($val)) {
+                $replacements[$placeholder] = 'array'.Utils::jsonEncode($val, null, true);
+            } else {
+                $replacements[$placeholder] = '['.\gettype($val).']';
+            }
+
+            if ($this->removeUsedContextFields) {
+                unset($context[$key]);
+            }
+        }
+
+        return $record->with(message: strtr($record->message, $replacements), context: $context);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Processor/TagProcessor.php
+++ b/vendor/monolog/monolog/src/Monolog/Processor/TagProcessor.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+use Monolog\LogRecord;
+
+/**
+ * Adds a tags array into record
+ *
+ * @author Martijn Riemers
+ */
+class TagProcessor implements ProcessorInterface
+{
+    /** @var string[] */
+    private array $tags;
+
+    /**
+     * @param string[] $tags
+     */
+    public function __construct(array $tags = [])
+    {
+        $this->setTags($tags);
+    }
+
+    /**
+     * @param  string[] $tags
+     * @return $this
+     */
+    public function addTags(array $tags = []): self
+    {
+        $this->tags = array_merge($this->tags, $tags);
+
+        return $this;
+    }
+
+    /**
+     * @param  string[] $tags
+     * @return $this
+     */
+    public function setTags(array $tags = []): self
+    {
+        $this->tags = $tags;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        $record->extra['tags'] = $this->tags;
+
+        return $record;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Processor/UidProcessor.php
+++ b/vendor/monolog/monolog/src/Monolog/Processor/UidProcessor.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+use Monolog\ResettableInterface;
+use Monolog\LogRecord;
+
+/**
+ * Adds a unique identifier into records
+ *
+ * @author Simon Mönch <sm@webfactory.de>
+ */
+class UidProcessor implements ProcessorInterface, ResettableInterface
+{
+    /** @var non-empty-string */
+    private string $uid;
+
+    /**
+     * @param int<1, 32> $length
+     */
+    public function __construct(int $length = 7)
+    {
+        if ($length > 32 || $length < 1) {
+            throw new \InvalidArgumentException('The uid length must be an integer between 1 and 32');
+        }
+
+        $this->uid = $this->generateUid($length);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        $record->extra['uid'] = $this->uid;
+
+        return $record;
+    }
+
+    public function getUid(): string
+    {
+        return $this->uid;
+    }
+
+    public function reset(): void
+    {
+        $this->uid = $this->generateUid(\strlen($this->uid));
+    }
+
+    /**
+     * @param  positive-int     $length
+     * @return non-empty-string
+     */
+    private function generateUid(int $length): string
+    {
+        return substr(bin2hex(random_bytes((int) ceil($length / 2))), 0, $length);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Processor/WebProcessor.php
+++ b/vendor/monolog/monolog/src/Monolog/Processor/WebProcessor.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Processor;
+
+use ArrayAccess;
+use Monolog\LogRecord;
+
+/**
+ * Injects url/method and remote IP of the current web request in all records
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class WebProcessor implements ProcessorInterface
+{
+    /**
+     * @var array<string, mixed>|ArrayAccess<string, mixed>
+     */
+    protected array|ArrayAccess $serverData;
+
+    /**
+     * Default fields
+     *
+     * Array is structured as [key in record.extra => key in $serverData]
+     *
+     * @var array<string, string>
+     */
+    protected array $extraFields = [
+        'url'         => 'REQUEST_URI',
+        'ip'          => 'REMOTE_ADDR',
+        'http_method' => 'REQUEST_METHOD',
+        'server'      => 'SERVER_NAME',
+        'referrer'    => 'HTTP_REFERER',
+        'user_agent'  => 'HTTP_USER_AGENT',
+    ];
+
+    /**
+     * @param array<string, mixed>|ArrayAccess<string, mixed>|null $serverData  Array or object w/ ArrayAccess that provides access to the $_SERVER data
+     * @param array<string, string>|array<string>|null             $extraFields Field names and the related key inside $serverData to be added (or just a list of field names to use the default configured $serverData mapping). If not provided it defaults to: [url, ip, http_method, server, referrer] + unique_id if present in server data
+     */
+    public function __construct(array|ArrayAccess|null $serverData = null, array|null $extraFields = null)
+    {
+        if (null === $serverData) {
+            $this->serverData = &$_SERVER;
+        } else {
+            $this->serverData = $serverData;
+        }
+
+        $defaultEnabled = ['url', 'ip', 'http_method', 'server', 'referrer'];
+        if (isset($this->serverData['UNIQUE_ID'])) {
+            $this->extraFields['unique_id'] = 'UNIQUE_ID';
+            $defaultEnabled[] = 'unique_id';
+        }
+
+        if (null === $extraFields) {
+            $extraFields = $defaultEnabled;
+        }
+        if (isset($extraFields[0])) {
+            foreach (array_keys($this->extraFields) as $fieldName) {
+                if (!\in_array($fieldName, $extraFields, true)) {
+                    unset($this->extraFields[$fieldName]);
+                }
+            }
+        } else {
+            $this->extraFields = $extraFields;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        // skip processing if for some reason request data
+        // is not present (CLI or wonky SAPIs)
+        if (!isset($this->serverData['REQUEST_URI'])) {
+            return $record;
+        }
+
+        $record->extra = $this->appendExtraFields($record->extra);
+
+        return $record;
+    }
+
+    /**
+     * @return $this
+     */
+    public function addExtraField(string $extraName, string $serverName): self
+    {
+        $this->extraFields[$extraName] = $serverName;
+
+        return $this;
+    }
+
+    /**
+     * @param  mixed[] $extra
+     * @return mixed[]
+     */
+    private function appendExtraFields(array $extra): array
+    {
+        foreach ($this->extraFields as $extraName => $serverName) {
+            $extra[$extraName] = $this->serverData[$serverName] ?? null;
+        }
+
+        return $extra;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Registry.php
+++ b/vendor/monolog/monolog/src/Monolog/Registry.php
@@ -1,0 +1,133 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog;
+
+use InvalidArgumentException;
+
+/**
+ * Monolog log registry
+ *
+ * Allows to get `Logger` instances in the global scope
+ * via static method calls on this class.
+ *
+ * <code>
+ * $application = new Monolog\Logger('application');
+ * $api = new Monolog\Logger('api');
+ *
+ * Monolog\Registry::addLogger($application);
+ * Monolog\Registry::addLogger($api);
+ *
+ * function testLogger()
+ * {
+ *     Monolog\Registry::api()->error('Sent to $api Logger instance');
+ *     Monolog\Registry::application()->error('Sent to $application Logger instance');
+ * }
+ * </code>
+ *
+ * @author Tomas Tatarko <tomas@tatarko.sk>
+ */
+class Registry
+{
+    /**
+     * List of all loggers in the registry (by named indexes)
+     *
+     * @var Logger[]
+     */
+    private static array $loggers = [];
+
+    /**
+     * Adds new logging channel to the registry
+     *
+     * @param  Logger                    $logger    Instance of the logging channel
+     * @param  string|null               $name      Name of the logging channel ($logger->getName() by default)
+     * @param  bool                      $overwrite Overwrite instance in the registry if the given name already exists?
+     * @throws \InvalidArgumentException If $overwrite set to false and named Logger instance already exists
+     */
+    public static function addLogger(Logger $logger, ?string $name = null, bool $overwrite = false): void
+    {
+        $name = $name ?? $logger->getName();
+
+        if (isset(self::$loggers[$name]) && !$overwrite) {
+            throw new InvalidArgumentException('Logger with the given name already exists');
+        }
+
+        self::$loggers[$name] = $logger;
+    }
+
+    /**
+     * Checks if such logging channel exists by name or instance
+     *
+     * @param string|Logger $logger Name or logger instance
+     */
+    public static function hasLogger($logger): bool
+    {
+        if ($logger instanceof Logger) {
+            $index = array_search($logger, self::$loggers, true);
+
+            return false !== $index;
+        }
+
+        return isset(self::$loggers[$logger]);
+    }
+
+    /**
+     * Removes instance from registry by name or instance
+     *
+     * @param string|Logger $logger Name or logger instance
+     */
+    public static function removeLogger($logger): void
+    {
+        if ($logger instanceof Logger) {
+            if (false !== ($idx = array_search($logger, self::$loggers, true))) {
+                unset(self::$loggers[$idx]);
+            }
+        } else {
+            unset(self::$loggers[$logger]);
+        }
+    }
+
+    /**
+     * Clears the registry
+     */
+    public static function clear(): void
+    {
+        self::$loggers = [];
+    }
+
+    /**
+     * Gets Logger instance from the registry
+     *
+     * @param  string                    $name Name of the requested Logger instance
+     * @throws \InvalidArgumentException If named Logger instance is not in the registry
+     */
+    public static function getInstance(string $name): Logger
+    {
+        if (!isset(self::$loggers[$name])) {
+            throw new InvalidArgumentException(sprintf('Requested "%s" logger instance is not in the registry', $name));
+        }
+
+        return self::$loggers[$name];
+    }
+
+    /**
+     * Gets Logger instance from the registry via static method call
+     *
+     * @param  string                    $name      Name of the requested Logger instance
+     * @param  mixed[]                   $arguments Arguments passed to static method call
+     * @throws \InvalidArgumentException If named Logger instance is not in the registry
+     * @return Logger                    Requested instance of Logger
+     */
+    public static function __callStatic(string $name, array $arguments): Logger
+    {
+        return self::getInstance($name);
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/ResettableInterface.php
+++ b/vendor/monolog/monolog/src/Monolog/ResettableInterface.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog;
+
+/**
+ * Handler or Processor implementing this interface will be reset when Logger::reset() is called.
+ *
+ * Resetting ends a log cycle gets them back to their initial state.
+ *
+ * Resetting a Handler or a Processor means flushing/cleaning all buffers, resetting internal
+ * state, and getting it back to a state in which it can receive log records again.
+ *
+ * This is useful in case you want to avoid logs leaking between two requests or jobs when you
+ * have a long running process like a worker or an application server serving multiple requests
+ * in one process.
+ *
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+interface ResettableInterface
+{
+    public function reset(): void;
+}

--- a/vendor/monolog/monolog/src/Monolog/SignalHandler.php
+++ b/vendor/monolog/monolog/src/Monolog/SignalHandler.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use ReflectionExtension;
+
+/**
+ * Monolog POSIX signal handler
+ *
+ * @author Robert Gust-Bardon <robert@gust-bardon.org>
+ */
+class SignalHandler
+{
+    private LoggerInterface $logger;
+
+    /** @var array<int, callable|string|int> SIG_DFL, SIG_IGN or previous callable */
+    private array $previousSignalHandler = [];
+    /** @var array<int, \Psr\Log\LogLevel::*> */
+    private array $signalLevelMap = [];
+    /** @var array<int, bool> */
+    private array $signalRestartSyscalls = [];
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param  int|string|Level $level Level or level name
+     * @return $this
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $level
+     */
+    public function registerSignalHandler(int $signo, int|string|Level $level = LogLevel::CRITICAL, bool $callPrevious = true, bool $restartSyscalls = true, ?bool $async = true): self
+    {
+        if (!\extension_loaded('pcntl') || !\function_exists('pcntl_signal')) {
+            return $this;
+        }
+
+        $level = Logger::toMonologLevel($level)->toPsrLogLevel();
+
+        if ($callPrevious) {
+            $handler = pcntl_signal_get_handler($signo);
+            $this->previousSignalHandler[$signo] = $handler;
+        } else {
+            unset($this->previousSignalHandler[$signo]);
+        }
+        $this->signalLevelMap[$signo] = $level;
+        $this->signalRestartSyscalls[$signo] = $restartSyscalls;
+
+        if ($async !== null) {
+            pcntl_async_signals($async);
+        }
+
+        pcntl_signal($signo, [$this, 'handleSignal'], $restartSyscalls);
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $siginfo
+     */
+    public function handleSignal(int $signo, $siginfo = null): void
+    {
+        /** @var array<int, string> $signals */
+        static $signals = [];
+
+        if (\count($signals) === 0 && \extension_loaded('pcntl')) {
+            $pcntl = new ReflectionExtension('pcntl');
+            foreach ($pcntl->getConstants() as $name => $value) {
+                if (substr($name, 0, 3) === 'SIG' && $name[3] !== '_' && \is_int($value)) {
+                    $signals[$value] = $name;
+                }
+            }
+        }
+
+        $level = $this->signalLevelMap[$signo] ?? LogLevel::CRITICAL;
+        $signal = $signals[$signo] ?? $signo;
+        $context = $siginfo ?? [];
+        $this->logger->log($level, sprintf('Program received signal %s', $signal), $context);
+
+        if (!isset($this->previousSignalHandler[$signo])) {
+            return;
+        }
+
+        if ($this->previousSignalHandler[$signo] === SIG_DFL) {
+            if (\extension_loaded('pcntl') && \function_exists('pcntl_signal') && \function_exists('pcntl_sigprocmask') && \function_exists('pcntl_signal_dispatch')
+                && \extension_loaded('posix') && \function_exists('posix_getpid') && \function_exists('posix_kill')
+            ) {
+                $restartSyscalls = $this->signalRestartSyscalls[$signo] ?? true;
+                pcntl_signal($signo, SIG_DFL, $restartSyscalls);
+                pcntl_sigprocmask(SIG_UNBLOCK, [$signo], $oldset);
+                posix_kill(posix_getpid(), $signo);
+                pcntl_signal_dispatch();
+                pcntl_sigprocmask(SIG_SETMASK, $oldset);
+                pcntl_signal($signo, [$this, 'handleSignal'], $restartSyscalls);
+            }
+        } elseif (\is_callable($this->previousSignalHandler[$signo])) {
+            $this->previousSignalHandler[$signo]($signo, $siginfo);
+        }
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Test/MonologTestCase.php
+++ b/vendor/monolog/monolog/src/Monolog/Test/MonologTestCase.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Test;
+
+use Monolog\Level;
+use Monolog\Logger;
+use Monolog\LogRecord;
+use Monolog\JsonSerializableDateTimeImmutable;
+use Monolog\Formatter\FormatterInterface;
+use Psr\Log\LogLevel;
+
+/**
+ * Lets you easily generate log records and a dummy formatter for testing purposes
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class MonologTestCase extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @param array<mixed> $context
+     * @param array<mixed> $extra
+     *
+     * @phpstan-param value-of<Level::VALUES>|value-of<Level::NAMES>|Level|LogLevel::* $level
+     */
+    protected function getRecord(int|string|Level $level = Level::Warning, string|\Stringable $message = 'test', array $context = [], string $channel = 'test', \DateTimeImmutable $datetime = new JsonSerializableDateTimeImmutable(true), array $extra = []): LogRecord
+    {
+        return new LogRecord(
+            message: (string) $message,
+            context: $context,
+            level: Logger::toMonologLevel($level),
+            channel: $channel,
+            datetime: $datetime,
+            extra: $extra,
+        );
+    }
+
+    /**
+     * @phpstan-return list<LogRecord>
+     */
+    protected function getMultipleRecords(): array
+    {
+        return [
+            $this->getRecord(Level::Debug, 'debug message 1'),
+            $this->getRecord(Level::Debug, 'debug message 2'),
+            $this->getRecord(Level::Info, 'information'),
+            $this->getRecord(Level::Warning, 'warning'),
+            $this->getRecord(Level::Error, 'error'),
+        ];
+    }
+
+    protected function getIdentityFormatter(): FormatterInterface
+    {
+        $formatter = $this->createMock(FormatterInterface::class);
+        $formatter->expects(self::any())
+            ->method('format')
+            ->willReturnCallback(function ($record) {
+                return $record->message;
+            });
+
+        return $formatter;
+    }
+}

--- a/vendor/monolog/monolog/src/Monolog/Test/TestCase.php
+++ b/vendor/monolog/monolog/src/Monolog/Test/TestCase.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog\Test;
+
+/**
+ * Lets you easily generate log records and a dummy formatter for testing purposes
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * @deprecated use MonologTestCase instead.
+ */
+class TestCase extends MonologTestCase
+{
+}

--- a/vendor/monolog/monolog/src/Monolog/Utils.php
+++ b/vendor/monolog/monolog/src/Monolog/Utils.php
@@ -1,0 +1,257 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Monolog;
+
+final class Utils
+{
+    const DEFAULT_JSON_FLAGS = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION | JSON_INVALID_UTF8_SUBSTITUTE | JSON_PARTIAL_OUTPUT_ON_ERROR;
+
+    public static function getClass(object $object): string
+    {
+        $class = \get_class($object);
+
+        if (false === ($pos = strpos($class, "@anonymous\0"))) {
+            return $class;
+        }
+
+        if (false === ($parent = get_parent_class($class))) {
+            return substr($class, 0, $pos + 10);
+        }
+
+        return $parent . '@anonymous';
+    }
+
+    public static function substr(string $string, int $start, ?int $length = null): string
+    {
+        if (\extension_loaded('mbstring')) {
+            return mb_strcut($string, $start, $length);
+        }
+
+        return substr($string, $start, (null === $length) ? \strlen($string) : $length);
+    }
+
+    /**
+     * Makes sure if a relative path is passed in it is turned into an absolute path
+     *
+     * @param string $streamUrl stream URL or path without protocol
+     */
+    public static function canonicalizePath(string $streamUrl): string
+    {
+        $prefix = '';
+        if ('file://' === substr($streamUrl, 0, 7)) {
+            $streamUrl = substr($streamUrl, 7);
+            $prefix = 'file://';
+        }
+
+        // other type of stream, not supported
+        if (false !== strpos($streamUrl, '://')) {
+            return $streamUrl;
+        }
+
+        // already absolute
+        if (substr($streamUrl, 0, 1) === '/' || substr($streamUrl, 1, 1) === ':' || substr($streamUrl, 0, 2) === '\\\\') {
+            return $prefix.$streamUrl;
+        }
+
+        $streamUrl = getcwd() . '/' . $streamUrl;
+
+        return $prefix.$streamUrl;
+    }
+
+    /**
+     * Return the JSON representation of a value
+     *
+     * @param  mixed             $data
+     * @param  int               $encodeFlags  flags to pass to json encode, defaults to DEFAULT_JSON_FLAGS
+     * @param  bool              $ignoreErrors whether to ignore encoding errors or to throw on error, when ignored and the encoding fails, "null" is returned which is valid json for null
+     * @throws \RuntimeException if encoding fails and errors are not ignored
+     * @return string            when errors are ignored and the encoding fails, "null" is returned which is valid json for null
+     */
+    public static function jsonEncode($data, ?int $encodeFlags = null, bool $ignoreErrors = false): string
+    {
+        if (null === $encodeFlags) {
+            $encodeFlags = self::DEFAULT_JSON_FLAGS;
+        }
+
+        if ($ignoreErrors) {
+            $json = @json_encode($data, $encodeFlags);
+            if (false === $json) {
+                return 'null';
+            }
+
+            return $json;
+        }
+
+        $json = json_encode($data, $encodeFlags);
+        if (false === $json) {
+            $json = self::handleJsonError(json_last_error(), $data);
+        }
+
+        return $json;
+    }
+
+    /**
+     * Handle a json_encode failure.
+     *
+     * If the failure is due to invalid string encoding, try to clean the
+     * input and encode again. If the second encoding attempt fails, the
+     * initial error is not encoding related or the input can't be cleaned then
+     * raise a descriptive exception.
+     *
+     * @param  int               $code        return code of json_last_error function
+     * @param  mixed             $data        data that was meant to be encoded
+     * @param  int               $encodeFlags flags to pass to json encode, defaults to JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION
+     * @throws \RuntimeException if failure can't be corrected
+     * @return string            JSON encoded data after error correction
+     */
+    public static function handleJsonError(int $code, $data, ?int $encodeFlags = null): string
+    {
+        if ($code !== JSON_ERROR_UTF8) {
+            self::throwEncodeError($code, $data);
+        }
+
+        if (\is_string($data)) {
+            self::detectAndCleanUtf8($data);
+        } elseif (\is_array($data)) {
+            array_walk_recursive($data, ['Monolog\Utils', 'detectAndCleanUtf8']);
+        } else {
+            self::throwEncodeError($code, $data);
+        }
+
+        if (null === $encodeFlags) {
+            $encodeFlags = self::DEFAULT_JSON_FLAGS;
+        }
+
+        $json = json_encode($data, $encodeFlags);
+
+        if ($json === false) {
+            self::throwEncodeError(json_last_error(), $data);
+        }
+
+        return $json;
+    }
+
+    /**
+     * Throws an exception according to a given code with a customized message
+     *
+     * @param  int               $code return code of json_last_error function
+     * @param  mixed             $data data that was meant to be encoded
+     * @throws \RuntimeException
+     */
+    private static function throwEncodeError(int $code, $data): never
+    {
+        $msg = match ($code) {
+            JSON_ERROR_DEPTH => 'Maximum stack depth exceeded',
+            JSON_ERROR_STATE_MISMATCH => 'Underflow or the modes mismatch',
+            JSON_ERROR_CTRL_CHAR => 'Unexpected control character found',
+            JSON_ERROR_UTF8 => 'Malformed UTF-8 characters, possibly incorrectly encoded',
+            default => 'Unknown error',
+        };
+
+        throw new \RuntimeException('JSON encoding failed: '.$msg.'. Encoding: '.var_export($data, true));
+    }
+
+    /**
+     * Detect invalid UTF-8 string characters and convert to valid UTF-8.
+     *
+     * Valid UTF-8 input will be left unmodified, but strings containing
+     * invalid UTF-8 codepoints will be reencoded as UTF-8 with an assumed
+     * original encoding of ISO-8859-15. This conversion may result in
+     * incorrect output if the actual encoding was not ISO-8859-15, but it
+     * will be clean UTF-8 output and will not rely on expensive and fragile
+     * detection algorithms.
+     *
+     * Function converts the input in place in the passed variable so that it
+     * can be used as a callback for array_walk_recursive.
+     *
+     * @param mixed $data Input to check and convert if needed, passed by ref
+     */
+    private static function detectAndCleanUtf8(&$data): void
+    {
+        if (\is_string($data) && preg_match('//u', $data) !== 1) {
+            $data = preg_replace_callback(
+                '/[\x80-\xFF]+/',
+                function (array $m): string {
+                    return \function_exists('mb_convert_encoding')
+                        ? mb_convert_encoding($m[0], 'UTF-8', 'ISO-8859-1')
+                        : (\function_exists('utf8_encode') ? utf8_encode($m[0]) : '');
+                },
+                $data
+            );
+            if (!\is_string($data)) {
+                $pcreErrorCode = preg_last_error();
+
+                throw new \RuntimeException('Failed to preg_replace_callback: ' . $pcreErrorCode . ' / ' . preg_last_error_msg());
+            }
+            $data = str_replace(
+                ['¤', '¦', '¨', '´', '¸', '¼', '½', '¾'],
+                ['€', 'Š', 'š', 'Ž', 'ž', 'Œ', 'œ', 'Ÿ'],
+                $data
+            );
+        }
+    }
+
+    /**
+     * Converts a string with a valid 'memory_limit' format, to bytes.
+     *
+     * @param  string|false $val
+     * @return int|false    Returns an integer representing bytes. Returns FALSE in case of error.
+     */
+    public static function expandIniShorthandBytes($val)
+    {
+        if (!\is_string($val)) {
+            return false;
+        }
+
+        // support -1
+        if ((int) $val < 0) {
+            return (int) $val;
+        }
+
+        if (!(bool) preg_match('/^\s*(?<val>\d+)(?:\.\d+)?\s*(?<unit>[gmk]?)\s*$/i', $val, $match)) {
+            return false;
+        }
+
+        $val = (int) $match['val'];
+        switch (strtolower($match['unit'])) {
+            case 'g':
+                $val *= 1024;
+                // no break
+            case 'm':
+                $val *= 1024;
+                // no break
+            case 'k':
+                $val *= 1024;
+        }
+
+        return $val;
+    }
+
+    public static function getRecordMessageForException(LogRecord $record): string
+    {
+        $context = '';
+        $extra = '';
+
+        try {
+            if (\count($record->context) > 0) {
+                $context = "\nContext: " . json_encode($record->context, JSON_THROW_ON_ERROR);
+            }
+            if (\count($record->extra) > 0) {
+                $extra = "\nExtra: " . json_encode($record->extra, JSON_THROW_ON_ERROR);
+            }
+        } catch (\Throwable $e) {
+            // noop
+        }
+
+        return "\nThe exception occurred while attempting to log: " . $record->message . $context . $extra;
+    }
+}

--- a/vendor/psr/log/LICENSE
+++ b/vendor/psr/log/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2012 PHP Framework Interoperability Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is 
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in 
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/psr/log/README.md
+++ b/vendor/psr/log/README.md
@@ -1,0 +1,58 @@
+PSR Log
+=======
+
+This repository holds all interfaces/classes/traits related to
+[PSR-3](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md).
+
+Note that this is not a logger of its own. It is merely an interface that
+describes a logger. See the specification for more details.
+
+Installation
+------------
+
+```bash
+composer require psr/log
+```
+
+Usage
+-----
+
+If you need a logger, you can use the interface like this:
+
+```php
+<?php
+
+use Psr\Log\LoggerInterface;
+
+class Foo
+{
+    private $logger;
+
+    public function __construct(LoggerInterface $logger = null)
+    {
+        $this->logger = $logger;
+    }
+
+    public function doSomething()
+    {
+        if ($this->logger) {
+            $this->logger->info('Doing work');
+        }
+           
+        try {
+            $this->doSomethingElse();
+        } catch (Exception $exception) {
+            $this->logger->error('Oh no!', array('exception' => $exception));
+        }
+
+        // do something useful
+    }
+}
+```
+
+You can then pick one of the implementations of the interface to get a logger.
+
+If you want to implement the interface, you can require this package and
+implement `Psr\Log\LoggerInterface` in your code. Please read the
+[specification text](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md)
+for details.

--- a/vendor/psr/log/composer.json
+++ b/vendor/psr/log/composer.json
@@ -1,0 +1,26 @@
+{
+    "name": "psr/log",
+    "description": "Common interface for logging libraries",
+    "keywords": ["psr", "psr-3", "log"],
+    "homepage": "https://github.com/php-fig/log",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "PHP-FIG",
+            "homepage": "https://www.php-fig.org/"
+        }
+    ],
+    "require": {
+        "php": ">=8.0.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Psr\\Log\\": "src"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.x-dev"
+        }
+    }
+}

--- a/vendor/psr/log/src/AbstractLogger.php
+++ b/vendor/psr/log/src/AbstractLogger.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Psr\Log;
+
+/**
+ * This is a simple Logger implementation that other Loggers can inherit from.
+ *
+ * It simply delegates all log-level-specific methods to the `log` method to
+ * reduce boilerplate code that a simple Logger that does the same thing with
+ * messages regardless of the error level has to implement.
+ */
+abstract class AbstractLogger implements LoggerInterface
+{
+    use LoggerTrait;
+}

--- a/vendor/psr/log/src/InvalidArgumentException.php
+++ b/vendor/psr/log/src/InvalidArgumentException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Psr\Log;
+
+class InvalidArgumentException extends \InvalidArgumentException
+{
+}

--- a/vendor/psr/log/src/LogLevel.php
+++ b/vendor/psr/log/src/LogLevel.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Psr\Log;
+
+/**
+ * Describes log levels.
+ */
+class LogLevel
+{
+    const EMERGENCY = 'emergency';
+    const ALERT     = 'alert';
+    const CRITICAL  = 'critical';
+    const ERROR     = 'error';
+    const WARNING   = 'warning';
+    const NOTICE    = 'notice';
+    const INFO      = 'info';
+    const DEBUG     = 'debug';
+}

--- a/vendor/psr/log/src/LoggerAwareInterface.php
+++ b/vendor/psr/log/src/LoggerAwareInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Psr\Log;
+
+/**
+ * Describes a logger-aware instance.
+ */
+interface LoggerAwareInterface
+{
+    /**
+     * Sets a logger instance on the object.
+     */
+    public function setLogger(LoggerInterface $logger): void;
+}

--- a/vendor/psr/log/src/LoggerAwareTrait.php
+++ b/vendor/psr/log/src/LoggerAwareTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Psr\Log;
+
+/**
+ * Basic Implementation of LoggerAwareInterface.
+ */
+trait LoggerAwareTrait
+{
+    /**
+     * The logger instance.
+     */
+    protected ?LoggerInterface $logger = null;
+
+    /**
+     * Sets a logger.
+     */
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
+}

--- a/vendor/psr/log/src/LoggerInterface.php
+++ b/vendor/psr/log/src/LoggerInterface.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Psr\Log;
+
+/**
+ * Describes a logger instance.
+ *
+ * The message MUST be a string or object implementing __toString().
+ *
+ * The message MAY contain placeholders in the form: {foo} where foo
+ * will be replaced by the context data in key "foo".
+ *
+ * The context array can contain arbitrary data. The only assumption that
+ * can be made by implementors is that if an Exception instance is given
+ * to produce a stack trace, it MUST be in a key named "exception".
+ *
+ * See https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md
+ * for the full interface specification.
+ */
+interface LoggerInterface
+{
+    /**
+     * System is unusable.
+     *
+     * @param mixed[] $context
+     */
+    public function emergency(string|\Stringable $message, array $context = []): void;
+
+    /**
+     * Action must be taken immediately.
+     *
+     * Example: Entire website down, database unavailable, etc. This should
+     * trigger the SMS alerts and wake you up.
+     *
+     * @param mixed[] $context
+     */
+    public function alert(string|\Stringable $message, array $context = []): void;
+
+    /**
+     * Critical conditions.
+     *
+     * Example: Application component unavailable, unexpected exception.
+     *
+     * @param mixed[] $context
+     */
+    public function critical(string|\Stringable $message, array $context = []): void;
+
+    /**
+     * Runtime errors that do not require immediate action but should typically
+     * be logged and monitored.
+     *
+     * @param mixed[] $context
+     */
+    public function error(string|\Stringable $message, array $context = []): void;
+
+    /**
+     * Exceptional occurrences that are not errors.
+     *
+     * Example: Use of deprecated APIs, poor use of an API, undesirable things
+     * that are not necessarily wrong.
+     *
+     * @param mixed[] $context
+     */
+    public function warning(string|\Stringable $message, array $context = []): void;
+
+    /**
+     * Normal but significant events.
+     *
+     * @param mixed[] $context
+     */
+    public function notice(string|\Stringable $message, array $context = []): void;
+
+    /**
+     * Interesting events.
+     *
+     * Example: User logs in, SQL logs.
+     *
+     * @param mixed[] $context
+     */
+    public function info(string|\Stringable $message, array $context = []): void;
+
+    /**
+     * Detailed debug information.
+     *
+     * @param mixed[] $context
+     */
+    public function debug(string|\Stringable $message, array $context = []): void;
+
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed $level
+     * @param mixed[] $context
+     *
+     * @throws \Psr\Log\InvalidArgumentException
+     */
+    public function log($level, string|\Stringable $message, array $context = []): void;
+}

--- a/vendor/psr/log/src/LoggerTrait.php
+++ b/vendor/psr/log/src/LoggerTrait.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Psr\Log;
+
+/**
+ * This is a simple Logger trait that classes unable to extend AbstractLogger
+ * (because they extend another class, etc) can include.
+ *
+ * It simply delegates all log-level-specific methods to the `log` method to
+ * reduce boilerplate code that a simple Logger that does the same thing with
+ * messages regardless of the error level has to implement.
+ */
+trait LoggerTrait
+{
+    /**
+     * System is unusable.
+     */
+    public function emergency(string|\Stringable $message, array $context = []): void
+    {
+        $this->log(LogLevel::EMERGENCY, $message, $context);
+    }
+
+    /**
+     * Action must be taken immediately.
+     *
+     * Example: Entire website down, database unavailable, etc. This should
+     * trigger the SMS alerts and wake you up.
+     */
+    public function alert(string|\Stringable $message, array $context = []): void
+    {
+        $this->log(LogLevel::ALERT, $message, $context);
+    }
+
+    /**
+     * Critical conditions.
+     *
+     * Example: Application component unavailable, unexpected exception.
+     */
+    public function critical(string|\Stringable $message, array $context = []): void
+    {
+        $this->log(LogLevel::CRITICAL, $message, $context);
+    }
+
+    /**
+     * Runtime errors that do not require immediate action but should typically
+     * be logged and monitored.
+     */
+    public function error(string|\Stringable $message, array $context = []): void
+    {
+        $this->log(LogLevel::ERROR, $message, $context);
+    }
+
+    /**
+     * Exceptional occurrences that are not errors.
+     *
+     * Example: Use of deprecated APIs, poor use of an API, undesirable things
+     * that are not necessarily wrong.
+     */
+    public function warning(string|\Stringable $message, array $context = []): void
+    {
+        $this->log(LogLevel::WARNING, $message, $context);
+    }
+
+    /**
+     * Normal but significant events.
+     */
+    public function notice(string|\Stringable $message, array $context = []): void
+    {
+        $this->log(LogLevel::NOTICE, $message, $context);
+    }
+
+    /**
+     * Interesting events.
+     *
+     * Example: User logs in, SQL logs.
+     */
+    public function info(string|\Stringable $message, array $context = []): void
+    {
+        $this->log(LogLevel::INFO, $message, $context);
+    }
+
+    /**
+     * Detailed debug information.
+     */
+    public function debug(string|\Stringable $message, array $context = []): void
+    {
+        $this->log(LogLevel::DEBUG, $message, $context);
+    }
+
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed $level
+     *
+     * @throws \Psr\Log\InvalidArgumentException
+     */
+    abstract public function log($level, string|\Stringable $message, array $context = []): void;
+}

--- a/vendor/psr/log/src/NullLogger.php
+++ b/vendor/psr/log/src/NullLogger.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Psr\Log;
+
+/**
+ * This Logger can be used to avoid conditional log calls.
+ *
+ * Logging should always be optional, and if no logger is provided to your
+ * library creating a NullLogger instance to have something to throw logs at
+ * is a good way to avoid littering your code with `if ($this->logger) { }`
+ * blocks.
+ */
+class NullLogger extends AbstractLogger
+{
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed[] $context
+     *
+     * @throws \Psr\Log\InvalidArgumentException
+     */
+    public function log($level, string|\Stringable $message, array $context = []): void
+    {
+        // noop
+    }
+}


### PR DESCRIPTION
Introduce user state management to handle account activation status and
moderation levels (normal, muted, restricted, suspended, banned).

- Add `is_activated` and `moderation_status` fields to User ACF group.
- Implement `users` helper and lifecycle services in `inc/users/`.
- add monolog and psr/log dependencies
- Integrate Monolog 3.x to replace the custom file-based logging implementation.
- Integrate activation check into `AuthService` to prevent login for
  unverified accounts.
- Register user lifecycle setup in `functions.php`.