### PR TITLE
fix(db): replace dynamic prefix with hardcoded prefix in listing queries for SQL views

### DIFF
--- a/inc/listing/Services/ListingService.php
+++ b/inc/listing/Services/ListingService.php
@@ -110,7 +110,7 @@ class ListingService
             // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
             $wpdb->prepare(
                 "SELECT post_id, code, name_category_oblast AS name, level, category
-             FROM {$wpdb->prefix}v_opportunity_search
+             FROM wp_v_opportunity_search
              WHERE post_id IN ($placeholders)",
                 ...$postIds
             ),
@@ -379,7 +379,7 @@ class ListingService
                      name_category_oblast   AS label,
                      level,
                      category
-                 FROM {$wpdb->prefix}v_opportunity_search
+                 FROM wp_v_opportunity_search
                  WHERE name LIKE %s
                  ORDER BY level ASC, name ASC
                  LIMIT 20",

--- a/inc/theme-helpers.php
+++ b/inc/theme-helpers.php
@@ -604,7 +604,7 @@ function sw_get_opportunity_view_data(int $post_id): array
 
     $locations = $wpdb->get_results($wpdb->prepare(
         "SELECT code, name_category_oblast as name, level, category
-         FROM {$wpdb->prefix}v_opportunity_search
+         FROM wp_v_opportunity_search
          WHERE post_id = %d
          ORDER BY level ASC, name ASC",
         $post_id


### PR DESCRIPTION
Replace `{$wpdb->prefix}` with `wp_` in SQL queries within `ListingService` and `theme-helpers.php` to target the `v_opportunity_search` view directly.