### PR TITLE
refactor(ui): improve date range rendering logic in single opportunity template

### DIFF
--- a/templates/single-opportunity.php
+++ b/templates/single-opportunity.php
@@ -105,7 +105,7 @@ if (function_exists('render_block')) {
                     <dl class="opportunity-article-meta">
                         <!-- 2. Dates -->
                         <?php if (
-                            ($data['date_start']['iso'] ?? '') !== '' &&
+                            ($data['date_start']['iso'] ?? '') !== '' or
                             ($data['date_end']['iso'] ?? '') !== ''
                         ) : ?>
                             <div class="info-card info-card--dates">
@@ -116,13 +116,19 @@ if (function_exists('render_block')) {
                                     <?php esc_html_e('Dates', 'starwishx'); ?>
                                 </dt>
                                 <div class="date-row">
-                                    <time class="btn-text-medium" datetime="<?php echo esc_attr($data['date_start']['iso']); ?>">
-                                        <?php echo esc_html($data['date_start']['display']); ?>
-                                    </time>
-                                    —
-                                    <time class="btn-text-medium" datetime="<?php echo esc_attr($data['date_end']['iso']); ?>">
-                                        <?php echo esc_html($data['date_end']['display']); ?>
-                                    </time>
+                                    <span><?= esc_html__('Lasts', 'starwishx') ?> </span>
+                                    <?php if (($data['date_start']['iso'] ?? '') !== '') : ?>
+                                        <span><?= esc_html__('from', 'starwishx') ?> </span>
+                                        <time class="btn-text-medium" datetime="<?php echo esc_attr($data['date_start']['iso']); ?>">
+                                            <?php echo esc_html($data['date_start']['display']); ?>
+                                        </time>
+                                    <?php endif; ?>
+                                    <?php if (($data['date_end']['iso'] ?? '') !== '') : ?>
+                                        <span> <?= esc_html__('to', 'starwishx') ?> </span>
+                                        <time class="btn-text-medium" datetime="<?php echo esc_attr($data['date_end']['iso']); ?>">
+                                            <?php echo esc_html($data['date_end']['display']); ?>
+                                        </time>
+                                    <?php endif; ?>
                                 </div>
                             </div>
                         <?php endif; ?>


### PR DESCRIPTION
Updates the single opportunity template to handle date ranges more gracefully. Instead of assuming both start and end dates exist, the template now independently checks for each and adds appropriate "from" and "to" labels.

- Replace strict AND condition with OR for date visibility check.
- Add conditional rendering for start and end dates.
- Introduce "Lasts", "from", and "to" translations for better clarity.
- Use span elements for labels to improve semantic structure.