### PR TITLE
fix(launchpad) in response to QA report card ID N54. 3. Recommendations/comments on improving the opportunity provision form, user profile

### DIFF
--- a/inc/launchpad/Assets/opportunities/actions.js
+++ b/inc/launchpad/Assets/opportunities/actions.js
@@ -14,6 +14,7 @@ import {
   fetchJson,
   normalizeUrl,
   scrollToFirstError,
+  scrollToPageTop,
 } from "../utils.js";
 
 let locationSearchTimeout = null;
@@ -247,6 +248,7 @@ export const opportunitiesActions = {
       );
 
       actions.opportunities.cancel();
+      scrollToPageTop();
       await actions.loadPanelState("opportunities");
     } catch (error) {
       // Map backend field_errors first so we can decide whether the

--- a/inc/launchpad/Assets/profile/actions.js
+++ b/inc/launchpad/Assets/profile/actions.js
@@ -13,6 +13,7 @@ import {
   fetchJson,
   normalizeUrl,
   scrollToFirstError,
+  scrollToPageTop,
   validateName,
   validateUsername,
   validateMessenger,
@@ -417,6 +418,7 @@ export const profileActions = {
       url.searchParams.delete("view");
       window.history.replaceState({}, "", url);
       actions.syncStateFromUrl();
+      scrollToPageTop();
     } catch (error) {
       // Map backend field_errors keys to translated messages
       if (error.fieldErrors) {

--- a/inc/launchpad/Assets/profile/actions.js
+++ b/inc/launchpad/Assets/profile/actions.js
@@ -279,6 +279,26 @@ export const profileActions = {
   },
 
   /**
+   * Input handler for the phone field.
+   * intlTelInput with separateDialCode:true keeps only the national part in
+   * input.value — the dial code lives in a sibling widget element. Read the
+   * canonical E.164 from the widget so state.phone (shown in the profile
+   * card view) keeps its country code. Falls back to ref.value only before
+   * the widget has initialized.
+   */
+  updatePhoneField() {
+    const { state } = store("launchpad");
+    const p = ensurePanel(state, "profile");
+    if (itiInstance) {
+      p.phone = itiInstance.getNumber() || "";
+    } else {
+      const { ref } = getElement();
+      p.phone = ref.value;
+    }
+    if (p.fieldErrors?.phone) p.fieldErrors.phone = null;
+  },
+
+  /**
    * Save profile changes to server
    */
   async save(event) {

--- a/inc/launchpad/Assets/utils.js
+++ b/inc/launchpad/Assets/utils.js
@@ -310,3 +310,16 @@ export function scrollToFirstError(root = document) {
     });
   });
 }
+
+/**
+ * Scroll the window to the very top.
+ *
+ * Called at the success path of form-save actions so the user lands at
+ * the top of the page — above the panel, where the full cabinet chrome
+ * (header, nav, mobile tab switcher) is visible — instead of sitting at
+ * the footer where the submit button was. Honors prefers-reduced-motion.
+ */
+export function scrollToPageTop() {
+  const reduced = matchMedia("(prefers-reduced-motion: reduce)").matches;
+  window.scrollTo({ top: 0, behavior: reduced ? "auto" : "smooth" });
+}

--- a/inc/launchpad/Panels/ProfilePanel.php
+++ b/inc/launchpad/Panels/ProfilePanel.php
@@ -249,7 +249,8 @@ class ProfilePanel extends AbstractPanel
                         <label for="lp-phone" class="label-required">
                             <?= esc_html__('Phone', 'starwishx'); ?>
                         </label>
-                        <input type="tel" id="lp-phone" />
+                        <input type="tel" id="lp-phone"
+                            data-wp-on--input="actions.profile.updatePhoneField" />
                         <label class="exclamation-circle__error" hidden
                             data-wp-bind--hidden="!<?= $this->statePath('fieldErrors') ?>.phone"
                             data-wp-text="<?= $this->statePath('fieldErrors') ?>.phone"></label>


### PR DESCRIPTION
UI/UX fixes following card ID N54 reports:
1. Lack of automatic return to the top of the page on forms save 
2. Lack of focus on the error in the phone number
3. Stuck error message in the number

- Implement a `scrollToPageTop` utility that respects `prefers-reduced-motion`
and integrate it into opportunities and profile action success paths.
This ensures users are returned to the top of the page after form
submissions instead of remaining at the bottom near the submit button.
- Add `updatePhoneField` to profile actions to ensure the phone number
is captured in E.164 format using the `intlTelInput` instance. This
prevents the loss of the dial code when the input value only contains
the national part. Integrate the handler into the ProfilePanel
template via a data-wp-on--input attribute.