### PR TITLE
refactor(launchpad): migrate country storage from taxonomy to custom tables

### DIFF
--- a/acf-json/taxonomy_6937410081dce.json
+++ b/acf-json/taxonomy_6937410081dce.json
@@ -2,7 +2,7 @@
     "key": "taxonomy_6937410081dce",
     "title": "Countries",
     "menu_order": 0,
-    "active": true,
+    "active": false,
     "taxonomy": "country",
     "object_type": [
         "opportunity"
@@ -71,5 +71,5 @@
     "meta_box": "default",
     "meta_box_cb": "",
     "meta_box_sanitize_cb": "",
-    "modified": 1775292613
+    "modified": 1777225678
 }

--- a/inc/launchpad/Data/Repositories/CountriesRepository.php
+++ b/inc/launchpad/Data/Repositories/CountriesRepository.php
@@ -1,0 +1,123 @@
+<?php
+// File: inc/launchpad/Data/Repositories/CountriesRepository.php
+
+declare(strict_types=1);
+
+namespace Launchpad\Data\Repositories;
+
+use Launchpad\Data\Migrations\CreateCountriesTable;
+
+/**
+ * Read-only access to wp_sw_countries (curated country dictionary).
+ *
+ * Source for opportunity form dropdowns and code-based resolution
+ * (alpha-2 slug → ISO numeric id). The table is seeded once on
+ * install (see CreateCountriesTable::seed) and curated subsequently
+ * via bumped-VERSION migrations — there is no write surface here.
+ *
+ * Sort: priority ASC, name ASC. Priority drives editorial pinning
+ * (Ukraine, Poland, Germany, etc.); the secondary sort keeps the long
+ * tail alphabetical in the active locale's name field.
+ */
+class CountriesRepository
+{
+    private function getTable(): string
+    {
+        return CreateCountriesTable::tableName();
+    }
+
+    /**
+     * Fetch all countries for dropdown rendering.
+     *
+     * Returns id (ISO 3166-1 numeric — globally meaningful, identical
+     * across environments), code (alpha-2, used as URL slug elsewhere),
+     * and name (Ukrainian, matching the active site locale). name_en
+     * comes along so a future locale-aware UI can switch column without
+     * another round trip.
+     *
+     * @return array<int, array{id: int, code: string, name: string, name_en: string}>
+     */
+    public function getAll(): array
+    {
+        global $wpdb;
+
+        $rows = $wpdb->get_results(
+            "SELECT id, code, name, name_en
+             FROM {$this->getTable()}
+             ORDER BY priority ASC, name ASC",
+            ARRAY_A
+        );
+
+        if (!is_array($rows)) {
+            return [];
+        }
+
+        return array_map(static fn(array $r): array => [
+            'id'      => (int) $r['id'],
+            'code'    => (string) $r['code'],
+            'name'    => (string) $r['name'],
+            'name_en' => (string) $r['name_en'],
+        ], $rows);
+    }
+
+    /**
+     * Fetch one country by ISO numeric id.
+     *
+     * @return array{id: int, code: string, name: string, name_en: string}|null
+     */
+    public function getById(int $id): ?array
+    {
+        global $wpdb;
+
+        $row = $wpdb->get_row(
+            $wpdb->prepare(
+                "SELECT id, code, name, name_en FROM {$this->getTable()} WHERE id = %d",
+                $id
+            ),
+            ARRAY_A
+        );
+
+        if (!$row) {
+            return null;
+        }
+
+        return [
+            'id'      => (int) $row['id'],
+            'code'    => (string) $row['code'],
+            'name'    => (string) $row['name'],
+            'name_en' => (string) $row['name_en'],
+        ];
+    }
+
+    /**
+     * Fetch one country by alpha-2 code (case-insensitive).
+     *
+     * Reserved for slug-based URL resolution in Listing — `?country=ua`
+     * resolves here to the numeric id stored in wp_opportunity_countries.
+     *
+     * @return array{id: int, code: string, name: string, name_en: string}|null
+     */
+    public function getByCode(string $code): ?array
+    {
+        global $wpdb;
+
+        $row = $wpdb->get_row(
+            $wpdb->prepare(
+                "SELECT id, code, name, name_en FROM {$this->getTable()} WHERE code = %s",
+                strtolower(trim($code))
+            ),
+            ARRAY_A
+        );
+
+        if (!$row) {
+            return null;
+        }
+
+        return [
+            'id'      => (int) $row['id'],
+            'code'    => (string) $row['code'],
+            'name'    => (string) $row['name'],
+            'name_en' => (string) $row['name_en'],
+        ];
+    }
+}

