### PR TITLE
build(assets): optimize asset delivery and build pipeline

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -75,26 +75,33 @@ function _themeprefix_theme_scripts()
   wp_register_style('_themeprefix-style', get_stylesheet_uri(), [], $version);
   // wp_register_style('normalize-css', get_stylesheet_directory_uri() . '/assets/css/normalize.css');
   // wp_register_style('swiper-css', get_stylesheet_directory_uri() . '/assets/css/swiper.min.css');
-  wp_register_style('swiper-css', get_stylesheet_directory_uri() . '/assets/css/swiper-bundle.min.css');
-  wp_register_style('lightbox-css', get_stylesheet_directory_uri() . '/assets/css/lightbox.min.css');
+  wp_register_style('swiper', get_stylesheet_directory_uri() . '/assets/css/swiper-bundle.min.css');
+  // wp_register_style('lightbox', get_stylesheet_directory_uri() . '/assets/css/lightbox.min.css');
 
-  wp_register_style('app-css', get_stylesheet_directory_uri() . '/assets/css/app.css', [], $version, 'all');
+  wp_register_style('app', get_stylesheet_directory_uri() . '/assets/css/app.css', [], $version, 'all');
+  wp_register_style('app-logged-in', get_stylesheet_directory_uri() . '/assets/css/app-logged-in.css', [], $version, 'all');
 
   wp_enqueue_style('_themeprefix-style');
   // wp_enqueue_style('normalize-css');
-  wp_enqueue_style('swiper-css');
-  wp_enqueue_style('lightbox-css');
-  wp_enqueue_style('app-css');
+  wp_enqueue_style('swiper');
+  // wp_enqueue_style('lightbox');
+  wp_enqueue_style('app');
+  if (is_user_logged_in()) {
+    wp_enqueue_style('app-logged-in');
+  }
 
-
-  wp_register_script('app-js', get_stylesheet_directory_uri() . '/assets/js/app.js', array('jquery'), $version, true);
+  // wp_register_script('app', get_stylesheet_directory_uri() . '/assets/js/app.js', array('jquery'), $version, true);
+  wp_register_script('app', get_stylesheet_directory_uri() . '/assets/js/app.js', [], $version, true);
   // wp_register_script('swiper-js', get_stylesheet_directory_uri() . '/assets/js/swiper.min.js', array('jquery'), $version, true);
-  wp_register_script('swiper-js', get_stylesheet_directory_uri() . '/assets/js/vendor/swiper-bundle.min.js', [], $version, true);
-  wp_register_script('lightbox-js', get_stylesheet_directory_uri() . '/assets/js/lightboxmmc.js', array('jquery'), $version, true);
+  wp_register_script('swiper', get_stylesheet_directory_uri() . '/assets/js/vendor/swiper-bundle.min.js', [], $version, [
+    'in_footer' => true,
+    'strategy'   => 'defer',
+  ]);
+  // wp_register_script('lightbox-js', get_stylesheet_directory_uri() . '/assets/js/lightboxmmc.js', array('jquery'), $version, true);
 
   // wp_enqueue_script('lightbox-js');
-  wp_enqueue_script('swiper-js');
-  wp_enqueue_script('app-js');
+  wp_enqueue_script('swiper');
+  wp_enqueue_script('app');
 }
 add_action('wp_enqueue_scripts', '_themeprefix_theme_scripts');
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,11 +2,11 @@ import pkg from "gulp";
 import postcss from "gulp-postcss";
 import sourcemaps from "gulp-sourcemaps";
 import autoprefixer from "autoprefixer";
+import cssnano from "cssnano";
 import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 import gulpSass from "gulp-sass";
 import * as sass from "sass";
-import cleanCss from "gulp-clean-css";
 import gulpif from "gulp-if";
 import imagemin from "gulp-imagemin";
 import { deleteAsync } from "del";
