### PR TITLE
feat(tour): add support for advancing steps via element interaction, following report card ID N49

### DIFF
--- a/inc/tour/Assets/tour-manager.js
+++ b/inc/tour/Assets/tour-manager.js
@@ -109,6 +109,19 @@ export class TourManager {
         stepOptions.extraHighlights = stepDef.extraHighlights;
       }
 
+      // Advance the tour when the user performs the step's action directly
+      // on the page (e.g. clicking the highlighted button) instead of the
+      // tooltip's Next button. Shepherd attaches the listener on step show
+      // and cleans it up on step exit. Both pathways converge on the same
+      // next step: prepareStep is idempotent against a URL/view that
+      // already matches stepDef.view.
+      if (stepDef.advanceOn?.selector && stepDef.advanceOn?.event) {
+        stepOptions.advanceOn = {
+          selector: stepDef.advanceOn.selector,
+          event: stepDef.advanceOn.event,
+        };
+      }
+
       // The key integration: beforeShowPromise handles panel/view switching + DOM readiness
       stepOptions.beforeShowPromise = () => this.prepareStep(stepDef);
 

--- a/inc/tour/Scenarios/OpportunityFormScenario.php
+++ b/inc/tour/Scenarios/OpportunityFormScenario.php
@@ -46,13 +46,17 @@ class OpportunityFormScenario implements ScenarioInterface
     {
         return [
             // Step 1 — Add button (on list view)
+            // advanceOn lets the user click the highlighted Add button directly
+            // and have the tour follow them into the form view, instead of
+            // leaving this step's tooltip stranded over the now-hidden list.
             [
-                'id'       => 'add-button',
-                'title'    => __('Share an Opportunity', 'starwishx'),
-                'text'     => __('Ready to help? Click this button to create a new opportunity and share it with people who may benefit.', 'starwishx'),
-                'attachTo' => ['element' => '.btn-opportunity__add', 'on' => 'bottom'],
-                'panel'    => 'opportunities',
-                'view'     => null,
+                'id'        => 'add-button',
+                'title'     => __('Share an Opportunity', 'starwishx'),
+                'text'      => __('Ready to help? Click this button to create a new opportunity and share it with people who may benefit.', 'starwishx'),
+                'attachTo'  => ['element' => '.btn-opportunity__add', 'on' => 'bottom'],
+                'advanceOn' => ['selector' => '.btn-opportunity__add', 'event' => 'click'],
+                'panel'     => 'opportunities',
+                'view'      => null,
             ],
             // Step 2 — Title field (opens form view)
             [


### PR DESCRIPTION
_In response to Testers team report card ID N49. [Video instruction. Take a tour]_

- Implement `advanceOn` functionality in `TourManager` to allow the tour to progress when a user interacts with a specific element on the page (e.g., clicking a highlighted button) rather than relying solely on the tooltip navigation buttons.

- Updated `OpportunityFormScenario` to utilize this new feature for the 'add-button' step, ensuring the tour follows the user into the form view after they click the primary action button.

