### PR TITLE
feat(tour): implement security hardening and rate limiting for REST API & launchpad UX improvement

### DIFF
--- a/inc/launchpad/Assets/utils.js
+++ b/inc/launchpad/Assets/utils.js
@@ -293,20 +293,24 @@ export function extendState(target, ...sources) {
  *
  * Targets any `.exclamation-circle__error` element that is currently not
  * hidden — covers both the panel-header banner (when p.error is set) and
- * inline field errors (when p.fieldErrors is populated). The double-rAF
- * waits for the Interactivity API to commit the pending state update so
- * the target element's `hidden` attribute reflects the new state before
- * we query the DOM.
+ * inline field errors (when p.fieldErrors is populated). When the match
+ * sits inside a `.form-field`, we scroll that container instead so the
+ * input and its error are both in frame; otherwise (banner case) we scroll
+ * the error element itself. The double-rAF waits for the Interactivity API
+ * to commit the pending state update so the target element's `hidden`
+ * attribute reflects the new state before we query the DOM.
  *
  * @param {Element|Document} [root=document] Scope to search within.
  */
 export function scrollToFirstError(root = document) {
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
-      const target = root.querySelector(
+      const err = root.querySelector(
         ".exclamation-circle__error:not([hidden])",
       );
-      target?.scrollIntoView({ behavior: "smooth", block: "center" });
+      if (!err) return;
+      const target = err.closest(".form-field") || err;
+      target.scrollIntoView({ behavior: "smooth", block: "center" });
     });
   });
 }

--- a/inc/tour/Api/TourController.php
+++ b/inc/tour/Api/TourController.php
@@ -6,113 +6,255 @@ declare(strict_types=1);
 namespace Tour\Api;
 
 use Shared\Core\AbstractApiController;
+use Shared\Policy\RateLimitPolicy;
+use Tour\Core\TourCore;
 use WP_REST_Request;
 use WP_REST_Response;