@@ -46,20 +46,21 @@ export const reload = (done) => {
 
 // Styles
 export const styles = () => {
-  return src(["src/scss/*.scss"])
-    .pipe(
-      stylelint({
-        fix: true,
-        reporters: [{ formatter: "string", console: true }],
-      }),
-    )
-    .pipe(gulpif(!PRODUCTION, sourcemaps.init()))
-    .pipe(SASS().on("error", SASS.logError))
-    .pipe(gulpif(PRODUCTION, postcss([autoprefixer])))
-    .pipe(gulpif(PRODUCTION, cleanCss({ compatibility: "ie8" })))
-    .pipe(gulpif(!PRODUCTION, sourcemaps.write()))
-    .pipe(dest("assets/css"))
-    .pipe(browserSync.stream());
+  return (
+    src(["src/scss/*.scss"])
+      .pipe(
+        stylelint({
+          fix: true,
+          reporters: [{ formatter: "string", console: true }],
+        }),
+      )
+      .pipe(gulpif(!PRODUCTION, sourcemaps.init()))
+      .pipe(SASS().on("error", SASS.logError))
+      .pipe(gulpif(PRODUCTION, postcss([autoprefixer, cssnano])))
+      .pipe(gulpif(!PRODUCTION, sourcemaps.write()))
+      .pipe(dest("assets/css"))
+      .pipe(browserSync.stream())
+  );
 };
 
 export const templatesStyles = () => {
@@ -72,8 +73,7 @@ export const templatesStyles = () => {
     )
     .pipe(gulpif(!PRODUCTION, sourcemaps.init()))
     .pipe(SASS().on("error", SASS.logError))
-    .pipe(gulpif(PRODUCTION, postcss([autoprefixer])))
-    .pipe(gulpif(PRODUCTION, cleanCss({ compatibility: "ie8" })))
+    .pipe(gulpif(PRODUCTION, postcss([autoprefixer, cssnano])))
     .pipe(gulpif(!PRODUCTION, sourcemaps.write()))
     .pipe(dest("assets/css/template-parts"))
     .pipe(browserSync.stream());
@@ -105,8 +105,7 @@ export const blockStyles = () => {
     )
     .pipe(gulpif(!PRODUCTION, sourcemaps.init()))
     .pipe(SASS().on("error", SASS.logError))
-    .pipe(gulpif(PRODUCTION, postcss([autoprefixer])))
-    .pipe(gulpif(PRODUCTION, cleanCss({ compatibility: "ie8" })))
+    .pipe(gulpif(PRODUCTION, postcss([autoprefixer, cssnano])))
     .pipe(gulpif(!PRODUCTION, sourcemaps.write()))
     .pipe(dest("assets/css/blocks"))
     .pipe(browserSync.stream());

--- a/gulpfile.nobs.js
+++ b/gulpfile.nobs.js
@@ -10,11 +10,11 @@ import pkg from "gulp";
 import postcss from "gulp-postcss";
 import sourcemaps from "gulp-sourcemaps";
 import autoprefixer from "autoprefixer";
+import cssnano from "cssnano";
 import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 import gulpSass from "gulp-sass";
 import * as sass from "sass";
-import cleanCss from "gulp-clean-css";
 import gulpif from "gulp-if";
 import imagemin from "gulp-imagemin";
 import { deleteAsync } from "del";
@@ -43,19 +43,20 @@ let cssModulesJSON = {};
 
 // Styles
 export const styles = () => {
-  return src(["src/scss/*.scss"])
-    .pipe(
-      stylelint({
-        fix: true,
-        reporters: [{ formatter: "string", console: true }],
-      }),
-    )
-    .pipe(gulpif(!PRODUCTION, sourcemaps.init()))
-    .pipe(SASS().on("error", SASS.logError))
-    .pipe(gulpif(PRODUCTION, postcss([autoprefixer])))
-    .pipe(gulpif(PRODUCTION, cleanCss({ compatibility: "ie8" })))
-    .pipe(gulpif(!PRODUCTION, sourcemaps.write()))
-    .pipe(dest("assets/css"));
+  return (
+    src(["src/scss/*.scss"])
+      .pipe(
+        stylelint({
+          fix: true,
+          reporters: [{ formatter: "string", console: true }],
+        }),
+      )
+      .pipe(gulpif(!PRODUCTION, sourcemaps.init()))
+      .pipe(SASS().on("error", SASS.logError))
+      .pipe(gulpif(PRODUCTION, postcss([autoprefixer, cssnano])))
+      .pipe(gulpif(!PRODUCTION, sourcemaps.write()))
+      .pipe(dest("assets/css"))
+  );
 };
 
 export const templatesStyles = () => {
@@ -68,8 +69,7 @@ export const templatesStyles = () => {
     )
     .pipe(gulpif(!PRODUCTION, sourcemaps.init()))
     .pipe(SASS().on("error", SASS.logError))
-    .pipe(gulpif(PRODUCTION, postcss([autoprefixer])))
-    .pipe(gulpif(PRODUCTION, cleanCss({ compatibility: "ie8" })))
+    .pipe(gulpif(PRODUCTION, postcss([autoprefixer, cssnano])))
     .pipe(gulpif(!PRODUCTION, sourcemaps.write()))
     .pipe(dest("assets/css/template-parts"));
 };
@@ -100,8 +100,7 @@ export const blockStyles = () => {
     )
     .pipe(gulpif(!PRODUCTION, sourcemaps.init()))
     .pipe(SASS().on("error", SASS.logError))
-    .pipe(gulpif(PRODUCTION, postcss([autoprefixer])))
-    .pipe(gulpif(PRODUCTION, cleanCss({ compatibility: "ie8" })))
+    .pipe(gulpif(PRODUCTION, postcss([autoprefixer, cssnano])))
     .pipe(gulpif(!PRODUCTION, sourcemaps.write()))
     .pipe(dest("assets/css/blocks"));
 };

--- a/inc/acf/blocks/projects/projects.php
+++ b/inc/acf/blocks/projects/projects.php
@@ -118,11 +118,11 @@ $query = new WP_Query($query_args);
 <?php wp_reset_postdata(); ?>
 
 <?php
-wp_enqueue_script('swiper-js');
+wp_enqueue_script('swiper');
 wp_enqueue_script(
     'projects-block-script',
     get_template_directory_uri() . '/assets/js/projects.js',
-    ['swiper-js'],
+    ['swiper'],
     '1.0',
     true
 );

--- a/inc/contact/Core/ContactCore.php
+++ b/inc/contact/Core/ContactCore.php
@@ -115,10 +115,13 @@ final class ContactCore
         if (! wp_script_is('intl-tel-input', 'registered')) {
             wp_register_script(
                 'intl-tel-input',
-                'https://cdn.jsdelivr.net/npm/intl-tel-input@26.8.1/build/js/intlTelInputWithUtils.min.js',
+                'https://cdn.jsdelivr.net/npm/intl-tel-input@latest/build/js/intlTelInputWithUtils.min.js',
                 [],
-                '26.8.1',
-                true
+                null,
+                [
+                    'in_footer' => true,
+                    'strategy'   => 'defer',
+                ]
             );
         }
         wp_enqueue_script('intl-tel-input');
@@ -128,7 +131,6 @@ final class ContactCore
                 'intl-tel-input',
                 'https://cdn.jsdelivr.net/npm/intl-tel-input@26.8.1/build/css/intlTelInput.css',
                 [],
-                '26.8.1'
             );
         }
         wp_enqueue_style('intl-tel-input');

