### PR TITLE
refactor(ui): improve contact link logic and data handling in footer

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -1,20 +1,35 @@
 <?php
 $footer_title = esc_html(get_field('title', 'options'));
-$email_title = esc_html(get_field('email_title', 'options'));
-$email_text = esc_html(get_field('email_name', 'options'));
-$email_link = esc_html(get_field('email_link', 'options'));
-$telegram_title = esc_html(get_field('telegram_title', 'options'));
-$telegram_text = esc_html(get_field('telegram_name', 'options'));
-$telegram_link = esc_html(get_field('telegram_link', 'options'));
-$linkedin_title = esc_html(get_field('linkedin_title', 'options'));
-$linkedin_text = esc_html(get_field('linkedin_name', 'options'));
-$linkedin_link = esc_html(get_field('linkedin_link', 'options'));
 
-// print_r("assadas");
-// print_r($email_text);
-// print_r($email_link);
-// print_r($telegram_text);
-// print_r($telegram_link);
+/*
+ * Contact rows. On the options page *_title is the network name ("Telegram"),
+ * *_name is the handle or address, and *_link is the URL.
+ *
+ * Each label falls back to the other field, and the guard below tests the
+ * resolved label rather than a field that is never displayed. Telegram and
+ * LinkedIn used to guard on *_name while printing *_title, so clearing the
+ * title left a link holding an icon and no text at all.
+ *
+ * Email leads with the address rather than the word "Email" - the address is
+ * the useful label there. The other two lead with the network name.
+ *
+ * Values are kept raw here and escaped at the point of output: esc_html() on a
+ * URL cannot break out of an href, but it does not validate the protocol
+ * either, so a javascript: value saved on the options page rendered live.
+ * The (string) casts keep esc_url() and esc_html() off ACF's null for an
+ * empty field, which PHP 8.1 deprecates.
+ */
+$email_link     = (string) get_field('email_link', 'options');
+$email_label    = (string) get_field('email_name', 'options')
+    ?: (string) get_field('email_title', 'options');
+
+$telegram_link  = (string) get_field('telegram_link', 'options');
+$telegram_label = (string) get_field('telegram_title', 'options')
+    ?: (string) get_field('telegram_name', 'options');
+
+$linkedin_link  = (string) get_field('linkedin_link', 'options');
+$linkedin_label = (string) get_field('linkedin_title', 'options')
+    ?: (string) get_field('linkedin_name', 'options');
 
 ?>
 
@@ -25,38 +40,32 @@ $linkedin_link = esc_html(get_field('linkedin_link', 'options'));
             <div class="footer-socwraper">
                 <h3 class="footer-title title-socblock"><?php echo $footer_title; ?></h3>
                 <ul class="socblock">
-                    <?php if ($email_text && $email_link): ?>
+                    <?php if ($email_label && $email_link): ?>
                         <li class="socblock-item">
-                            <a href="mailto:<?php echo $email_link; ?>" class="socblock-link socblock-link-email" target="_blank" rel="noopener noreferrer">
-                                <svg class="socblock-icon">
-                                    <use xlink:href="<?php echo get_template_directory_uri(); ?>/assets/img/sprites.svg#icon-email"></use>
-                                </svg>
+                            <a href="<?php echo esc_url('mailto:' . $email_link); ?>" class="socblock-link socblock-link-email" target="_blank" rel="noopener noreferrer">
+                                <?php sw_svg_e('icon-email', 24, null, 'socblock-icon'); ?>
                                 <span>
-                                    <?php echo $email_text; ?>
+                                    <?php echo esc_html($email_label); ?>
                                 </span>
                             </a>
                         </li>
                     <?php endif; ?>
-                    <?php if ($telegram_text && $telegram_link): ?>
+                    <?php if ($telegram_label && $telegram_link): ?>
                         <li class="socblock-item">
-                            <a href="<?php echo $telegram_link; ?>" class="socblock-link socblock-link-telegram" target="_blank" rel="noopener noreferrer">
-                                <svg class="socblock-icon">
-                                    <use xlink:href="<?php echo get_template_directory_uri(); ?>/assets/img/sprites.svg#icon-telegram"></use>
-                                </svg>
+                            <a href="<?php echo esc_url($telegram_link); ?>" class="socblock-link socblock-link-telegram" target="_blank" rel="noopener noreferrer">
+                                <?php sw_svg_e('icon-telegram', 24, null, 'socblock-icon'); ?>
                                 <span>
-                                    <?php echo $telegram_title; ?>
+                                    <?php echo esc_html($telegram_label); ?>
                                 </span>
                             </a>
                         </li>
                     <?php endif; ?>