--- a/inc/launchpad/Data/Repositories/OpportunityCountriesRepository.php
+++ b/inc/launchpad/Data/Repositories/OpportunityCountriesRepository.php
@@ -50,6 +50,98 @@ class OpportunityCountriesRepository
     }
 
     /**
+     * Set the (single) country for $postId, enforcing 1:1 cardinality
+     * at the application layer. The composite PK on (post_id, country_id)
+     * technically permits many-to-many, but the opportunity form is
+     * single-select — so writes go through this method, not assign().
+     *
+     * Atomic delete-then-insert: drops any prior assignment, then
+     * inserts the new one. Pass null (or 0) to clear without
+     * reassigning. The caller is expected to be inside a transaction
+     * (saveOpportunity wraps every save in one), so the empty state
+     * between DELETE and INSERT is never observed by other readers.
+     */
+    public function setCountry(int $postId, ?int $countryId): bool
+    {
+        global $wpdb;
+
+        $deleted = $wpdb->delete(
+            $this->getTable(),
+            ['post_id' => $postId],
+            ['%d']
+        );
+        if ($deleted === false) {
+            return false;
+        }
+
+        if ($countryId === null || $countryId === 0) {
+            return true;
+        }
+
+        return $this->assign($postId, $countryId);
+    }
+
+    /**
+     * Fetch the (single) country_id for $postId, or null if unset.
+     *
+     * 1:1 is enforced at write time via setCountry(); LIMIT 1 here is
+     * defensive — picks a deterministic row if the invariant is ever
+     * broken by direct SQL or migration mishap, rather than throwing.
+     */
+    public function getCountryId(int $postId): ?int
+    {
+        global $wpdb;
+
+        $value = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT country_id FROM {$this->getTable()} WHERE post_id = %d LIMIT 1",
+                $postId
+            )
+        );
+
+        return $value === null ? null : (int) $value;
+    }
+
+    /**
+     * Batch fetch country_ids for a page of posts, keyed by post_id.
+     *
+     * Missing post ids are simply absent from the result — the listing
+     * card formatter falls back to an empty country display rather than
+     * surfacing a synthetic placeholder.
+     *
+     * @param  int[] $postIds
+     * @return array<int, int>
+     */
+    public function getBatchCountryIds(array $postIds): array
+    {
+        if (empty($postIds)) {
+            return [];
+        }
+
+        global $wpdb;
+
+        $postIds = array_map('intval', $postIds);
+        $placeholders = implode(',', array_fill(0, count($postIds), '%d'));
+
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT post_id, country_id
+                 FROM {$this->getTable()}
+                 WHERE post_id IN ($placeholders)",
+                ...$postIds
+            ),
+            ARRAY_A
+        );
+
+        $indexed = [];
+        foreach ($rows as $row) {
+            $indexed[(int) $row['post_id']] = (int) $row['country_id'];
+        }
+
+        return $indexed;
+    }
+
+    /**
      * Clean up on post deletion. Called from the delete_post hook —
      * without FK cascade, this is what keeps the junction in sync with
      * wp_posts when an opportunity is hard-deleted.

--- a/inc/launchpad/Panels/OpportunitiesPanel.php
+++ b/inc/launchpad/Panels/OpportunitiesPanel.php
@@ -608,7 +608,7 @@ class OpportunitiesPanel extends AbstractPanel
                                     </div>
                                     <!-- Country Dropdown -->
                                     <div class="form-field">
-                                        <label class="<?php echo $required['country'] ? 'label-required' : ''; ?>"><?php echo esc_html($labels['country'] ?? __('Country', 'starwishx')); ?></label>
+                                        <label><?= esc_html__('Country', 'starwishx'); ?></label>
                                         <div class="lp-dropdown lp-dropdown--toggleable"
                                             data-wp-class--lp-dropdown--open="state.isCountryDropdownOpen"
                                             data-wp-on--focusout="actions.opportunities.countryFocusout"

--- a/inc/launchpad/Services/OpportunitiesService.php
+++ b/inc/launchpad/Services/OpportunitiesService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Launchpad\Services;
 
+use Launchpad\Data\Repositories\CountriesRepository;
 use Launchpad\Data\Repositories\OpportunityCountriesRepository;
 use Launchpad\Data\Repositories\OpportunityDetailsRepository;
 use Shared\Policy\UrlPolicy;
@@ -21,6 +22,7 @@ class OpportunitiesService
 
     private OpportunityDetailsRepository $detailsRepository;
     private OpportunityCountriesRepository $countriesRepository;
+    private CountriesRepository $countriesDictionary;
 
     /**
      * Repositories are injected so tests can swap them. Defaults keep
@@ -29,10 +31,12 @@ class OpportunitiesService
      */
     public function __construct(
         ?OpportunityDetailsRepository $detailsRepository = null,
-        ?OpportunityCountriesRepository $countriesRepository = null
+        ?OpportunityCountriesRepository $countriesRepository = null,
+        ?CountriesRepository $countriesDictionary = null
     ) {
         $this->detailsRepository   = $detailsRepository   ?? new OpportunityDetailsRepository();
         $this->countriesRepository = $countriesRepository ?? new OpportunityCountriesRepository();
+        $this->countriesDictionary = $countriesDictionary ?? new CountriesRepository();
     }
 
     /**
@@ -250,7 +254,7 @@ class OpportunitiesService
     {
         return [
             'categories' => $this->getHierarchicalCategoryTerms('category-oportunities'),
-            'countries'  => $this->getTerms('country'),
+            'countries'  => $this->countriesDictionary->getAll(),
             'seekers'    => $this->getTerms('category-seekers'),
         ];
     }
@@ -370,7 +374,7 @@ class OpportunitiesService
             'date_ends'       => $dateEnds,
             'category'        => $getIntArray('opportunity_category'), // Now an array
 
-            'country'         => get_field('country', $postId) ?: '',
+            'country'         => $this->countriesRepository->getCountryId($postId) ?? '',
             'locations'       => $locations,
             // We keep 'city' just for now in case to not brake things
             'city'            => get_field('city', $postId) ?: '',
@@ -558,10 +562,18 @@ class OpportunitiesService
             update_field('opportunity_category', $categories, $id);
             wp_set_object_terms($id, $categories, 'category-oportunities');
 
-            // Country
+            // Country — typed storage in wp_opportunity_countries replaces the
+            // `country` taxonomy and ACF field. setCountry() is delete-then-
+            // insert, atomic inside this transaction. Failure rolls back the
+            // entire save (caught below).
             $countryId = (int) ($data['country'] ?? 0);
-            update_field('country', $countryId, $id);
-            wp_set_object_terms($id, $countryId, 'country');
+            $countryWritten = $this->countriesRepository->setCountry(
+                (int) $id,
+                $countryId > 0 ? $countryId : null
+            );
+            if (!$countryWritten) {
+                throw new \RuntimeException('Failed to persist opportunity country.');
+            }
 
             // Seekers (Multi)
             $seekers = array_map('intval', $data['seekers'] ?? []);

--- a/inc/listing/Assets/utils.js
+++ b/inc/listing/Assets/utils.js
@@ -127,8 +127,18 @@ export function syncStateToUrl(query) {
           }
         }
       }
+    } else if (key === "country" && Array.isArray(value)) {
+      // Country: emit alpha-2 code (?country=pl) for SEO. Look up each
+      // selected id in facets to get its code; fall back to the numeric
+      // id only if the facet entry is missing (orphaned id, or facets
+      // not yet hydrated). The server-side 301 catches that fallback.
+      const countryFacets = state.facets?.country || [];
+      for (const id of value) {
+        const c = countryFacets.find((cf) => cf.id === id);
+        params.append(key, c?.code || id);
+      }
     } else if (Array.isArray(value)) {
-      // Clean URL: ?country=75 (no brackets)
+      // Clean URL: ?seekers=75 (no brackets, repeated key)
       value.forEach((val) => params.append(key, val));
     } else {
       params.set(key, value);
@@ -232,18 +242,40 @@ export function syncUrlToState(queryState) {
     queryState.category = [...new Set(ids)];
   }
 
-  // Handle remaining params (skip category — already resolved)
+  // Resolve country: alpha-2 codes → ids via facets, numerics → as-is.
+  // The server-side 301 normalizes numeric URLs to slugs on full page
+  // loads; this branch keeps back/forward (popstate) navigation robust
+  // when an older state object is restored from history.
+  const countryFacets = state.facets?.country || [];
+  const countryRaw = params.getAll("country");
+  if (countryRaw.length > 0) {
+    const ids = [];
+    for (const val of countryRaw) {
+      if (isNaN(val)) {
+        const c = countryFacets.find(
+          (cf) => cf.code === String(val).toLowerCase(),
+        );
+        if (c) ids.push(c.id);
+      } else {
+        ids.push(Number(val));
+      }
+    }
+    queryState.country = [...new Set(ids)];
+  }
+
+  // Handle remaining params (skip category and country — already resolved)
   for (const [key, value] of params.entries()) {
     const cleanKey = key.replace("[]", "");
 
     if (cleanKey === "category") continue;
+    if (cleanKey === "country") continue;
 
     if (Array.isArray(queryState[cleanKey])) {
       // It's a taxonomy array
       const allValues = params.getAll(key);
       queryState[cleanKey] = allValues.map((v) => (isNaN(v) ? v : Number(v)));
-    } else if (cleanKey === "page" || cleanKey === "country") {
-      // Forced numeric types
+    } else if (cleanKey === "page") {
+      // Forced numeric type
       queryState[cleanKey] = Number(value);
     } else {
       // Standard strings (city, search)

--- a/inc/listing/Core/ListingCore.php
+++ b/inc/listing/Core/ListingCore.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace Listing\Core;
 
+use Launchpad\Data\Repositories\CountriesRepository;
 use Listing\Api\MainController;
 use Listing\Services\ListingService;
 use Listing\Filters\CategoryFilter;
@@ -38,6 +39,7 @@ final class ListingCore
     private StateAggregator $stateAggregator;
     private ResultsGrid $grid;
     private TermCountingService $termCounter;
+    private CountriesRepository $countriesRepository;
 
     /**
      * Reset singleton (for testing only).
@@ -65,23 +67,26 @@ final class ListingCore
         ?StateAggregator $stateAggregator = null,
         ?ResultsGrid $grid = null,
         ?QueryBuilder $queryBuilder = null,
-        ?TermCountingService $termCounter = null
+        ?TermCountingService $termCounter = null,
+        ?CountriesRepository $countriesRepository = null
     ): self {
         if (!self::$instance) {
-            $registry         = $registry        ?? new FilterRegistry();
-            $queryBuilder     = $queryBuilder    ?? new QueryBuilder($registry);
-            $termCounter      = $termCounter     ?? new TermCountingService($queryBuilder);
+            $registry            = $registry            ?? new FilterRegistry();
+            $queryBuilder        = $queryBuilder        ?? new QueryBuilder($registry);
+            $termCounter         = $termCounter         ?? new TermCountingService($queryBuilder);
+            $countriesRepository = $countriesRepository ?? new CountriesRepository();
             // Reuse service from the shared Favorites module
-            $favoritesService = \favorites()->service();
-            $service          = $service         ?? new ListingService($queryBuilder, $termCounter, $favoritesService);
-            $stateAggregator  = $stateAggregator ?? new StateAggregator($service);
+            $favoritesService    = \favorites()->service();
+            $service             = $service             ?? new ListingService($queryBuilder, $termCounter, $favoritesService);
+            $stateAggregator     = $stateAggregator     ?? new StateAggregator($service, $countriesRepository);
 
-            self::$instance   = new self(
+            self::$instance      = new self(
                 $registry,
                 $service,
                 $stateAggregator,
                 $grid ?? new ResultsGrid(),
-                $termCounter
+                $termCounter,
+                $countriesRepository
             );
         }
 
@@ -93,13 +98,15 @@ final class ListingCore
         ListingService $service,
         StateAggregator $stateAggregator,
         ResultsGrid $grid,
-        TermCountingService $termCounter
+        TermCountingService $termCounter,
+        CountriesRepository $countriesRepository
     ) {
-        $this->registry        = $registry;
-        $this->service         = $service;
-        $this->stateAggregator = $stateAggregator;
-        $this->grid            = $grid;
-        $this->termCounter     = $termCounter;
+        $this->registry            = $registry;
+        $this->service             = $service;
+        $this->stateAggregator     = $stateAggregator;
+        $this->grid                = $grid;
+        $this->termCounter         = $termCounter;
+        $this->countriesRepository = $countriesRepository;
 
         $this->bootstrap();
     }
@@ -109,8 +116,9 @@ final class ListingCore
      */
     private function bootstrap(): void
     {
-        add_action('wp_enqueue_scripts', [$this, 'enqueueAssets']);
-        add_action('rest_api_init',      [$this, 'registerRestRoutes']);
+        add_action('wp_enqueue_scripts',  [$this, 'enqueueAssets']);
+        add_action('rest_api_init',       [$this, 'registerRestRoutes']);
+        add_action('template_redirect',   [$this, 'redirectNumericCountryParams']);
         add_action('init', fn() => do_action('listing_register_filters', $this->registry), 20);
         add_action('listing_register_filters', [$this, 'registerDefaultFilters'], 5);
         // Invalidate the category term map transient whenever a term is saved.
@@ -200,6 +208,93 @@ final class ListingCore
         unset($vars['listing_cat']);
 
         return $vars;
+    }
+
+    /**
+     * 301 any numeric country query value to its alpha-2 slug, so that
+     * `/opportunities/?country=804` becomes `/opportunities/?country=ua`
+     * before the page renders.
+     *
+     * Why a redirect rather than just a canonical link tag:
+     *   - A canonical is a hint; bots may take time to consolidate, and
+     *     Bing/Yandex respect it less reliably than Google.
+     *   - A 301 normalizes immediately for both bots and users, prevents
+     *     ranking dilution and split crawl budget across `?country=804`
+     *     and `?country=ua` for identical content, and silently catches
+     *     accidental leaks (legacy links, raw-state shares, future bugs
+     *     that emit ids by mistake).
+     *
+     * SPA in-page filter changes go through syncStateToUrl which already
+     * emits slugs — so this only fires on full page loads.
+     *
+     * Uses QueryStringParser rather than $_GET so multi-value
+     * (?country=pl&country=de — repeated-key, no brackets) round-trips
+     * correctly: PHP's default $_GET would silently drop all but the
+     * last value.
+     */
+    public function redirectNumericCountryParams(): void
+    {
+        if (!is_post_type_archive('opportunity')) {
+            return;
+        }
+
+        $rawParams = QueryStringParser::fromServer();
+        if (empty($rawParams['country'])) {
+            return;
+        }
+
+        $rawCountries = (array) $rawParams['country'];
+
+        // Bail if all values are already non-numeric (slug form) — no work to do.
+        $hasNumeric = false;
+        foreach ($rawCountries as $val) {
+            if (is_numeric($val)) {
+                $hasNumeric = true;
+                break;
+            }
+        }
+        if (!$hasNumeric) {
+            return;
+        }
+
+        // Resolve each value to its alpha-2 code; numerics that don't
+        // map to a known country are silently dropped (mirrors the
+        // missing-slug behavior in StateAggregator::resolveCountryValues).
+        $codes = [];
+        foreach ($rawCountries as $val) {
+            if (is_numeric($val)) {
+                $row = $this->countriesRepository->getById((int) $val);
+                if ($row) {
+                    $codes[] = $row['code'];
+                }
+            } else {
+                $codes[] = strtolower(sanitize_text_field((string) $val));
+            }
+        }
+
+        // Rebuild the query string keeping the repeated-key shape that
+        // syncStateToUrl emits (?key=v1&key=v2, no brackets), so the URL
+        // layout stays consistent across server-side 301 and client-side
+        // pushState navigation.
+        $queryParts = [];
+        foreach ($rawParams as $key => $val) {
+            if ($key === 'country') {
+                continue;
+            }
+            $vals = is_array($val) ? $val : [$val];
+            foreach ($vals as $v) {
+                $queryParts[] = rawurlencode((string) $key) . '=' . rawurlencode((string) $v);
+            }
+        }
+        foreach (array_unique($codes) as $code) {
+            $queryParts[] = 'country=' . rawurlencode((string) $code);
+        }
+
+        $path  = strtok($_SERVER['REQUEST_URI'] ?? '/', '?');
+        $query = !empty($queryParts) ? '?' . implode('&', $queryParts) : '';
+
+        wp_safe_redirect(home_url($path . $query), 301);
+        exit;
     }
 
     /**

--- a/inc/listing/Core/StateAggregator.php
+++ b/inc/listing/Core/StateAggregator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Listing\Core;
 
+use Launchpad\Data\Repositories\CountriesRepository;
 use Listing\Services\ListingService;
 
 /**
@@ -17,10 +18,14 @@ use Listing\Services\ListingService;
 class StateAggregator
 {
     private ListingService $service;
+    private CountriesRepository $countriesRepository;
 
-    public function __construct(ListingService $service)
-    {
-        $this->service = $service;
+    public function __construct(
+        ListingService $service,
+        ?CountriesRepository $countriesRepository = null
+    ) {
+        $this->service             = $service;
+        $this->countriesRepository = $countriesRepository ?? new CountriesRepository();
     }
 
     /**
@@ -63,7 +68,7 @@ class StateAggregator
         return [
             's'        => sanitize_text_field($raw['s'] ?? ''),
             'category' => $this->resolveCategoryValues((array) ($raw['category'] ?? [])),
-            'country'  => array_map('absint', (array) ($raw['country']  ?? [])),
+            'country'  => $this->resolveCountryValues((array) ($raw['country'] ?? [])),
             'location' => sanitize_text_field($raw['location'] ?? ''),
             'seekers'  => array_map('absint', (array) ($raw['seekers']  ?? [])),
             'page'     => absint($raw['paged'] ?? $raw['page'] ?? 1),
@@ -116,6 +121,42 @@ class StateAggregator
 
             if (!is_wp_error($children)) {
                 $ids = array_merge($ids, array_map('absint', $children));
+            }
+        }
+
+        return array_values(array_unique($ids));
+    }
+
+    /**
+     * Resolve mixed country values from the URL into ISO numeric IDs.
+     *
+     * Accepts either form:
+     *   - alpha-2 code (`?country=ua`) — canonical for SEO, resolved via
+     *     wp_sw_countries.code lookup
+     *   - numeric ISO id (`?country=804`) — accepted but non-canonical;
+     *     ListingCore::redirectNumericCountryParams 301s browser-facing
+     *     numeric URLs into slug form. Numeric remains supported here
+     *     for REST clients and any future internal links that prefer ids.
+     *
+     * Unresolvable codes are silently dropped, mirroring
+     * resolveCategoryValues' missing-slug behavior.
+     *
+     * @param  array $values  Raw values from the query string.
+     * @return int[]          Deduplicated array of ISO numeric IDs.
+     */
+    private function resolveCountryValues(array $values): array
+    {
+        $ids = [];
+
+        foreach ($values as $value) {
+            if (is_numeric($value)) {
+                $ids[] = absint($value);
+                continue;
+            }
+
+            $row = $this->countriesRepository->getByCode(sanitize_text_field((string) $value));
+            if ($row) {
+                $ids[] = (int) $row['id'];
             }
         }
 

--- a/inc/listing/Enums/Taxonomy.php
+++ b/inc/listing/Enums/Taxonomy.php
@@ -4,10 +4,19 @@ declare(strict_types=1);
 
 namespace Listing\Enums;
 
+/**
+ * Enumeration of WP taxonomies used by the listing's facet pipeline.
+ *
+ * Country was removed when the `country` taxonomy was retired in favor
+ * of wp_opportunity_countries (typed junction) + wp_sw_countries
+ * (curated dictionary). The listing's country filter lives in
+ * CountryFilter and reads from those tables directly — country is
+ * intentionally absent from this enum so iterating Taxonomy::cases()
+ * only visits actual WP taxonomies.
+ */
 enum Taxonomy: string
 {
     case CATEGORY = 'category-oportunities';
-    case COUNTRY  = 'country';
     case SEEKERS  = 'category-seekers';
 
     /**
@@ -18,7 +27,6 @@ enum Taxonomy: string
     {
         return match ($this) {
             self::CATEGORY => 'category',
-            self::COUNTRY  => 'country',
             self::SEEKERS  => 'seekers',
         };
     }
@@ -27,7 +35,6 @@ enum Taxonomy: string
     {
         return match ($this) {
             self::CATEGORY => __('Category', 'starwishx'),
-            self::COUNTRY  => __('Country', 'starwishx'),
             self::SEEKERS  => __('Seekers', 'starwishx'),
         };
     }

--- a/inc/listing/Filters/CountryFilter.php
+++ b/inc/listing/Filters/CountryFilter.php
@@ -5,11 +5,23 @@ declare(strict_types=1);
 namespace Listing\Filters;
 
 /**
- * Specialized filter for the Country taxonomy.
+ * Country filter, backed by wp_opportunity_countries (junction) and
+ * wp_sw_countries (curated dictionary) — not a WP taxonomy.
+ *
+ * applyQuery pre-resolves selected country_ids to a post__in list
+ * because tax_query can't reach a custom table. Facet counts come
+ * from ListingService::buildCountryFacets which scopes the join
+ * to the current filter context.
  */
 class CountryFilter extends AbstractFilter
 {
-    private const TAXONOMY = 'country';
+    /**
+     * Facet key in iAPI state (state.facets.country) and the registered
+     * filter id. Was named TAXONOMY when country was a WP taxonomy —
+     * renamed after the wp_opportunity_countries migration since the
+     * filter no longer maps to anything in WP's taxonomy system.
+     */
+    private const FACET_KEY = 'country';
 
     public function getId(): string
     {
@@ -22,7 +34,16 @@ class CountryFilter extends AbstractFilter
     }
 
     /**
-     * Applies the country taxonomy selection to the WP_Query.
+     * Applies the country selection to the WP_Query via post__in.
+     *
+     * Country is no longer a WP taxonomy, so tax_query can't reach it.
+     * Strategy: pre-resolve the selected country_ids to a post_id set
+     * via wp_opportunity_countries, then inject into post__in. Stays
+     * inside the standard WP_Query path — no posts_clauses gymnastics.
+     *
+     * Composes with any existing post__in (from another filter) by
+     * intersecting; an empty intersect or zero matches collapses to
+     * [0], a sentinel that forces zero rows without raising an error.
      */
     public function applyQuery(array $args, $value): array
     {
@@ -30,31 +51,68 @@ class CountryFilter extends AbstractFilter
             return $args;
         }
 
-        $args['tax_query'][] = [
-            'taxonomy' => self::TAXONOMY,
-            'field'    => 'term_id',
-            'terms'    => (array) $value,
-            'operator' => 'IN',
-        ];
+        $countryIds = array_filter(
+            array_map('intval', (array) $value),
+            static fn(int $id): bool => $id > 0
+        );
+        if (empty($countryIds)) {
+            return $args;
+        }
+
+        global $wpdb;
+        $placeholders = implode(',', array_fill(0, count($countryIds), '%d'));
+
+        $postIds = $wpdb->get_col($wpdb->prepare(
+            "SELECT DISTINCT post_id
+             FROM {$wpdb->prefix}opportunity_countries
+             WHERE country_id IN ($placeholders)",
+            ...$countryIds
+        ));
+
+        $postIds = array_map('intval', $postIds ?: []);
+
+        if (empty($postIds)) {
+            $args['post__in'] = [0];
+            return $args;
+        }
+
+        if (!empty($args['post__in'])) {
+            $existing    = array_map('intval', $args['post__in']);
+            $intersected = array_values(array_intersect($existing, $postIds));
+            $args['post__in'] = !empty($intersected) ? $intersected : [0];
+        } else {
+            $args['post__in'] = $postIds;
+        }
 
         return $args;
     }
 
     /**
-     * Retrieves terms and counts from the state facets.
+     * Static facet list: every country that has at least one opportunity.
+     *
+     * Note: this method is not on the listing's hot path — ListingService::
+     * getFacets() builds context-aware counts via buildCountryFacets() and
+     * does not call here. Kept for FilterInterface conformance and for any
+     * future caller that wants the unfiltered list.
      */
     public function getFacetData(array $current_query_results): array
     {
-        $terms = get_terms([
-            'taxonomy'   => self::TAXONOMY,
-            'hide_empty' => true,
-        ]);
+        global $wpdb;
 
-        return array_map(fn($t) => [
-            'id'    => $t->term_id,
-            'label' => $t->name,
-            'count' => $t->count,
-        ], $terms);
+        $rows = $wpdb->get_results(
+            "SELECT c.id, c.name AS label, COUNT(DISTINCT oc.post_id) AS count
+             FROM {$wpdb->prefix}sw_countries c
+             INNER JOIN {$wpdb->prefix}opportunity_countries oc ON oc.country_id = c.id
+             GROUP BY c.id
+             ORDER BY c.priority ASC, c.name ASC",
+            ARRAY_A
+        );
+
+        return array_map(static fn(array $r): array => [
+            'id'    => (int) $r['id'],
+            'label' => (string) $r['label'],
+            'count' => (int) $r['count'],
+        ], $rows ?: []);
     }
 
     /**
@@ -67,7 +125,7 @@ class CountryFilter extends AbstractFilter
 ?>
         <div class="filter-list">
             <template
-                data-wp-each--item="state.facets.<?php echo self::TAXONOMY; ?>"
+                data-wp-each--item="state.facets.<?php echo self::FACET_KEY; ?>"
                 data-wp-key="context.item.id"
                 data-wp-context='{"filterField": "country"}'>
                 <label class="filter-checkbox" data-wp-context='{"filterField": "country"}'>

--- a/inc/listing/Services/ListingService.php
+++ b/inc/listing/Services/ListingService.php
@@ -125,9 +125,35 @@ class ListingService
         }
 
         // --- Taxonomy terms — prime the WP object cache in bulk -------------
-        // One query per taxonomy (3 total). All subsequent get_the_terms() calls
-        // in formatOpportunityCard() resolve from cache, not the database.
-        update_object_term_cache($postIds, ['country', 'category-oportunities', 'category-seekers']);
+        // Two queries (one per taxonomy). Country is no longer a taxonomy —
+        // it's read from wp_opportunity_countries below, joined to the
+        // dictionary in a single batch query.
+        update_object_term_cache($postIds, ['category-oportunities', 'category-seekers']);
+
+        // --- Countries (typed table) ----------------------------------------
+        // One query joining wp_opportunity_countries with wp_sw_countries to
+        // hydrate id + code + display name per post. Replaces the per-post
+        // get_the_terms('country') call previously satisfied by the cache prime.
+        $countriesByPost = [];
+        if (!empty($postIds)) {
+            $countryRows = $wpdb->get_results(
+                $wpdb->prepare(
+                    "SELECT oc.post_id, c.id, c.code, c.name
+                     FROM {$wpdb->prefix}opportunity_countries oc
+                     INNER JOIN {$wpdb->prefix}sw_countries c ON c.id = oc.country_id
+                     WHERE oc.post_id IN ($placeholders)",
+                    ...$postIds
+                ),
+                ARRAY_A
+            );
+            foreach ($countryRows ?: [] as $row) {
+                $countriesByPost[(int) $row['post_id']] = [
+                    'id'   => (int) $row['id'],
+                    'code' => (string) $row['code'],
+                    'name' => (string) $row['name'],
+                ];
+            }
+        }
 
         // --- Full category term map for parent-climbing ---------------------
         // Cached via transient so the get_terms() query is only paid once per hour
@@ -164,6 +190,7 @@ class ListingService
             'locations'       => $locationsByPost,
             'categoryTermMap' => $categoryTermMap,
             'favoriteIds'     => $favoriteIds,
+            'countriesByPost' => $countriesByPost,
         ];
     }
 
@@ -245,7 +272,57 @@ class ListingService
             ], $activeTerms));
         }
 
+        // Country lives in wp_opportunity_countries — outside Taxonomy::cases()
+        // because the typed-table path doesn't share term_id semantics with
+        // the term_relationships joins in TermCountingService. Same "Exclude
+        // Self" rule applied: drop country from the context before counting.
+        $contextForCountry = $filters;
+        unset($contextForCountry['country']);
+        $facets['country'] = $this->buildCountryFacets($contextForCountry);
+
         return $facets;
+    }
+
+    /**
+     * Build country facets from wp_opportunity_countries joined with
+     * wp_sw_countries, scoped to the post set produced by the current
+     * filter context.
+     *
+     * Mirrors TermCountingService's trick of embedding $query->request as
+     * a subquery — the post selection is computed by WP_Query once, then
+     * the count rolls up over the typed junction without re-executing.
+     */
+    private function buildCountryFacets(array $contextFilters): array
+    {
+        $args                  = $this->queryBuilder->build($contextFilters, -1);
+        $args['fields']        = 'ids';
+        $args['no_found_rows'] = true;
+
+        $query = new WP_Query($args);
+
+        if (empty($query->request)) {
+            return [];
+        }
+
+        global $wpdb;
+        $sw = $wpdb->prefix . 'sw_countries';
+        $oc = $wpdb->prefix . 'opportunity_countries';
+
+        $rows = $wpdb->get_results(
+            "SELECT c.id, c.name AS label, COUNT(DISTINCT oc.post_id) AS count
+             FROM {$sw} c
+             INNER JOIN {$oc} ON oc.country_id = c.id
+             WHERE oc.post_id IN ({$query->request})
+             GROUP BY c.id
+             ORDER BY c.priority ASC, c.name ASC",
+            ARRAY_A
+        );
+
+        return array_map(static fn(array $r): array => [
+            'id'    => (int) $r['id'],
+            'label' => (string) $r['label'],
+            'count' => (int) $r['count'],
+        ], $rows ?: []);
     }
 
     /**
@@ -331,11 +408,8 @@ class ListingService
 
         $locations = $preloaded['locations'][$postId] ?? [];
 
-        // Country — first term only (one per post by convention)
-        $countryTerms = get_the_terms($postId, 'country');
-        $country      = (! empty($countryTerms) && ! is_wp_error($countryTerms))
-            ? $countryTerms[0]->name
-            : '';
+        // Country — typed table, hydrated in bulk by preloadPostData().
+        $country = $preloaded['countriesByPost'][$postId]['name'] ?? '';
 
         // Categories — resolved to unique top-level ancestors
         $rawCategories = get_the_terms($postId, 'category-oportunities');

--- a/inc/listing/Services/ListingService.php
+++ b/inc/listing/Services/ListingService.php
@@ -311,7 +311,7 @@ class ListingService
         $rows = $wpdb->get_results(
             "SELECT c.id, c.name AS label, COUNT(DISTINCT oc.post_id) AS count
              FROM {$sw} c
-             INNER JOIN {$oc} ON oc.country_id = c.id
+             INNER JOIN {$oc} oc ON oc.country_id = c.id
              WHERE oc.post_id IN ({$query->request})
              GROUP BY c.id
              ORDER BY c.priority ASC, c.name ASC",

--- a/inc/listing/Services/ListingService.php
+++ b/inc/listing/Services/ListingService.php
@@ -308,8 +308,12 @@ class ListingService
         $sw = $wpdb->prefix . 'sw_countries';
         $oc = $wpdb->prefix . 'opportunity_countries';
 
+        // `code` is exposed alongside id so the client can serialize
+        // ?country=pl in syncStateToUrl without a separate dictionary
+        // round trip. Server-side 301 catches any URL that arrives
+        // with the numeric form.
         $rows = $wpdb->get_results(
-            "SELECT c.id, c.name AS label, COUNT(DISTINCT oc.post_id) AS count
+            "SELECT c.id, c.code, c.name AS label, COUNT(DISTINCT oc.post_id) AS count
              FROM {$sw} c
              INNER JOIN {$oc} oc ON oc.country_id = c.id
              WHERE oc.post_id IN ({$query->request})
@@ -320,6 +324,7 @@ class ListingService
 
         return array_map(static fn(array $r): array => [
             'id'    => (int) $r['id'],
+            'code'  => (string) $r['code'],
             'label' => (string) $r['label'],
             'count' => (int) $r['count'],
         ], $rows ?: []);

--- a/inc/theme-helpers.php
+++ b/inc/theme-helpers.php
@@ -613,10 +613,18 @@ function sw_get_opportunity_view_data(int $post_id): array
     $d_start = sw_format_date_for_ui(get_post_meta($post_id, 'opportunity_date_starts', true), 'd.m.y', true);
     $d_end   = sw_format_date_for_ui(get_post_meta($post_id, 'opportunity_date_ends',   true), 'd.m.y', true);
 
-    $country_id   = sw_get_field('country', $post_id);
-    $country_name = $country_id
-        ? (get_term($country_id, 'country')?->name ?? '')
-        : __('Worldwide', 'starwishx');
+    // Country — typed storage replaces the `country` taxonomy. JOIN against
+    // wp_sw_countries gets the display name in one round trip; LIMIT 1
+    // matches the 1:1 invariant enforced at write time (setCountry()).
+    $country_row = $wpdb->get_row($wpdb->prepare(
+        "SELECT c.id, c.code, c.name
+         FROM {$wpdb->prefix}sw_countries c
+         INNER JOIN {$wpdb->prefix}opportunity_countries oc ON oc.country_id = c.id
+         WHERE oc.post_id = %d
+         LIMIT 1",
+        $post_id
+    ));
+    $country_name = $country_row ? $country_row->name : __('Worldwide', 'starwishx');
 
     $seeker_ids   = sw_get_field('opportunity_seekers', $post_id) ?? [];
     $seeker_terms = sw_get_prepared_terms($seeker_ids, 'category-seekers');


### PR DESCRIPTION
Replace the `country` WordPress taxonomy with a typed junction table
(`wp_opportunity_countries`) and a curated dictionary (`wp_sw_countries`).

- Implement `CountriesRepository` and `OpportunityCountriesRepository`
  for typed data access.
- Update `OpportunitiesService` to use the new repositories for
  persisting and retrieving country data.
- Refactor `CountryFilter` to resolve selections via `post__in`
  instead of `tax_query`.
- Update `ListingService` to batch-load country data using a single
  JOIN query, replacing per-post taxonomy lookups.
- Update `theme-helpers.php` to fetch country names via direct SQL
  joins.
- Remove `country` from `Taxonomy` enum and update ACF configuration.
- minor fixes