--- a/inc/launchpad/Core/LaunchpadCore.php
+++ b/inc/launchpad/Core/LaunchpadCore.php
@@ -210,16 +210,19 @@ final class LaunchpadCore
             // intlTelInput CDN — phone field widget (CSS + all-in-one JS with utils)
             wp_enqueue_style(
                 'intl-tel-input',
-                'https://cdn.jsdelivr.net/npm/intl-tel-input@26.8.1/build/css/intlTelInput.css',
+                'https://cdn.jsdelivr.net/npm/intl-tel-input@latest/build/css/intlTelInput.css',
                 [],
-                '26.8.1'
+                null
             );
             wp_enqueue_script(
                 'intl-tel-input',
-                'https://cdn.jsdelivr.net/npm/intl-tel-input@26.8.1/build/js/intlTelInputWithUtils.min.js',
+                'https://cdn.jsdelivr.net/npm/intl-tel-input@latest/build/js/intlTelInputWithUtils.min.js',
                 [],
-                '26.8.1',
-                true
+                null,
+                [
+                    'in_footer' => true,
+                    'strategy'   => 'defer',
+                ]
             );
 
             $asset_path = get_template_directory() . '/inc/launchpad/Assets/store.asset.php';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.2.1",
       "license": "ISC",
       "dependencies": {
-        "@wordpress/i18n": "^6.17.0"
+        "@wordpress/i18n": "^6.18.0",
+        "cssnano": "^7.1.7"
       },
       "devDependencies": {
         "@babel/core": "^7.29.0",
@@ -21,7 +22,6 @@
         "git-rev-sync": "^3.0.2",
         "gulp": "^5.0.1",
         "gulp-changed": "^5.0.4",
-        "gulp-clean-css": "^4.3.0",
         "gulp-cli": "^3.1.0",
         "gulp-fonter-fix": "^0.0.1",
         "gulp-if": "^3.0.0",
@@ -1604,6 +1604,12 @@
         "keyv": "^5.5.4"
       }
     },
