### PR TITLE
perf(blocks): implement deferred script loading for acf blocks & fix build(gulp) asset copying

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -365,18 +365,29 @@ export const production = () => {
 };
 
 export const copyBinariesToProduction = () => {
-  const sources = [];
+  const promises = [];
+
   if (fs.existsSync("assets/img")) {
-    sources.push("assets/img/**/*");
+    promises.push(
+      new Promise((resolve) =>
+        src("assets/img/**/*", { allowEmpty: true, encoding: false })
+          .pipe(dest("production/assets/img"))
+          .on("end", resolve),
+      ),
+    );
   }
+
   if (fs.existsSync("assets/fonts")) {
-    sources.push("assets/fonts/**/*");
+    promises.push(
+      new Promise((resolve) =>
+        src("assets/fonts/**/*", { allowEmpty: true, encoding: false })
+          .pipe(dest("production/assets/fonts"))
+          .on("end", resolve),
+      ),
+    );
   }
-  if (sources.length === 0) return Promise.resolve(); // Nothing to copy
-  return src(sources, {
-    allowEmpty: true,
-    encoding: false,
-  }).pipe(dest("production/assets"));
+
+  return Promise.all(promises);
 };
 
 export const watchForChanges = () => {

--- a/gulpfile.nobs.js
+++ b/gulpfile.nobs.js
@@ -355,18 +355,29 @@ export const production = () => {
 };
 
 export const copyBinariesToProduction = () => {
-  const sources = [];
+  const promises = [];
+
   if (fs.existsSync("assets/img")) {
-    sources.push("assets/img/**/*");
+    promises.push(
+      new Promise((resolve) =>
+        src("assets/img/**/*", { allowEmpty: true, encoding: false })
+          .pipe(dest("production/assets/img"))
+          .on("end", resolve),
+      ),
+    );
   }
+
   if (fs.existsSync("assets/fonts")) {
-    sources.push("assets/fonts/**/*");
+    promises.push(
+      new Promise((resolve) =>
+        src("assets/fonts/**/*", { allowEmpty: true, encoding: false })
+          .pipe(dest("production/assets/fonts"))
+          .on("end", resolve),
+      ),
+    );
   }
-  if (sources.length === 0) return Promise.resolve();
-  return src(sources, {
-    allowEmpty: true,
-    encoding: false,
-  }).pipe(dest("production/assets"));
+
+  return Promise.all(promises);
 };
 
 export const watchForChanges = () => {

--- a/inc/acf/blocks/pagination/register.php
+++ b/inc/acf/blocks/pagination/register.php
@@ -1,47 +1,60 @@
 <?php
 acf_register_block_type(array(
-    'name' => 'pagination',
-    'title' => __('Pagination', '_themedomain'),
-    'description' => __('Block pagination', '_themedomain'),
+    'name'            => 'pagination',
+    'title'           => __('Pagination', '_themedomain'),
+    'description'     => __('Block pagination', '_themedomain'),
     'render_template' => acf_theme_blocks_path('pagination/pagination.php'),
-    'enqueue_style' => get_template_directory_uri() . '/assets/css/blocks/pagination/pagination.module.css',
+    'enqueue_style'   => get_template_directory_uri() . '/assets/css/blocks/pagination/pagination.module.css',
     // 'enqueue_script' => get_template_directory_uri() . '/assets/js/pagination.js',
-    'icon'  =>  'format-image',
-    'category' => 'custom-blocks',
+    'icon'            => 'format-image',
+    'category'        => 'custom-blocks',
+    'enqueue_assets'  => function () {
+        wp_enqueue_script(
+            'pagination',
+            get_template_directory_uri() . '/assets/js/pagination.js',
+            [],
+            null,
+            [
+                'in_footer' => true,
+                'strategy'  => 'defer',
+            ]
+        );
+        wp_localize_script('pagination', 'THEME_AJAX', [
+            'url' => admin_url('admin-ajax.php'),
+        ]);
+    }
 ));
 
-// register.php — твой файл для подключения ACF блоков
 
-add_action('enqueue_block_assets', function () {
+/** 
+ * ! Whats wrong with this: enqueing on every page across all the theme.
+ * Obviously is better to use callback `enqueue_assets`
+ */
+// add_action('enqueue_block_assets', function () {
+//     wp_register_script(
+//         'pagination-block',
+//         get_template_directory_uri() . '/assets/js/pagination.js',
+//         [],
+//         null,
+//         true
+//     );
 
-    // регистрируем скрипт
-    wp_register_script(
-        'pagination-block',
-        get_template_directory_uri() . '/assets/js/pagination.js',
-        [],
-        null,
-        true
-    );
+//     wp_localize_script('pagination-block', 'THEME_AJAX', [
+//         'url' => admin_url('admin-ajax.php'),
+//     ]);
 
-    // локализуем переменные
-    wp_localize_script('pagination-block', 'THEME_AJAX', [
-        'url' => admin_url('admin-ajax.php'),
-    ]);
+//     wp_enqueue_script('pagination-block');
+// });
 
-    // подключаем скрипт (вместо enqueue_script в блоке)
-    wp_enqueue_script('pagination-block');
-});
+// add_action('acf/init', function () {
 
-add_action('acf/init', function () {
-
-    acf_register_block_type([
-        'name'            => 'pagination',
-        'title'           => __('Pagination', '_themedomain'),
-        'description'     => __('Block pagination', '_themedomain'),
-        'render_template' => acf_theme_blocks_path('pagination/pagination.php'),
-        'enqueue_style'   => get_template_directory_uri() . '/assets/css/blocks/pagination/pagination.module.css',
-        'icon'            => 'format-image',
-        'category'        => 'custom-blocks',
-    ]);
-});
-
+//     acf_register_block_type([
+//         'name'            => 'pagination',
+//         'title'           => __('Pagination', '_themedomain'),
+//         'description'     => __('Block pagination', '_themedomain'),
+//         'render_template' => acf_theme_blocks_path('pagination/pagination.php'),
+//         'enqueue_style'   => get_template_directory_uri() . '/assets/css/blocks/pagination/pagination.module.css',
+//         'icon'            => 'format-image',
+//         'category'        => 'custom-blocks',
+//     ]);
+// });

--- a/inc/acf/blocks/video-text/register.php
+++ b/inc/acf/blocks/video-text/register.php
@@ -1,11 +1,23 @@
 <?php
 acf_register_block_type(array(
-    'name' => 'video-text',
-    'title' => __('Video & Text', 'starwishx'),
-    'description' => __('Block with title, video & text', 'starwishx'),
+    'name'            => 'video-text',
+    'title'           => __('Video & Text', 'starwishx'),
+    'description'     => __('Block with title, video & text', 'starwishx'),
     'render_template' => acf_theme_blocks_path('video-text/video-text.php'),
-    'enqueue_style' => get_template_directory_uri() . '/assets/css/blocks/video-text/video-text.module.css',
-    'enqueue_script' => get_template_directory_uri() . '/assets/js/video-text.js',
-    'icon'  =>  'format-video',
-    'category' => 'custom-blocks',
+    'enqueue_style'   => get_template_directory_uri() . '/assets/css/blocks/video-text/video-text.module.css',
+    // 'enqueue_script' => get_template_directory_uri() . '/assets/js/video-text.js',
+    'icon'            =>  'format-video',
+    'category'        => 'custom-blocks',
+    'enqueue_assets'  => function () {
+        wp_enqueue_script(
+            'video-text',
+            get_template_directory_uri() . '/assets/js/video-text.js',
+            [],
+            null,
+            [
+                'in_footer' => true,
+                'strategy'  => 'defer',
+            ]
+        );
+    }
 ));


### PR DESCRIPTION
- Use the `enqueue_assets` callback for pagination and video-text blocks to
enable the `defer` loading strategy and improve page performance. This
replaces the standard `enqueue_script` parameter to allow for more
granular control over asset registration and localization.

- Update `copyBinariesToProduction` to handle image and font transfers
individually using a promise-based approach to separate destination folders. 
This ensures more reliable asset delivery during the production build process 
by awaiting the completion of each stream via `Promise.all`.