-                    <?php if ($linkedin_text && $linkedin_link): ?>
+                    <?php if ($linkedin_label && $linkedin_link): ?>
                         <li class="socblock-item">
-                            <a href="<?php echo $linkedin_link; ?>" class="socblock-link socblock-link-linkedin" target="_blank" rel="noopener noreferrer">
-                                <svg class="socblock-icon">
-                                    <use xlink:href="<?php echo get_template_directory_uri(); ?>/assets/img/sprites.svg#icon-linkedin"></use>
-                                </svg>
+                            <a href="<?php echo esc_url($linkedin_link); ?>" class="socblock-link socblock-link-linkedin" target="_blank" rel="noopener noreferrer">
+                                <?php sw_svg_e('icon-linkedin', 24, null, 'socblock-icon'); ?>
                                 <span>
-                                    <?php echo $linkedin_title; ?>
+                                    <?php echo esc_html($linkedin_label); ?>
                                 </span>
                             </a>
                         </li>
@@ -90,13 +99,13 @@ $linkedin_link = esc_html(get_field('linkedin_link', 'options'));
                 <div class="copyright-text1">
                     <p class="copyright-text">
                         <?php echo esc_html(get_field('parts_2', 'options')); ?>
-                        <a href="<?php echo esc_html(get_field('parts_2_link', 'options')); ?>" class="copyright-link" target="_blank"><?php echo esc_html(get_field('parts_2_text_link', 'options')); ?></a>
+                        <a href="<?php echo esc_url((string) get_field('parts_2_link', 'options')); ?>" class="copyright-link" target="_blank"><?php echo esc_html(get_field('parts_2_text_link', 'options')); ?></a>
                     </p>
                 </div>
             </div>
             <div class="footer-copyright2">
-                <a href="<?php echo esc_html(get_field('privacy_policy_page', 'options')); ?>" class="copyright-link" target="_blank"><?php echo esc_html(get_field('privacy_policy_text', 'options')); ?></a>
-                <a href="<?php echo esc_html(get_field('privacy_data_protection_page', 'options')); ?>" class="copyright-link" target="_blank"><?php echo esc_html(get_field('privacy_data_protection_text', 'options')); ?></a>
+                <a href="<?php echo esc_url((string) get_field('privacy_policy_page', 'options')); ?>" class="copyright-link" target="_blank"><?php echo esc_html(get_field('privacy_policy_text', 'options')); ?></a>
+                <a href="<?php echo esc_url((string) get_field('privacy_data_protection_page', 'options')); ?>" class="copyright-link" target="_blank"><?php echo esc_html(get_field('privacy_data_protection_text', 'options')); ?></a>
             </div>
             <?php echo esc_html(get_field('copyright', 'options')); ?>
         </div>

--- a/templates/page-policy.php
+++ b/templates/page-policy.php
@@ -50,7 +50,12 @@ $date = sw_format_date_for_ui($policy_date_raw, 'j F Y', true);
 // $date['iso']     — ISO 8601 for <time datetime="...">
 // $date['display'] — localized human-readable string
 
-$pdf_title = $pdf_title_override ? $pdf_title_override : $doc['title'];
+// sw_prepare_document() returns null for an empty field or a deleted
+// attachment, so the fallback has to survive $doc being null - indexing it
+// raised "Trying to access array offset on null" on every policy page with no
+// PDF. ?: rather than ??, so an override saved as an empty string still falls
+// through to the attachment title.
+$pdf_title = $pdf_title_override ?: ($doc['title'] ?? '');
 
 get_header();
 ?>
@@ -117,7 +122,13 @@ if (function_exists('render_block')) {
 
                         <span class="policy-pdf-info" id="policy-pdf-meta-<?php echo esc_attr($post_id); ?>">
                             <span class="policy-pdf-title text-small">
-                                <?php esc_html_e($pdf_title); ?>
+                                <?php
+                                // echo esc_html(), not esc_html_e(): the title is
+                                // a runtime value, and esc_html_e() would look it
+                                // up in the 'default' text domain and offer it to
+                                // string extraction as a translatable literal.
+                                echo esc_html($pdf_title);
+                                ?>
                             </span>
                             <span class="policy-pdf-meta text-small">
                                 <?php


### PR DESCRIPTION
Refactor how contact information (email, telegram, linkedin) is retrieved 
and displayed in the footer. 

- Implement fallback logic for labels to ensure visibility when specific 
  fields are empty.
- Cast ACF field values to strings to prevent PHP 8.1 deprecation 
  warnings on null values.
- Improve security by using esc_url for mailto links and esc_html for 
  labels.
- Replace inline SVG markup with a helper function for cleaner code.
- Update conditional checks to use resolved labels instead of raw field 
  values.
  
  fix(policy): guard the PDF title fallback against a null document