+    "node_modules/@colordx/core": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.4.3.tgz",
+      "integrity": "sha512-kIxYSfA5T8HXjav55UaaH/o/cKivF6jCCGIb8eqtcsfI46wsvlSiT8jMDyrl779qLec3c2c2oHBZo4oAhvbjrQ==",
+      "license": "MIT"
+    },
     "node_modules/@csstools/css-parser-algorithms": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
@@ -2789,9 +2795,9 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.44.0.tgz",
-      "integrity": "sha512-6p2vFvoFaovqnKFnIoy6Kib2XJhTwaJ1VhMXp4tM2PhSLnFMXVm1TpcHeX/kH7E6sWKJACBrDR6FH2nGYMk5dA==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.45.0.tgz",
+      "integrity": "sha512-+gOlu8TdohqL1INQNxS/7CxhM4T4MuYnKietWV9zWDmNQV2ysM0SdamNk5pWERJ4w0yY9XhtMBcwR/piJtePZg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -2799,13 +2805,13 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.17.0.tgz",
-      "integrity": "sha512-v1SLBweg7CRzQ+5+WSC1U93i8h9d3AoB0YBvMsd6gWI5vO8Zh4YKlEMexvrHQC++WN83egwqux84fWEdeU0MUA==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.18.0.tgz",
+      "integrity": "sha512-6dYCih4wUwi7Csu4RNfHiAKkgWhpSQdl8YthvQUF59Sfsoia3RCdtd4K2l7W4f18ldFA/RXjShMjvSexWy6OyQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.44.0",
+        "@wordpress/hooks": "^4.45.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "tannin": "^1.2.0"
@@ -3408,7 +3414,6 @@
       "version": "2.10.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
       "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -3894,9 +3899,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -4062,7 +4065,6 @@
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
       "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4427,11 +4429,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/caniuse-api": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+      "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.0.0",
+        "caniuse-lite": "^1.0.0",
+        "lodash.memoize": "^4.1.2",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001788",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
       "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4539,19 +4552,6 @@
       "peer": true,
       "engines": {
         "node": ">=6.0"
-      }
-    },
-    "node_modules/clean-css": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
-      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 4.0"
       }
     },
     "node_modules/cliui": {
@@ -4940,6 +4940,18 @@
         "source-map-resolve": "^0.6.0"
       }
     },
+    "node_modules/css-declaration-sorter": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.4.0.tgz",
+      "integrity": "sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.9"
+      }
+    },
     "node_modules/css-functions-list": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
@@ -4972,7 +4984,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
       "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.12.2",
@@ -4986,9 +4997,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
       "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-      "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
       "engines": {
         "node": ">= 6"
       },