+use WP_Error;
 
 class TourController extends AbstractApiController
 {
     protected $namespace = 'tour/v1';
 
+    // Shared bucket for complete/dismiss/reset — rotating endpoints
+    // shouldn't multiply the budget. Tour state changes are once-per-user
+    // events, so 60/hr is generous for legitimate use.
+    private const STATE_RATE_LIMIT_MAX    = 60;
+    private const STATE_RATE_LIMIT_WINDOW = HOUR_IN_SECONDS;
+
+    // GET /scenarios has its own bucket — keeps repeated client-side
+    // refresh from eating into the state-write budget.
+    private const FETCH_RATE_LIMIT_MAX    = 120;
+    private const FETCH_RATE_LIMIT_WINDOW = HOUR_IN_SECONDS;
+
+    // Defense in depth: even if a rogue ID slips past the allowlist later,
+    // the user_meta array can't grow unbounded.
+    private const MAX_STORED_TOURS = 100;
+
     public function registerRoutes(): void
     {
+        $tourIdArg = [
+            'required'          => true,
+            'type'              => 'string',
+            'sanitize_callback' => 'sanitize_text_field',
+            // Authoritative allowlist: only registered scenario IDs accepted.
+            // Stops arbitrary strings from accumulating in sw_completed_tours
+            // / sw_dismissed_tours user_meta. Scenarios are registered on
+            // init priority 22; REST callbacks run after that, so the
+            // registry is always populated when this validator fires.
+            'validate_callback' => function ($value) {
+                if (!is_string($value) || $value === '') {
+                    return new WP_Error(
+                        'invalid_data',
+                        __('Tour ID is required.', 'starwishx'),
+                        ['status' => 422]
+                    );
+                }
+                if (!TourCore::instance()->hasScenario($value)) {
+                    return new WP_Error(
+                        'invalid_data',
+                        __('Unknown tour.', 'starwishx'),
+                        ['status' => 422]
+                    );
+                }
+                return true;
+            },
+        ];
+
         register_rest_route($this->namespace, '/scenarios', [
             'methods'             => 'GET',
             'callback'            => [$this, 'getScenarios'],
-            'permission_callback' => [$this, 'checkLoggedIn'],
+            'permission_callback' => [$this, 'checkLoggedInWithNonce'],
         ]);
 
         register_rest_route($this->namespace, '/complete', [
             'methods'             => 'POST',
             'callback'            => [$this, 'completeTour'],
-            'permission_callback' => [$this, 'checkLoggedIn'],
+            'permission_callback' => [$this, 'checkLoggedInWithNonce'],
+            'args'                => ['tourId' => $tourIdArg],
         ]);
 
         register_rest_route($this->namespace, '/dismiss', [
             'methods'             => 'POST',
             'callback'            => [$this, 'dismissTour'],
-            'permission_callback' => [$this, 'checkLoggedIn'],
+            'permission_callback' => [$this, 'checkLoggedInWithNonce'],
+            'args'                => ['tourId' => $tourIdArg],
         ]);
 
         register_rest_route($this->namespace, '/reset', [
             'methods'             => 'POST',
             'callback'            => [$this, 'resetTour'],
-            'permission_callback' => [$this, 'checkLoggedIn'],
+            'permission_callback' => [$this, 'checkLoggedInWithNonce'],
+            'args'                => ['tourId' => $tourIdArg],
         ]);
     }
 
-    public function getScenarios(WP_REST_Request $request): WP_REST_Response
+    public function getScenarios(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
         $userId = get_current_user_id();
-        $scenarios = \Tour\Core\TourCore::instance()->buildScenarioData($userId);
+
+        $rateLimited = $this->applyFetchRateLimit($userId);
+        if ($rateLimited !== null) {
+            return $rateLimited;
+        }
+
+        $scenarios = TourCore::instance()->buildScenarioData($userId);
 
         return $this->success(['scenarios' => $scenarios]);
     }
 
-    public function completeTour(WP_REST_Request $request): WP_REST_Response
+    public function completeTour(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
-        $tourId = sanitize_text_field($request->get_param('tourId') ?? '');
-        if (empty($tourId)) {
-            return new WP_REST_Response(['message' => 'Tour ID required'], 400);
+        $userId = get_current_user_id();
+
+        $rateLimited = $this->applyStateRateLimit($userId);
+        if ($rateLimited !== null) {
+            return $rateLimited;
         }
 
-        $userId = get_current_user_id();
-        $completed = get_user_meta($userId, 'sw_completed_tours', true) ?: [];
-        if (!is_array($completed)) {
-            $completed = [];
-        }
+        $tourId    = (string) $request->get_param('tourId');
+        $completed = $this->readTourList($userId, 'sw_completed_tours');
 
         if (!in_array($tourId, $completed, true)) {
             $completed[] = $tourId;
+            $completed   = $this->capList($completed);
             update_user_meta($userId, 'sw_completed_tours', $completed);
         }
 
         return $this->success(['completed' => $completed]);
     }
 
-    public function dismissTour(WP_REST_Request $request): WP_REST_Response
+    public function dismissTour(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
-        $tourId = sanitize_text_field($request->get_param('tourId') ?? '');
-        if (empty($tourId)) {
-            return new WP_REST_Response(['message' => 'Tour ID required'], 400);
+        $userId = get_current_user_id();
+
+        $rateLimited = $this->applyStateRateLimit($userId);
+        if ($rateLimited !== null) {
+            return $rateLimited;
         }
 
-        $userId = get_current_user_id();
-        $dismissed = get_user_meta($userId, 'sw_dismissed_tours', true) ?: [];
-        if (!is_array($dismissed)) {
-            $dismissed = [];
-        }
+        $tourId    = (string) $request->get_param('tourId');
+        $dismissed = $this->readTourList($userId, 'sw_dismissed_tours');
 
         if (!in_array($tourId, $dismissed, true)) {
             $dismissed[] = $tourId;
+            $dismissed   = $this->capList($dismissed);
             update_user_meta($userId, 'sw_dismissed_tours', $dismissed);
         }
 
         return $this->success(['dismissed' => $dismissed]);
     }
 
-    public function resetTour(WP_REST_Request $request): WP_REST_Response
+    public function resetTour(WP_REST_Request $request): WP_REST_Response|WP_Error
     {
-        $tourId = sanitize_text_field($request->get_param('tourId') ?? '');
-        if (empty($tourId)) {
-            return new WP_REST_Response(['message' => 'Tour ID required'], 400);
-        }
-
         $userId = get_current_user_id();
 
-        // Remove from completed
-        $completed = get_user_meta($userId, 'sw_completed_tours', true) ?: [];
-        if (is_array($completed)) {
-            $completed = array_values(array_filter($completed, fn($id) => $id !== $tourId));
-            update_user_meta($userId, 'sw_completed_tours', $completed);
+        $rateLimited = $this->applyStateRateLimit($userId);
+        if ($rateLimited !== null) {
+            return $rateLimited;
         }
 
-        // Remove from dismissed
-        $dismissed = get_user_meta($userId, 'sw_dismissed_tours', true) ?: [];
-        if (is_array($dismissed)) {
-            $dismissed = array_values(array_filter($dismissed, fn($id) => $id !== $tourId));
-            update_user_meta($userId, 'sw_dismissed_tours', $dismissed);
+        $tourId = (string) $request->get_param('tourId');
+
+        $completed = array_values(array_filter(
+            $this->readTourList($userId, 'sw_completed_tours'),
+            fn($id) => $id !== $tourId
+        ));
+        update_user_meta($userId, 'sw_completed_tours', $completed);
+
+        $dismissed = array_values(array_filter(
+            $this->readTourList($userId, 'sw_dismissed_tours'),
+            fn($id) => $id !== $tourId
+        ));
+        update_user_meta($userId, 'sw_dismissed_tours', $dismissed);
+
+        return $this->success([
+            'completed' => $completed,
+            'dismissed' => $dismissed,
+        ]);
+    }
+
+    /**
+     * Read a tour-list user_meta entry, normalising any non-array storage
+     * (corrupted meta, legacy serialized scalar) to an empty array so
+     * downstream array_* / in_array() calls are safe.
+     */
+    private function readTourList(int $userId, string $metaKey): array
+    {
+        $list = get_user_meta($userId, $metaKey, true);
+        return is_array($list) ? array_values($list) : [];
+    }
+
+    /**
+     * Cap the stored list at MAX_STORED_TOURS by trimming the oldest
+     * entries. Defense-in-depth — the validate_callback allowlist already
+     * prevents random strings from getting in, but this contains damage
+     * if a future scenario churn produces a long history.
+     */
+    private function capList(array $list): array
+    {
+        if (count($list) <= self::MAX_STORED_TOURS) {
+            return $list;
+        }
+        return array_slice($list, -self::MAX_STORED_TOURS);
+    }
+
+    /** Per-user rate limit — complete/dismiss/reset share one bucket. */
+    private function applyStateRateLimit(int $userId): ?WP_Error
+    {
+        return $this->applyRateLimit(
+            'tour_state',
+            $userId,
+            self::STATE_RATE_LIMIT_MAX,
+            self::STATE_RATE_LIMIT_WINDOW,
+            __('Tour changes', 'starwishx')
+        );
+    }
+
+    /** Per-user rate limit — GET /scenarios. Separate from state writes. */
+    private function applyFetchRateLimit(int $userId): ?WP_Error
+    {
+        return $this->applyRateLimit(
+            'tour_fetch',
+            $userId,
+            self::FETCH_RATE_LIMIT_MAX,
+            self::FETCH_RATE_LIMIT_WINDOW,
+            __('Tour data', 'starwishx')
+        );
+    }
+
+    /**
+     * Generic per-user rate-limit guard with an action-named, friendly message.
+     *
+     * Mirrors ProfileController::applyRateLimit / ActivityController::applyRateLimit
+     * — wait duration is derived from the window via human_time_diff() so the
+     * wording tracks any future window change.
+     *
+     * `mapServiceError()` translates the policy's `rate_limited` code into 429.
+     */
+    private function applyRateLimit(
+        string $action,
+        int $userId,
+        int $max,
+        int $window,
+        string $actionLabel
+    ): ?WP_Error {
+        $key = RateLimitPolicy::key($action, (string) $userId);
+
+        $message = sprintf(
+            /* translators: 1: action name (e.g., "Tour changes"), 2: human-readable wait duration */
+            __('%1$s limit reached. Please wait %2$s before trying again.', 'starwishx'),
+            $actionLabel,
+            human_time_diff(time(), time() + $window)
+        );
+
+        $check = RateLimitPolicy::check($key, $max, $window, $message);
+        if (is_wp_error($check)) {
+            return $this->mapServiceError($check);
         }
 
-        return $this->success(['completed' => $completed, 'dismissed' => $dismissed]);
+        RateLimitPolicy::hit($key, $window);
+
+        return null;
     }
 }

--- a/inc/tour/Core/TourCore.php
+++ b/inc/tour/Core/TourCore.php
@@ -104,6 +104,16 @@ final class TourCore
     }
 
     /**
+     * Whether the given tour ID corresponds to a registered scenario.
+     * Used by TourController to allowlist tourId at the REST boundary so
+     * arbitrary strings can't accumulate in user_meta.
+     */
+    public function hasScenario(string $id): bool
+    {
+        return $this->registry->has($id);
+    }
+
+    /**
      * Build scenario data for a user (role-aware, i18n in PHP).
      * Used by both SSR hydration and the REST scenarios endpoint.
      */


### PR DESCRIPTION
- Introduce rate limiting via `RateLimitPolicy` for tour state changes and
scenario fetching to prevent abuse. Added strict validation for `tourId`
using an allowlist from `TourCore` to prevent arbitrary data injection
into user meta. Updated permission callbacks to use nonce-based
authentication.

- feat(launchpad): Following testers team report card ID N55. Recommendations/comments on improving the opportunity provision form, user profile:
Scroll to the first counting from top of the form error field:
Update `scrollToFirstError` to scroll the parent `.form-field` container
instead of just the error icon when an error occurs within a field.
This ensures the associated input field remains visible in the viewport
alongside the error message.