### PR TITLE
fix(launchpad): scroll to top on cancel form edit and re-guard WP-CLI migration

### DIFF
--- a/inc/launchpad/Assets/opportunities/actions.js
+++ b/inc/launchpad/Assets/opportunities/actions.js
@@ -338,6 +338,7 @@ export const opportunitiesActions = {
     url.searchParams.delete("id");
     window.history.pushState({}, "", url);
     actions.syncStateFromUrl();
+    scrollToPageTop();
   },
 
   updateForm() {

--- a/inc/launchpad/setup.php
+++ b/inc/launchpad/setup.php
@@ -96,7 +96,7 @@ add_action('after_setup_theme', function () {
 }, 20);
 
 // Register WP-CLI commands only when CLI is loaded.
-// if (defined('WP_CLI') && WP_CLI) {
-\Launchpad\Cli\MigrateOpportunityDatesCommand::register();
-update_option('starwish_run_opportunity_dates_migration', 1);
-// }
+if (defined('WP_CLI') && WP_CLI) {
+    \Launchpad\Cli\MigrateOpportunityDatesCommand::register();
+    update_option('starwish_run_opportunity_dates_migration', 1);
+}


### PR DESCRIPTION
- Add `scrollToPageTop()` call when on cancel form edit.
- Re-guard the registration of `MigrateOpportunityDatesCommand` and the migration option update within the `WP_CLI` conditional block in `setup.php`.