@@ -5000,13 +5009,88 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cssnano": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.7.tgz",
+      "integrity": "sha512-N5LGn/OlhMxDTvKACwUPMzT34SSj1b022pvUAE/Vh6r2WD1aUCbc+QNIP/JjX9VVxebdJWZQ3352Lt4oF7dQ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "cssnano-preset-default": "^7.0.15",
+        "lilconfig": "^3.1.3"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/cssnano"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/cssnano-preset-default": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.15.tgz",
+      "integrity": "sha512-60kx7lJ40//HA85cIfQXSOJFby2D2V1pOMNHVCxue3KFWCjRzmiQyL9OvI+NAhwUlaojOfF9eK3nGvrJLCBUfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "css-declaration-sorter": "^7.2.0",
+        "cssnano-utils": "^5.0.2",
+        "postcss-calc": "^10.1.1",
+        "postcss-colormin": "^7.0.9",
+        "postcss-convert-values": "^7.0.11",
+        "postcss-discard-comments": "^7.0.7",
+        "postcss-discard-duplicates": "^7.0.3",
+        "postcss-discard-empty": "^7.0.2",
+        "postcss-discard-overridden": "^7.0.2",
+        "postcss-merge-longhand": "^7.0.6",
+        "postcss-merge-rules": "^7.0.10",
+        "postcss-minify-font-values": "^7.0.2",
+        "postcss-minify-gradients": "^7.0.4",
+        "postcss-minify-params": "^7.0.8",
+        "postcss-minify-selectors": "^7.1.0",
+        "postcss-normalize-charset": "^7.0.2",
+        "postcss-normalize-display-values": "^7.0.2",
+        "postcss-normalize-positions": "^7.0.3",
+        "postcss-normalize-repeat-style": "^7.0.3",
+        "postcss-normalize-string": "^7.0.2",
+        "postcss-normalize-timing-functions": "^7.0.2",
+        "postcss-normalize-unicode": "^7.0.8",
+        "postcss-normalize-url": "^7.0.2",
+        "postcss-normalize-whitespace": "^7.0.2",
+        "postcss-ordered-values": "^7.0.3",
+        "postcss-reduce-initial": "^7.0.8",
+        "postcss-reduce-transforms": "^7.0.2",
+        "postcss-svgo": "^7.1.2",
+        "postcss-unique-selectors": "^7.0.6"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/cssnano-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.2.tgz",
+      "integrity": "sha512-kt41WLK7FLKfePzPi645Y+/NtW/nNM7Su6nlNUfJyRNW3JcuU3JU7+cWJc+JexTeZ8dRBvFufefdG2XpXkIo0A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
       }
     },
     "node_modules/csso": {
@@ -5477,15 +5561,13 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/fb55"
         }
       ],
-      "license": "BSD-2-Clause",
-      "optional": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/domhandler": {
       "version": "4.3.1",
@@ -5714,7 +5796,6 @@
       "version": "1.5.340",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
       "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -5993,7 +6074,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7655,19 +7735,6 @@
         "gulp": {
           "optional": true
         }
-      }
-    },
-    "node_modules/gulp-clean-css": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/gulp-clean-css/-/gulp-clean-css-4.3.0.tgz",
-      "integrity": "sha512-mGyeT3qqFXTy61j0zOIciS4MkYziF2U594t2Vs9rUnpkEHqfu6aDITMp8xOvZcvdX61Uz3y1mVERRYmjzQF5fg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-css": "4.2.3",
-        "plugin-error": "1.0.1",
-        "through2": "3.0.1",
-        "vinyl-sourcemaps-apply": "0.2.1"
       }
     },
     "node_modules/gulp-cli": {
@@ -9575,7 +9642,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -9681,6 +9747,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "license": "MIT"
+    },
     "node_modules/lodash.some": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
@@ -9693,6 +9765,12 @@
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
     },
     "node_modules/lowercase-keys": {
@@ -9897,7 +9975,6 @@
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/memize": {
@@ -10273,7 +10350,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10397,7 +10473,6 @@
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nopt": {
@@ -10524,9 +10599,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dev": true,
       "license": "BSD-2-Clause",
-      "optional": true,
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -11056,7 +11129,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -11180,10 +11252,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -11206,6 +11277,107 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-calc": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.1.tgz",
+      "integrity": "sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12 || ^20.9 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.38"
+      }
+    },
+    "node_modules/postcss-colormin": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.9.tgz",
+      "integrity": "sha512-EZpoUlmbXQUpe+g4ZaGM2kjGlHrQ7Bjzb3xHcNrC9ysI1tGoib6DAYvxg6aB7MGxsjgLF+Qx/jwZQkJ5cKDvXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colordx/core": "^5.2.0",
+        "browserslist": "^4.28.2",
+        "caniuse-api": "^3.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-convert-values": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.11.tgz",
+      "integrity": "sha512-H+s7P0f9jJylSysAHs3/5MhAx7GthDO05uw1h56L2xyEqpiLTFLEqBNw3PUYzD5p/AKwWaigCXf6FGELpOw9lw==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-discard-comments": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.7.tgz",
+      "integrity": "sha512-FJhE3fSte7HaRNL4iwD8LTG9vWqj3puxXIdig6LfrFqc1TJRUhY4kXOkeTXZZfTXYny+k+SO7fd2fymj1wduJg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^7.1.1"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-discard-duplicates": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.3.tgz",
+      "integrity": "sha512-9cRxXwhEM/aNZon1qZyToX4NmjbFbxOGbww+0CnbYFDbbPRGZ8jg4IbM8UlA+CzkXxM35itxyaHKNqBBg/RTDg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-discard-empty": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.2.tgz",
+      "integrity": "sha512-NZFouOmOwtngJVgkNeI1LtkzFdYqIurxgy4wq3qNvIiXFURTZ3b/K7q3dP3QitlWQ5imHDQL0qSorItQhoxb1g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-discard-overridden": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.2.tgz",
+      "integrity": "sha512-Ym01X4v6U3sY8X0P1J9P+RTar+7JyLTOzDrxKSeaArFsLmkVu4KcAKPBWDYRIyZ/q4jwpSPnOnekeSSqXSXKUw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
       }
     },
     "node_modules/postcss-load-config": {
@@ -11254,6 +11426,107 @@
       "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/postcss-merge-longhand": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.6.tgz",
+      "integrity": "sha512-lDsWeKRsssX/9vKFpingoRiuvGajtOGCJhs1kyaTJ5fzaVzs0aPPYe38UZ/ukMFEA5iuRIjQJHIkH2niYO3ubQ==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0",
+        "stylehacks": "^7.0.10"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-merge-rules": {
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.10.tgz",
+      "integrity": "sha512-UXYKxkg8Cy1so/evF7AE/25PNXZb3E0SrvjdbtbGf+MW+doLenKqRLQzz6YZW469ktiXK2MVLFWtel/DftCV0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-api": "^3.0.0",
+        "cssnano-utils": "^5.0.2",
+        "postcss-selector-parser": "^7.1.1"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-minify-font-values": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-7.0.2.tgz",
+      "integrity": "sha512-Z82NUmnvhPrvMUaHfkaAVBmWQq9F8Dox4Dy0LiwbaTxfmDUWLQtS+0WCgKViwdWCPPajiY9YzoQftgqKdXkM5g==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-minify-gradients": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.4.tgz",
+      "integrity": "sha512-g8MNeNyN+lbwKy8DCtJ6zU6awBL0InBsSOaKmgZ1MdRLVItLQUNFNAzzzBnOp4qowOcyyB6GetTlQ0/0UNXvag==",
+      "license": "MIT",
+      "dependencies": {
+        "@colordx/core": "^5.2.0",
+        "cssnano-utils": "^5.0.2",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-minify-params": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.8.tgz",
+      "integrity": "sha512-DIUKM5DZGTmxN7KFKT+rxt0FdPDmRrdK/k3n3+6Po+N/QYn06juwagHcfOVBG0CfCHwcnI612GAUCZc3eT+ZEg==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "cssnano-utils": "^5.0.2",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-minify-selectors": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.1.0.tgz",
+      "integrity": "sha512-HYl/6I0aL+UvpA10t65BSa7h+tVjBgE6oRI5N/3ylX3vtwvlDL67G3FT3vYDPnTksxr0riiyJcT0tBtyRVoloA==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1",
+        "caniuse-api": "^3.0.0",
+        "cssesc": "^3.0.0",
+        "postcss-selector-parser": "^7.1.1"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
     },
     "node_modules/postcss-modules": {
       "version": "6.0.1",
@@ -11338,6 +11611,186 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/postcss-normalize-charset": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.2.tgz",
+      "integrity": "sha512-YoINoiR4YKlzfB95Y93b0DSxWy7FLw+1SADIaznMHb88AKizpzfF80tolmiDEbYr1UM4r4Hw+NZq37SwT5f3uw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-normalize-display-values": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.2.tgz",
+      "integrity": "sha512-wu/NTSjnp8sX5TnEHVPN+eScjAtRs18ELtEduG+Ek3GxjeUDUT+VAA3PJjVIXBcVIk6fiLYFj2iKH0q99S3T2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-normalize-positions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-7.0.3.tgz",
+      "integrity": "sha512-1CJI++oA3yK/fQlPUcEngUfcSWS08Pkt9fK+jVgL53mmtHDBHi0YiuB0m3D9BXwZjmfvCc2GQmFqCAF/CVcPzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-normalize-repeat-style": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-7.0.3.tgz",
+      "integrity": "sha512-RvImJ2Ml4LZSx31qC2C8LDiz65IgBNATtwEr9r3Aue+D0cCGbj4rjNojb/uGpEm4QxnOTzFqMvaDYuKiT1Cmpg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-normalize-string": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-7.0.2.tgz",
+      "integrity": "sha512-FqtrUh2BU2MnVeLeWBbJ2rwOjuDnA91XvoImc1BbgMWIxdxiPTaquflBHsmFBA3xh3pC3wPZO9W5MaIc7wU/Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-normalize-timing-functions": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-7.0.2.tgz",
+      "integrity": "sha512-5H5fpXBnMACEXzn7k9RP7qWZ1eWg8cuZkUuFygStY7icOj+UucwMWXeMmdkF/iITvTVa7fP85tdRCJeznpdFfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-normalize-unicode": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.8.tgz",
+      "integrity": "sha512-imCM3cwK3hvlAG4z1AzYM24m8BPA3/Jk/S71wfbn2I6+E2b+UwFaGvlNqydihXTSl3OFPeQXztqCzg+NGeSibQ==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-normalize-url": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-7.0.2.tgz",
+      "integrity": "sha512-bLnNY7t76NLRb9QQyCVmCN4qwoHxiq6vABH/CXav9wTuR6dNGHGQ72AyO/+h2quWxZk3l7BqxNL1vtDi9H6y1g==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-normalize-whitespace": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-7.0.2.tgz",
+      "integrity": "sha512-TNSVkuhkeOhl36WruQlflxOb7HweoeZowSusNpfsM1+ZvqJ24Mc+xksu05ecMQxlu+0zgI8pyznO2EWqDCQbLA==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-ordered-values": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.3.tgz",
+      "integrity": "sha512-FTt6R9RF7NAYfpOHa2XFPm89FVuo5GiIbcfwOXFy1MYF38BeiNW9ke8ybw9Pk62eEsUlRVVbxHWA3B7ERYqOOA==",
+      "license": "MIT",
+      "dependencies": {
+        "cssnano-utils": "^5.0.2",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-reduce-initial": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.8.tgz",
+      "integrity": "sha512-VeVRmbgpgTZuRcDQdqnsB4iYTeS2dBRV07UdwK6V3x61F1xTQ2pgIzHBIR4rQYRlXRNKBTGYYhEL1eNA7w9vaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-api": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-reduce-transforms": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-7.0.2.tgz",
+      "integrity": "sha512-OV5P9hMnf7kEkeXVXyS5ESqxbIls7a3TqFymUAV5JICO/9YCBEU+QQhQjZiDHaLwFdV7/CL481kVeBUk5FdY3w==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
     "node_modules/postcss-resolve-nested-selector": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
@@ -11403,7 +11856,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -11413,11 +11865,179 @@
         "node": ">=4"
       }
     },
+    "node_modules/postcss-svgo": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.1.2.tgz",
+      "integrity": "sha512-ixExc8m+/68yuSYQzV/1DgtTup/7nI2dN9eiDS5GMRUzeCH4q9UcqeZPwcSVhdf8ay9fRwXDUHwcY5/XzQSszQ==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0",
+        "svgo": "^4.0.1"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >= 18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
+    "node_modules/postcss-svgo/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/postcss-svgo/node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/postcss-svgo/node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/postcss-svgo/node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/postcss-svgo/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/postcss-svgo/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/postcss-svgo/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/postcss-svgo/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/postcss-svgo/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/postcss-svgo/node_modules/svgo": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^11.1.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^3.0.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.1.1",
+        "sax": "^1.5.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/postcss-unique-selectors": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.6.tgz",
+      "integrity": "sha512-cDxnYw1QuBMW5w3svZ0BlYF0IA4Amr+1JoTLXzu6vDFPNwohN2QU+sPZNx15b930LR7ce+/600h28/cYoxO9vw==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^7.1.1"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
+      }
+    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prepend-http": {
@@ -12046,6 +12666,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/schema-utils": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -12619,7 +13248,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -12924,6 +13552,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/stylehacks": {
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.10.tgz",
+      "integrity": "sha512-sRJ7klmhe/Fl5woJcbJUa2qP1Ueffsl1CQI4ePvqXLkZmcIuAt09aP9uT/FOFPqXh9Rh8M5UkgEnwTdTKn/Aag==",
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "postcss-selector-parser": "^7.1.1"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.10"
       }
     },
     "node_modules/stylelint": {
@@ -14083,7 +14727,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -14139,7 +14782,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "git-rev-sync": "^3.0.2",
     "gulp": "^5.0.1",
     "gulp-changed": "^5.0.4",
-    "gulp-clean-css": "^4.3.0",
     "gulp-cli": "^3.1.0",
     "gulp-fonter-fix": "^0.0.1",
     "gulp-if": "^3.0.0",
@@ -52,6 +51,7 @@
     "yargs": "^18.0.0"
   },
   "dependencies": {
-    "@wordpress/i18n": "^6.17.0"
+    "@wordpress/i18n": "^6.18.0",
+    "cssnano": "^7.1.7"
   }
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,4 +1,4 @@
 
-import "./jquery.marquee.min.js";
-import "./odometer.js";
+// import "./jquery.marquee.min.js";
+// import "./odometer.js";
 import "./_header.js";

--- a/src/scss/app-logged-in.scss
+++ b/src/scss/app-logged-in.scss
@@ -1,0 +1,2 @@
+@use "components/launchpad" as *;
+@use "components/tour" as *;

--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -7,7 +7,8 @@
 @use "components/404" as *;
 @use "components/page-policy" as *;
 @use "components/lg-shared" as *;
-@use "components/launchpad" as *;
+
+// @use "components/launchpad" as *;
 @use "components/gateway" as *;
 @use "components/comments" as *;
 @use "components/listing" as *;
@@ -22,4 +23,5 @@
 @use "components/single-news" as *;
 @use "components/archive-projects" as *;
 @use "components/contact" as *;
-@use "components/tour" as *;
+
+// @use "components/tour" as *;

--- a/src/scss/components/_launchpad.scss
+++ b/src/scss/components/_launchpad.scss
@@ -414,7 +414,7 @@
     border: 1px solid $stroke-default;
     border-radius: $radius-input;
     background: $surface-primary;
-    .opportunity-card--inner {
+    &--inner {
         display: flex;
         flex-wrap: wrap;
         justify-content: space-between;


### PR DESCRIPTION
- Replace abandoned `gulp-clean-css` with `cssnano` minification
- Implement `defer` loading strategy for `swiper` and `intl-tel-input` scripts
- Standardize script and style handles (e.g., `swiper-js` to `swiper`)
- Add conditional enqueuing of `app-logged-in` stylesheet for authenticated users
- Update `@wordpress/i18n` dependency
- Clean up unused imports and commented-out code in JS and SCSS files